### PR TITLE
Semi naive fix

### DIFF
--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -386,8 +386,8 @@ pub(crate) fn desugar_command(
 
             if seminaive {
                 let mut new_rule = rule.clone();
-                // let mut iter_idx = 0;
-                // let mut remove_idx: Vec<i32> = Vec:new();
+                // only add new rule where there is Call in head to avoid adding same rule again.
+                let mut add_new_rule = false;
 
                 for head_slice in new_rule.head.iter_mut() {
                     match head_slice {
@@ -396,6 +396,7 @@ pub(crate) fn desugar_command(
                             // move it to body so seminaive fires
                             match value {
                                 Expr::Call(_, _) => {
+                                    add_new_rule = true;
                                     let mut eq_vec: Vec<Expr> = Vec::new();
                                     let fresh_symbol = desugar.get_fresh();
                                     eq_vec.push(Expr::Var(fresh_symbol));
@@ -426,7 +427,8 @@ pub(crate) fn desugar_command(
 
                 println!("new rule = {}", new_rule);
 
-                vec![
+                if add_new_rule {
+                    vec![
                     NCommand::NormRule {
                         ruleset,
                         name,
@@ -438,6 +440,15 @@ pub(crate) fn desugar_command(
                         rule: flatten_rule(new_rule, desugar),
                     },
                 ]
+
+                } else {
+                    vec![NCommand::NormRule {
+                        ruleset,
+                        name,
+                        rule: flatten_rule(rule, desugar),
+                    }]
+                }
+
             } else {
                 vec![NCommand::NormRule {
                     ruleset,

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -386,7 +386,7 @@ pub(crate) fn desugar_command(
 
             if seminaive {
                 let mut new_rule = rule.clone();
-                // only add new rule where there is Call in head to avoid adding same rule again.
+                // only add new rule when there is Call in body to avoid adding same rule.
                 let mut add_new_rule = false;
 
                 for head_slice in new_rule.head.iter_mut() {
@@ -425,22 +425,21 @@ pub(crate) fn desugar_command(
                     _ => true,
                 });
 
-                println!("new rule = {}", new_rule);
-
                 if add_new_rule {
-                    vec![
-                    NCommand::NormRule {
-                        ruleset,
-                        name,
-                        rule: flatten_rule(rule, desugar),
-                    },
-                    NCommand::NormRule {
-                        ruleset,
-                        name,
-                        rule: flatten_rule(new_rule, desugar),
-                    },
-                ]
+                    log::debug!("Added semi-naive desugared rules:\n{}", new_rule);
 
+                    vec![
+                        NCommand::NormRule {
+                            ruleset,
+                            name,
+                            rule: flatten_rule(rule, desugar),
+                        },
+                        NCommand::NormRule {
+                            ruleset,
+                            name,
+                            rule: flatten_rule(new_rule, desugar),
+                        },
+                    ]
                 } else {
                     vec![NCommand::NormRule {
                         ruleset,
@@ -448,7 +447,6 @@ pub(crate) fn desugar_command(
                         rule: flatten_rule(rule, desugar),
                     }]
                 }
-
             } else {
                 vec![NCommand::NormRule {
                     ruleset,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1036,7 +1036,7 @@ impl EGraph {
         let program_desugared = self
             .proof_state
             .desugar
-            .desugar_program(vec![command], self.test_proofs)?;
+            .desugar_program(vec![command], self.test_proofs, self.seminaive)?;
 
         let type_info_before = self.proof_state.type_info.clone();
         self.proof_state
@@ -1048,7 +1048,7 @@ impl EGraph {
             // we need to pass in the desugar
             let proofs = self.proof_state.add_proofs(program_desugared);
 
-            let final_desugared = self.proof_state.desugar.desugar_program(proofs, false)?;
+            let final_desugared = self.proof_state.desugar.desugar_program(proofs, false, self.seminaive)?;
 
             // revert back to the type info before
             // proofs were added, typecheck again

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1033,10 +1033,11 @@ impl EGraph {
     }
 
     fn process_command(&mut self, command: Command) -> Result<Vec<NormCommand>, Error> {
-        let program_desugared = self
-            .proof_state
-            .desugar
-            .desugar_program(vec![command], self.test_proofs, self.seminaive)?;
+        let program_desugared = self.proof_state.desugar.desugar_program(
+            vec![command],
+            self.test_proofs,
+            self.seminaive,
+        )?;
 
         let type_info_before = self.proof_state.type_info.clone();
         self.proof_state
@@ -1048,7 +1049,10 @@ impl EGraph {
             // we need to pass in the desugar
             let proofs = self.proof_state.add_proofs(program_desugared);
 
-            let final_desugared = self.proof_state.desugar.desugar_program(proofs, false, self.seminaive)?;
+            let final_desugared =
+                self.proof_state
+                    .desugar
+                    .desugar_program(proofs, false, self.seminaive)?;
 
             // revert back to the type info before
             // proofs were added, typecheck again

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -674,7 +674,11 @@ impl EGraph {
                                 self.functions.get_mut(f).unwrap().insert(values, value, ts);
                                 value
                             }
-                            _ => panic!("invalid default for {:?}", function.decl.name),
+                            _ => {
+                                return Err(Error::NotFoundError(NotFoundError(Expr::Var(
+                                    format!("fake expression {f} {:?}", values).into(),
+                                ))))
+                            }
                         }
                     } else {
                         return Err(Error::NotFoundError(NotFoundError(Expr::Var(

--- a/tests/semi_naive_set_function.egg
+++ b/tests/semi_naive_set_function.egg
@@ -85,6 +85,9 @@
 
 (run 100)
 (print f) 
+(check (!= 0 (f 0)))
+(check (!= 0 (f 1)))
+(check (!= 0 (f 2)))
 
 (pop)
 
@@ -98,4 +101,4 @@
 (run 100)
 (print g) 
 
-(check (= 50 (g 50)))
+(check (= 20 (g 20)))

--- a/tests/semi_naive_set_function.egg
+++ b/tests/semi_naive_set_function.egg
@@ -1,0 +1,101 @@
+;; From issue#93. The change happened in right-hand-side of a rule may also impact output in semi-naive cases
+(push)
+(function f (i64) i64 :merge (max old new))
+
+(set (f 0) 0)
+(set (f 3) 0)
+
+(rule ((= f0 (f 0))) ((set (f 1) f0)))
+(rule ((= f1 (f 1))) ((set (f 2) f1)))
+
+;; update f3 some iters later to make sure f(0) is inactive
+(rule ((= f2 (f 2))) ((set (f 3) 3)))
+
+(push)
+
+;; This rule should fire and set f(0) to be 3, but because f0 is inactive, 
+;; it does not fire (despite that f3 is active now)
+(rule ((= f0 (f 0))) ((set (f 0) (f 3))))
+
+(run 100)
+(print f) ;; f0 is expected to have value 3, but has 0 in reality.
+
+(check (= (f 0) 3))
+(check (= (f 1) 3))
+(check (= (f 2) 3))
+(check (= (f 3) 3))
+
+(pop)
+(push)
+
+;; variants of the last rule.
+(rule ((= f0 (f 0)) (= x 3) (= y x))  ((set (f 0) (f y))))
+
+(run 100)
+(check (= (f 0) 3))
+(check (= (f 1) 3))
+(check (= (f 2) 3))
+(check (= (f 3) 3))
+
+(pop)
+(push)
+
+;; adding let binding
+(rule ((= f0 (f 0))) ((let x 3) (let y x) (set (f 0) (f y))))
+
+(run 100)
+(check (= (f 0) 3))
+(check (= (f 1) 3))
+(check (= (f 2) 3))
+(check (= (f 3) 3))
+
+(pop)
+(push)
+
+(function g (i64) i64 :merge (max old new))
+(set (g 0) 3)
+
+;; bind to another function
+(rule ((= f0 (f 0))) ((let x (g 0)) (let y x) (set (f 0) (f y))))
+
+(run 100)
+(check (= (f 0) 3))
+(check (= (f 1) 3))
+(check (= (f 2) 3))
+(check (= (f 3) 3))
+
+(pop)
+(pop)
+
+;; more complicated case, when the evaluation never finish
+;; the semi_naive and naive behavior diverage a bit
+(function f (i64) i64 :merge (max old new))
+
+(set (f 0) 0)
+(set (f 3) 0)
+
+(rule ((= f0 (f 0))) ((set (f 1) (+ 1 f0))))
+(rule ((= f1 (f 1))) ((set (f 2) (+ 1 f1))))
+
+(push)
+
+(rule ((= f2 (f 2))) ((set (f 3) 1)))
+(rule ((= f0 (f 0))) ((set (f 0) (f (f 3)))))
+
+
+(run 100)
+(print f) 
+
+(pop)
+
+
+;; id function that will set all int values, but need strong induction.
+(function g (i64) i64 :merge (max old new))
+(set (g 0) 0)
+(set (g 1) 1)
+(rule ((= x (g x))) ((set (g (+ x 1)) (+ (g (- x 1)) 2))))
+
+(run 100)
+(print g) 
+
+(check (= 50 (g 50)))


### PR DESCRIPTION
Fixing the problem in issue[#93](https://github.com/mwillsey/egg-smol/issues/93), that in semi-naive eval, the change happens in the right-hand-side in set operation should affect the evaluation, but being ignored due to semi-naive. The fix was to add a new rule while meeting setting to a Call, add one more equal relation to the body part of the rule in the desugar_command phase, as well as let binding since they might bind variables in the Call. 
