### PR TITLE
Fix high cost overflowing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,9 @@ impl RunReport {
     }
 }
 
-pub const HIGH_COST: usize = usize::MAX;
+// Set a high cost to avoid being extracted
+// Use half of our bits to avoid overflow when adding costs
+pub const HIGH_COST: usize = usize::MAX >> (usize::BITS / 2);
 
 #[derive(Clone)]
 pub struct Primitive(Arc<dyn PrimitiveLike>);


### PR DESCRIPTION
This PR reduces the size of the HIGH_COST so that it won't overflow when added to other costs.

Instead of using all the bits, it will only use half of them, which should still give it a pretty high cost but also plenty of room to grow.