### PR TITLE
Fix bug when extracting sets/maps with equality sort values

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -29,8 +29,8 @@ impl EGraph {
         None
     }
 
-    pub fn extract(&self, value: Value, arcsort: Option<&ArcSort>) -> (Cost, Expr) {
-        Extractor::new(self).find_best(value, arcsort)
+    pub fn extract(&self, value: Value, arcsort: &ArcSort) -> (Cost, Expr) {
+        Extractor::new(self).find_best(value, Some(arcsort))
     }
 
     pub fn extract_variants(&mut self, value: Value, limit: usize) -> Vec<Expr> {

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -2,7 +2,7 @@ use hashbrown::hash_map::Entry;
 
 use crate::ast::Symbol;
 use crate::util::HashMap;
-use crate::{EGraph, Expr, Function, Id, Value};
+use crate::{EGraph, Expr, Function, Id, Value, ArcSort};
 
 type Cost = usize;
 
@@ -29,8 +29,8 @@ impl EGraph {
         None
     }
 
-    pub fn extract(&mut self, value: Value) -> (Cost, Expr) {
-        Extractor::new(self).find_best(value)
+    pub fn extract(&self, value: Value, arcsort: Option<&ArcSort>) -> (Cost, Expr) {
+        Extractor::new(self).find_best(value, arcsort)
     }
 
     pub fn extract_variants(&mut self, value: Value, limit: usize) -> Vec<Expr> {
@@ -78,12 +78,12 @@ impl<'a> Extractor<'a> {
     }
 
     fn expr_from_node(&self, node: &Node) -> Expr {
-        let children = node.inputs.iter().map(|&value| self.find_best(value).1);
+        let children = node.inputs.iter().map(|&value| self.find_best(value, None).1);
         Expr::call(node.sym, children)
     }
 
-    fn find_best(&self, value: Value) -> (Cost, Expr) {
-        let sort = self.egraph.get_sort(&value).unwrap();
+    fn find_best(&self, value: Value, sort: Option<&ArcSort>) -> (Cost, Expr) {
+        let sort = sort.unwrap_or_else(|| self.egraph.get_sort(&value).unwrap());
         if sort.is_eq_sort() {
             let id = self.egraph.find(Id::from(value.bits as usize));
             let (cost, node) = &self
@@ -92,7 +92,7 @@ impl<'a> Extractor<'a> {
                 .unwrap_or_else(|| panic!("No cost for {:?}", value));
             (*cost, self.expr_from_node(node))
         } else {
-            (0, sort.make_expr(value))
+            (0, sort.make_expr(self.egraph, value))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,14 +421,14 @@ impl EGraph {
             write!(s, "({}", sym).unwrap();
             for (a, t) in ins.iter().copied().zip(&schema.input) {
                 s.push(' ');
-                let e = self.extract(a, Some(t)).1;
+                let e = self.extract(a, t).1;
                 write!(s, "{}", e).unwrap();
             }
 
             if out_is_unit {
                 s.push(')');
             } else {
-                let e = self.extract(out.value, Some(&schema.output)).1;
+                let e = self.extract(out.value, &schema.output).1;
                 write!(s, ") -> {}", e).unwrap();
             }
             s.push('\n');
@@ -993,7 +993,7 @@ impl EGraph {
         self.push();
         let (t, value) = self.eval_expr(&expr, None, true).unwrap();
         self.run_report = Some(self.run_rules(config));
-        let (cost, expr) = self.extract(value, Some(&t));
+        let (cost, expr) = self.extract(value, &t);
         self.pop().unwrap();
         Ok(ExtractReport {
             cost,
@@ -1005,7 +1005,7 @@ impl EGraph {
     // of other variants, if variants is not zero.
     pub fn extract_expr(&mut self, e: Expr, variants: usize) -> Result<ExtractReport, Error> {
         let (t, value) = self.eval_expr(&e, None, true)?;
-        let (cost, expr) = self.extract(value, Some(&t));
+        let (cost, expr) = self.extract(value, &t);
         let exprs = match variants {
             0 => vec![],
             1 => vec![expr.clone()],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,22 +421,14 @@ impl EGraph {
             write!(s, "({}", sym).unwrap();
             for (a, t) in ins.iter().copied().zip(&schema.input) {
                 s.push(' ');
-                let e = if t.is_eq_sort() {
-                    self.extract(a).1
-                } else {
-                    t.make_expr(a)
-                };
+                let e = self.extract(a, Some(t)).1;
                 write!(s, "{}", e).unwrap();
             }
 
             if out_is_unit {
                 s.push(')');
             } else {
-                let e = if schema.output.is_eq_sort() {
-                    self.extract(out.value).1
-                } else {
-                    schema.output.make_expr(out.value)
-                };
+                let e = self.extract(out.value, Some(&schema.output)).1;
                 write!(s, ") -> {}", e).unwrap();
             }
             s.push('\n');
@@ -999,9 +991,9 @@ impl EGraph {
 
     fn simplify(&mut self, expr: Expr, config: &NormRunConfig) -> Result<ExtractReport, Error> {
         self.push();
-        let (_t, value) = self.eval_expr(&expr, None, true).unwrap();
+        let (t, value) = self.eval_expr(&expr, None, true).unwrap();
         self.run_report = Some(self.run_rules(config));
-        let (cost, expr) = self.extract(value);
+        let (cost, expr) = self.extract(value, Some(&t));
         self.pop().unwrap();
         Ok(ExtractReport {
             cost,
@@ -1012,8 +1004,8 @@ impl EGraph {
     // Extract an expression from the current state, returning the cost, the extracted expression and some number
     // of other variants, if variants is not zero.
     pub fn extract_expr(&mut self, e: Expr, variants: usize) -> Result<ExtractReport, Error> {
-        let (_t, value) = self.eval_expr(&e, None, true)?;
-        let (cost, expr) = self.extract(value);
+        let (t, value) = self.eval_expr(&e, None, true)?;
+        let (cost, expr) = self.extract(value, Some(&t));
         let exprs = match variants {
             0 => vec![],
             1 => vec![expr.clone()],

--- a/src/sort/f64.rs
+++ b/src/sort/f64.rs
@@ -44,7 +44,7 @@ impl Sort for F64Sort {
         add_primitives!(eg, "max" = |a: f64, b: f64| -> f64 { a.max(b) });
     }
 
-    fn make_expr(&self, value: Value) -> Expr {
+    fn make_expr(&self, _egraph: &EGraph, value: Value) -> Expr {
         assert!(value.tag == self.name());
         Expr::Lit(Literal::F64(OrderedFloat(f64::from_bits(value.bits))))
     }

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -51,7 +51,7 @@ impl Sort for I64Sort {
         add_primitives!(eg, "max" = |a: i64, b: i64| -> i64 { a.max(b) });
     }
 
-    fn make_expr(&self, value: Value) -> Expr {
+    fn make_expr(&self, _egraph: &EGraph, value: Value) -> Expr {
         assert!(value.tag == self.name());
         Expr::Lit(Literal::Int(value.bits as _))
     }

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -131,8 +131,8 @@ impl Sort for MapSort {
         let map = ValueMap::load(self, &value);
         let mut expr = Expr::call("map-empty", []);
         for (k, v) in map.iter().rev() {
-            let k = egraph.extract(*k, Some(&self.key)).1;
-            let v = egraph.extract(*v, Some(&self.value)).1;
+            let k = egraph.extract(*k, &self.key).1;
+            let v = egraph.extract(*v, &self.value).1;
             expr = Expr::call("map-insert", [expr, k, v])
         }
         expr

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -127,12 +127,12 @@ impl Sort for MapSort {
         });
     }
 
-    fn make_expr(&self, value: Value) -> Expr {
+    fn make_expr(&self, egraph: &EGraph, value: Value) -> Expr {
         let map = ValueMap::load(self, &value);
         let mut expr = Expr::call("map-empty", []);
         for (k, v) in map.iter().rev() {
-            let k = self.key.make_expr(*k);
-            let v = self.value.make_expr(*v);
+            let k = egraph.extract(*k, Some(&self.key)).1;
+            let v = egraph.extract(*v, Some(&self.value)).1;
             expr = Expr::call("map-insert", [expr, k, v])
         }
         expr

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -60,7 +60,7 @@ pub trait Sort: Any + Send + Sync + Debug {
         let _ = info;
     }
 
-    fn make_expr(&self, value: Value) -> Expr;
+    fn make_expr(&self, egraph: &EGraph, value: Value) -> Expr;
 }
 
 #[derive(Debug)]
@@ -92,7 +92,7 @@ impl Sort for EqSort {
         }
     }
 
-    fn make_expr(&self, _value: Value) -> Expr {
+    fn make_expr(&self, _egraph: &EGraph, _value: Value) -> Expr {
         unimplemented!("No make_expr for EqSort {}", self.name)
     }
 }

--- a/src/sort/rational.rs
+++ b/src/sort/rational.rs
@@ -105,7 +105,7 @@ impl Sort for RationalSort {
         add_primitives!(eg, "<=" = |a: R, b: R| -> Opt { if a <= b {Some(())} else {None} }); 
         add_primitives!(eg, ">=" = |a: R, b: R| -> Opt { if a >= b {Some(())} else {None} }); 
    }
-    fn make_expr(&self, value: Value) -> Expr {
+    fn make_expr(&self, _egraph: &EGraph, value: Value) -> Expr {
         assert!(value.tag == self.name());
         let rat = R::load(self, &value);
         let numer = *rat.numer();

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -133,7 +133,7 @@ impl Sort for SetSort {
         let set = ValueSet::load(self, &value);
         let mut expr = Expr::call("set-empty", []);
         for e in set.iter().rev() {
-            let e = egraph.extract(*e, Some(&self.element)).1;
+            let e = egraph.extract(*e, &self.element).1;
             expr = Expr::call("set-insert", [expr, e])
         }
         expr

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -129,11 +129,11 @@ impl Sort for SetSort {
         });
     }
 
-    fn make_expr(&self, value: Value) -> Expr {
+    fn make_expr(&self, egraph: &EGraph, value: Value) -> Expr {
         let set = ValueSet::load(self, &value);
         let mut expr = Expr::call("set-empty", []);
         for e in set.iter().rev() {
-            let e = self.element.make_expr(*e);
+            let e = egraph.extract(*e, Some(&self.element)).1;
             expr = Expr::call("set-insert", [expr, e])
         }
         expr

--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -24,7 +24,7 @@ impl Sort for StringSort {
         self
     }
 
-    fn make_expr(&self, value: Value) -> Expr {
+    fn make_expr(&self, _egraph: &EGraph, value: Value) -> Expr {
         assert!(value.tag == self.name);
         let sym = Symbol::from(NonZeroU32::new(value.bits as _).unwrap());
         Expr::Lit(Literal::String(sym))

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -25,7 +25,7 @@ impl Sort for UnitSort {
         type_info.add_primitive(NotEqualPrimitive { unit: self })
     }
 
-    fn make_expr(&self, value: Value) -> Expr {
+    fn make_expr(&self, _egraph: &EGraph, value: Value) -> Expr {
         assert_eq!(value.tag, self.name);
         Expr::Lit(Literal::Unit)
     }

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -124,7 +124,7 @@ impl Sort for VecSort {
         let vec = ValueVec::load(self, &value);
         let mut expr = Expr::call("vec-empty", []);
         for e in vec.iter().rev() {
-            let e = egraph.extract(*e, Some(&self.element)).1;
+            let e = egraph.extract(*e, &self.element).1;
             expr = Expr::call("vec-insert", [expr, e])
         }
         expr

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -120,11 +120,11 @@ impl Sort for VecSort {
         });
     }
 
-    fn make_expr(&self, value: Value) -> Expr {
+    fn make_expr(&self, egraph: &EGraph, value: Value) -> Expr {
         let vec = ValueVec::load(self, &value);
         let mut expr = Expr::call("vec-empty", []);
         for e in vec.iter().rev() {
-            let e = self.element.make_expr(*e);
+            let e = egraph.extract(*e, Some(&self.element)).1;
             expr = Expr::call("vec-insert", [expr, e])
         }
         expr

--- a/tests/fusion.egg
+++ b/tests/fusion.egg
@@ -135,6 +135,9 @@
 
 (run 100)
 
+(extract (freer expr))
+
+
 (define my-output
     (CaseSplit (TVar (V "expr")) (Num 0) 
            (Lam (V "x") (Lam (V "xs'") 


### PR DESCRIPTION
This PR resolves a bug that previously triggered an error when trying to extract a set or map with a user-defined equality sort as its value. The issue stemmed from the fact that equality sorts were not properly handled in certain circumstances.

To fix this, I passed the egraph into the make_expr function on each sort. This allows sorts that may contain equality sorts to call the extract method and load those values when necessary.

I also add added a demonstration of this feature to provide a working example and test case to the `tests/fusion.egg` file.

During this process, I refactored some parts of the code to use the `extract` method. This ensures that all code determining whether a value is an equality sort uses the same logic.

These changes ensure that all code determining whether a value is an equality sort uses the same logic, which leads to more consistent behavior.