### PR TITLE
Add EGraph Visualizations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,12 @@ jobs:
     - name: Build
       run: make web
 
+    - name: Upload web artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: www
+        path: target/www
+
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       # only actually deploy if pushed to main branch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       run: make web
 
     - name: Upload web artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: www
         path: target/www

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger",
+ "getrandom",
  "glob",
  "graphviz-rust",
  "hashbrown 0.13.1",
@@ -356,8 +357,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,9 @@ clap = {version = "4", features = ["derive"], optional = true}
 env_logger = {version = "0.10", optional = true}
 
 ordered-float = {version = "3.4"}
+
 graphviz-rust = "0.6.2"
+# Need to add "js" feature for "graphviz-rust" to work in wasm
 getrandom = {version="*", features = ["js"]}
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ env_logger = {version = "0.10", optional = true}
 
 ordered-float = {version = "3.4"}
 graphviz-rust = "0.6.2"
+getrandom = {version="*", features = ["js"]}
 
 [build-dependencies]
 glob = "0.3.1"

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ${DIST_WASM}: ${RUST_SRC}
 	wasm-pack build web-demo --target no-modules --no-typescript --out-dir ${WWW}
 	rm -f ${WWW}/{.gitignore,package.json}
 
-graphs: $(patsubst %.egg,%.svg,$(filter-out tests//fail-typecheck/%, ${TESTS}))
+graphs: $(patsubst %.egg,%.svg,$(filter-out tests//fail-typecheck/% tests//cykjson.egg, ${TESTS}))
 
 %.svg: %.egg
 	cargo run -- --save-dot --save-svg  $^

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ ${DIST_WASM}: ${RUST_SRC}
 	wasm-pack build web-demo --target no-modules --no-typescript --out-dir ${WWW}
 	rm -f ${WWW}/{.gitignore,package.json}
 
-graphs: $(patsubst %.egg,%.svg,$(filter-out tests//fail-typecheck/% tests//cykjson.egg, ${TESTS}))
+graphs: $(patsubst %.egg,%.svg,$(shell find tests -type f -name '*.egg' -not -name '*cykjson*' -not -name '*unbound.egg'))
 
 %.svg: %.egg
-	cargo run -- --save-dot --save-svg  $^
+	cargo run --release -- --save-dot --save-svg  $^
 
 rm-graphs:
 	rm -f tests/*.dot tests/*.svg

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -4,7 +4,7 @@ use smallvec::SmallVec;
 
 mod binary_search;
 pub mod index;
-mod table;
+pub(crate) mod table;
 
 pub type ValueVec = SmallVec<[Value; 3]>;
 

--- a/src/function/table.rs
+++ b/src/function/table.rs
@@ -302,7 +302,7 @@ impl Table {
     }
 }
 
-fn hash_values(vs: &[Value]) -> u64 {
+pub(crate) fn hash_values(vs: &[Value]) -> u64 {
     // Just hash the bits: all inputs to the same function should have matching
     // column types.
     let mut hasher = BH::default().build_hasher();

--- a/src/graph/from_egraph.rs
+++ b/src/graph/from_egraph.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::{ast::Id, function::table::hash_values, EGraph, Value};
 
-pub(crate) fn graph_from_egraph(egraph: &EGraph) -> Graph {
-    let mut graph = Graph::default();
+pub(crate) fn graph_from_egraph(egraph: &EGraph) -> ExportedGraph {
+    let mut graph = ExportedGraph::default();
     for (_id, function) in egraph.functions.iter() {
         let name = function.decl.name.to_string();
         // Skip generated names

--- a/src/graph/from_egraph.rs
+++ b/src/graph/from_egraph.rs
@@ -10,7 +10,7 @@ pub(crate) fn graph_from_egraph(egraph: &EGraph) -> Graph {
         if name.ends_with("___") {
             continue;
         }
-        for (input, output) in function.nodes.vals.iter() {
+        for (offset, (input, output)) in function.nodes.vals.iter().enumerate() {
             if !input.live() {
                 continue;
             }
@@ -29,7 +29,7 @@ pub(crate) fn graph_from_egraph(egraph: &EGraph) -> Graph {
                 Arg::Eq(parent_id) => {
                     eclasses.entry(parent_id).or_default().push(fn_call);
                 }
-                Arg::Prim(prim_value) => prim_outputs.push(PrimOutput(fn_call, prim_value)),
+                Arg::Prim(prim_value) => prim_outputs.push(PrimOutput(fn_call, prim_value, offset)),
             }
         }
     }

--- a/src/graph/from_egraph.rs
+++ b/src/graph/from_egraph.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{ast::Id, function::table::hash_values, EGraph, Value, ArcSort};
+use crate::{ast::Id, function::table::hash_values, ArcSort, EGraph, Value};
 
 pub(crate) fn graph_from_egraph(egraph: &EGraph) -> ExportedGraph {
     let mut calls = ExportedGraph::default();

--- a/src/graph/from_egraph.rs
+++ b/src/graph/from_egraph.rs
@@ -37,12 +37,11 @@ fn is_temp_name(name: String) -> bool {
 
 fn export_value(egraph: &EGraph, value: Value) -> ExportedValue {
     let sort = egraph.get_sort(&value).unwrap();
-    println!("sort: {:?} {:?}", sort, sort.is_eq_container_sort());
     if sort.is_eq_sort() {
         let id = value.bits as usize;
         let canonical: usize = egraph.unionfind.find(Id::from(id)).into();
         ExportedValue::EClass(canonical)
-    } else if sort.is_eq_container_sort() {
+    } else if sort.is_container_sort() {
         let inner: Vec<Value> = sort
             .inner_values(&value)
             .into_iter()

--- a/src/graph/from_egraph.rs
+++ b/src/graph/from_egraph.rs
@@ -5,8 +5,8 @@ pub(crate) fn graph_from_egraph(egraph: &EGraph) -> ExportedGraph {
     let mut graph = ExportedGraph::default();
     for (_id, function) in egraph.functions.iter() {
         let name = function.decl.name.to_string();
-        // Skip generated names
-        if name.ends_with("___") {
+        // Keep temporary functions if proofs are enabled, because the proofs reference them
+        if is_temp_name(name.clone()) && !egraph.proofs_enabled {
             continue;
         }
         for (input, output) in function.nodes.vals.iter() {
@@ -32,6 +32,12 @@ pub(crate) fn graph_from_egraph(egraph: &EGraph) -> ExportedGraph {
         }
     }
     graph
+}
+
+/// Returns true if the name is in the form v{digits}___
+/// like v78___
+fn is_temp_name(name: String) -> bool {
+    name.starts_with('v') && name.ends_with("___") && name[1..name.len() - 3].parse::<u32>().is_ok()
 }
 
 fn arg_from_value(egraph: &EGraph, value: Value) -> Arg {

--- a/src/graph/from_egraph.rs
+++ b/src/graph/from_egraph.rs
@@ -1,32 +1,12 @@
-use clap::ValueEnum;
-
 use super::*;
 use crate::{ast::Id, function::table::hash_values, EGraph, Value};
 
-/// Whether to include temporary functions in the exported graph
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-pub enum IncludeTempFunctions {
-    /// Include temporary functions if proofs are enabled, since some non temporary functions in proofs may depend on them
-    IfProofsEnabled,
-    /// Always include temporary functions
-    Always,
-    /// Never include temporary functions
-    Never,
-}
-
-pub(crate) fn graph_from_egraph(
-    egraph: &EGraph,
-    show_temp_functions: IncludeTempFunctions,
-) -> ExportedGraph {
+pub(crate) fn graph_from_egraph(egraph: &EGraph) -> ExportedGraph {
     let mut graph = ExportedGraph::default();
     for (_id, function) in egraph.functions.iter() {
         let name = function.decl.name.to_string();
-        let include_temp_functions = match show_temp_functions {
-            IncludeTempFunctions::Never => false,
-            IncludeTempFunctions::IfProofsEnabled => egraph.proofs_enabled,
-            IncludeTempFunctions::Always => true,
-        };
-        if !include_temp_functions && is_temp_name(name.clone()) {
+        // Keep temporary functions if proofs are enabled, because the proofs reference them
+        if is_temp_name(name.clone()) && !egraph.proofs_enabled {
             continue;
         }
         for (input, output) in function.nodes.vals.iter() {

--- a/src/graph/from_egraph.rs
+++ b/src/graph/from_egraph.rs
@@ -5,8 +5,8 @@ pub(crate) fn graph_from_egraph(egraph: &EGraph) -> ExportedGraph {
     let mut graph = ExportedGraph::default();
     for (_id, function) in egraph.functions.iter() {
         let name = function.decl.name.to_string();
-        // Keep temporary functions if proofs are enabled, because the proofs reference them
-        if is_temp_name(name.clone()) && !egraph.proofs_enabled {
+        // Skip temporary names
+        if is_temp_name(name.clone()) {
             continue;
         }
         for (input, output) in function.nodes.vals.iter() {

--- a/src/graph/from_egraph.rs
+++ b/src/graph/from_egraph.rs
@@ -38,7 +38,6 @@ pub(crate) fn graph_from_egraph(egraph: &EGraph) -> ExportedGraph {
         .take(MAX_FUNCTIONS)
         .flatten()
         .collect()
-
 }
 
 /// Returns true if the name is in the form v{digits}___

--- a/src/graph/from_egraph.rs
+++ b/src/graph/from_egraph.rs
@@ -1,7 +1,7 @@
-use crate::{EGraph, Value, ast::Id};
 use super::*;
+use crate::{ast::Id, EGraph, Value};
 
-pub (crate) fn graph_from_egraph(egraph: &EGraph) -> Graph {
+pub(crate) fn graph_from_egraph(egraph: &EGraph) -> Graph {
     let mut prim_outputs = vec![];
     let mut eclasses = HashMap::<String, Vec<FnCall>>::default();
     for (_id, function) in egraph.functions.iter() {
@@ -29,9 +29,7 @@ pub (crate) fn graph_from_egraph(egraph: &EGraph) -> Graph {
                 Arg::Eq(parent_id) => {
                     eclasses.entry(parent_id).or_default().push(fn_call);
                 }
-                Arg::Prim(prim_value) => {
-                    prim_outputs.push(PrimOutput(fn_call, prim_value))
-                }
+                Arg::Prim(prim_value) => prim_outputs.push(PrimOutput(fn_call, prim_value)),
             }
         }
     }
@@ -40,7 +38,6 @@ pub (crate) fn graph_from_egraph(egraph: &EGraph) -> Graph {
         eclasses,
     }
 }
-
 
 fn arg_from_value(egraph: &EGraph, value: Value) -> Arg {
     let sort = egraph.get_sort(&value).unwrap();

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -18,7 +18,7 @@ pub(crate) struct ExportedCall {
 }
 
 /// An argument is either a primitive value or a reference to a eclass
-#[derive(Debug, Hash, Clone)]
+#[derive(Debug, Hash, Clone, PartialEq, Eq)]
 pub(crate) enum ExportedValue {
     /// A primitive value, i.e. int, float, String
     Prim (String),

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,57 +1,33 @@
 pub(crate) mod from_egraph;
 pub(crate) mod to_graphviz;
 
-use crate::{ast::Expr, util::HashMap};
-
 type Offset = usize;
 type EClassID = Offset;
 type Hash = u64;
-type EClasses = HashMap<EClassID, Vec<FnCall>>;
 
 /// Exposed graph structure which can be used to print/visualize the state of the e-graph.
-#[derive(Debug, Default)]
-pub(crate) struct ExportedGraph {
-    /// All of the primitive values which are outputs of functions
-    pub prim_outputs: Vec<PrimOutput>,
-    /// All of the e-classes which are have non primitive types
-    pub eclasses: EClasses,
+pub(crate) type ExportedGraph = Vec<ExportedCall>;
+
+#[derive(Debug)]
+pub(crate) struct ExportedCall {
+    fn_name: String,
+    inputs: Vec<ExportedValue>,
+    output: ExportedValue,
+    /// Hash of arguments
+    input_hash: Hash,
 }
-
-/// A primitive value which is output from a function.
-#[derive(Debug)]
-pub(crate) struct PrimOutput(pub FnCall, pub PrimValue);
-
-#[derive(Debug)]
-pub(crate) struct FnCall(
-    pub Fn,
-    pub Vec<Arg>,
-    // Hash of arguments
-    pub Hash,
-);
 
 /// An argument is either a primitive value or a reference to a eclass
-#[derive(Debug)]
-pub(crate) enum Arg {
-    Prim(PrimValue),
-    Eq(EClassID),
-}
-
-#[derive(Debug)]
-pub(crate) struct Fn {
-    pub name: String,
-    // TODO: Add cost
-}
-
-/// A primitive value (str, float, int, etc)
-#[derive(Debug)]
-pub(crate) struct PrimValue(String);
-
-pub(crate) fn from_expr(expr: &Expr) -> PrimValue {
-    PrimValue(expr.to_string())
-}
-
-impl ToString for PrimValue {
-    fn to_string(&self) -> String {
-        self.0.clone()
-    }
+#[derive(Debug, Hash, Clone)]
+pub(crate) enum ExportedValue {
+    /// A primitive value, i.e. int, float, String
+    Prim (String),
+    /// A container sort, i.e. Vec, Map, Set
+    Container {
+        name: String,
+        inner: Vec<ExportedValue>,
+        inner_hash: Hash,
+    },
+    /// A reference to an eclass
+    EClass(EClassID),
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -23,14 +23,8 @@ pub(crate) struct ExportedValueWithSort(ExportedValue, String);
 /// An argument is either a primitive value or a reference to a eclass
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
 pub(crate) enum ExportedValue {
-    /// A primitive value, i.e. int, float, String
-    Prim(String),
-    /// A container sort, i.e. Vec, Map, Set
-    Container {
-        name: String,
-        inner: Vec<ExportedValueWithSort>,
-        inner_hash: Hash,
-    },
+    /// A primitive value,, i.e. int, float, String, Vec, Map, Set
+    Prim(String, Vec<ExportedValueWithSort>, Hash),
     /// A reference to an eclass
     EClass(EClassID),
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -5,16 +5,16 @@ use crate::{ast::Expr, util::HashMap};
 
 type EClassID = String;
 
-// Exposed graph structure which can be used to print/visualize the state of the e-graph.
+/// Exposed graph structure which can be used to print/visualize the state of the e-graph.
 #[derive(Debug)]
 pub(crate) struct Graph {
-    // All of the primitive values which are outputs of functions
+    /// All of the primitive values which are outputs of functions
     pub prim_outputs: Vec<PrimOutput>,
-    // All of the e-classes which are have non primitive types
+    /// All of the e-classes which are have non primitive types
     pub eclasses: HashMap<EClassID, Vec<FnCall>>,
 }
 
-// A primitive value which is output from a function.
+/// A primitive value which is output from a function.
 #[derive(Debug)]
 pub(crate) struct PrimOutput(pub FnCall, pub PrimValue);
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -5,6 +5,8 @@ use crate::{ast::Expr, util::HashMap};
 
 type Offset = usize;
 type EClassID = Offset;
+type Hash = u64;
+type EClasses = HashMap<EClassID, Vec<FnCall>>;
 
 /// Exposed graph structure which can be used to print/visualize the state of the e-graph.
 #[derive(Debug, Default)]
@@ -12,20 +14,20 @@ pub(crate) struct Graph {
     /// All of the primitive values which are outputs of functions
     pub prim_outputs: Vec<PrimOutput>,
     /// All of the e-classes which are have non primitive types
-    pub eclasses: HashMap<EClassID, Vec<FnCall>>,
+    pub eclasses: EClasses,
 }
 
 /// A primitive value which is output from a function.
 #[derive(Debug)]
-pub(crate) struct PrimOutput(
-    pub FnCall,
-    pub PrimValue,
-    /// Unique offset, per function, of what call this is. Needed to preserve resulting graph ID's accross time.
-    pub Offset,
-);
+pub(crate) struct PrimOutput(pub FnCall, pub PrimValue);
 
 #[derive(Debug)]
-pub(crate) struct FnCall(pub Fn, pub Vec<Arg>);
+pub(crate) struct FnCall(
+    pub Fn,
+    pub Vec<Arg>,
+    // Hash of arguments
+    pub Hash,
+);
 
 /// An argument is either a primitive value or a reference to a eclass
 #[derive(Debug)]

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -10,7 +10,7 @@ type EClasses = HashMap<EClassID, Vec<FnCall>>;
 
 /// Exposed graph structure which can be used to print/visualize the state of the e-graph.
 #[derive(Debug, Default)]
-pub(crate) struct Graph {
+pub(crate) struct ExportedGraph {
     /// All of the primitive values which are outputs of functions
     pub prim_outputs: Vec<PrimOutput>,
     /// All of the e-classes which are have non primitive types

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod to_graphviz;
 use crate::{ast::Expr, util::HashMap};
 
 type EClassID = String;
+type Offset = usize;
 
 /// Exposed graph structure which can be used to print/visualize the state of the e-graph.
 #[derive(Debug)]
@@ -16,7 +17,7 @@ pub(crate) struct Graph {
 
 /// A primitive value which is output from a function.
 #[derive(Debug)]
-pub(crate) struct PrimOutput(pub FnCall, pub PrimValue);
+pub(crate) struct PrimOutput(pub FnCall, pub PrimValue, pub Offset);
 
 #[derive(Debug)]
 pub(crate) struct FnCall(pub Fn, pub Vec<Arg>);

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -11,11 +11,14 @@ pub(crate) type ExportedGraph = Vec<ExportedCall>;
 #[derive(Debug)]
 pub(crate) struct ExportedCall {
     fn_name: String,
-    inputs: Vec<ExportedValue>,
-    output: ExportedValue,
+    inputs: Vec<ExportedValueWithSort>,
+    output: ExportedValueWithSort,
     /// Hash of arguments
     input_hash: Hash,
 }
+
+#[derive(Debug, Hash, Clone, PartialEq, Eq)]
+pub(crate) struct ExportedValueWithSort(ExportedValue, String);
 
 /// An argument is either a primitive value or a reference to a eclass
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
@@ -25,7 +28,7 @@ pub(crate) enum ExportedValue {
     /// A container sort, i.e. Vec, Map, Set
     Container {
         name: String,
-        inner: Vec<ExportedValue>,
+        inner: Vec<ExportedValueWithSort>,
         inner_hash: Hash,
     },
     /// A reference to an eclass

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -3,11 +3,11 @@ pub(crate) mod to_graphviz;
 
 use crate::{ast::Expr, util::HashMap};
 
-type EClassID = String;
 type Offset = usize;
+type EClassID = Offset;
 
 /// Exposed graph structure which can be used to print/visualize the state of the e-graph.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct Graph {
     /// All of the primitive values which are outputs of functions
     pub prim_outputs: Vec<PrimOutput>,
@@ -17,7 +17,12 @@ pub(crate) struct Graph {
 
 /// A primitive value which is output from a function.
 #[derive(Debug)]
-pub(crate) struct PrimOutput(pub FnCall, pub PrimValue, pub Offset);
+pub(crate) struct PrimOutput(
+    pub FnCall,
+    pub PrimValue,
+    /// Unique offset, per function, of what call this is. Needed to preserve resulting graph ID's accross time.
+    pub Offset,
+);
 
 #[derive(Debug)]
 pub(crate) struct FnCall(pub Fn, pub Vec<Arg>);

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,8 +1,6 @@
 pub(crate) mod from_egraph;
 pub(crate) mod to_graphviz;
 
-use graphviz_rust::attributes::GraphAttributes;
-
 use crate::{ast::Expr, util::HashMap};
 
 type EClassID = String;

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -24,7 +24,7 @@ pub(crate) struct ExportedValueWithSort(ExportedValue, String);
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
 pub(crate) enum ExportedValue {
     /// A primitive value, i.e. int, float, String
-    Prim (String),
+    Prim(String),
     /// A container sort, i.e. Vec, Map, Set
     Container {
         name: String,

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -1,104 +1,6 @@
 use super::*;
 use graphviz_rust::{attributes as a, dot_structures as d};
 
-fn eclass_cluster_name(eclass_id: &EClassID) -> String {
-    format!("cluster_{}", eclass_id)
-}
-/// The Node ID for the eclass is the first node in the eclass cluster
-fn eclass_node_id(eclass_id: &EClassID) -> d::NodeId {
-    d::NodeId(d::Id::Plain(quote(format!("e_{}_0", eclass_id))), None)
-}
-
-/// An e-class is converted into a cluster with a node for each function call
-fn eclass_to_graphviz(eclass_id: &EClassID, fn_calls: &[FnCall]) -> Vec<d::Stmt> {
-    let mut stmts: Vec<d::Stmt> = fn_calls
-        .iter()
-        .enumerate()
-        .flat_map(|(index, fn_call)| {
-            fn_call
-                .1
-                .iter()
-                .flat_map(|arg| arg.to_graphviz(format!("e_{}_{}", eclass_id, index)))
-                .collect::<Vec<d::Stmt>>()
-        })
-        .collect();
-    stmts.push(d::Stmt::Subgraph(d::Subgraph {
-        id: d::Id::Plain(eclass_cluster_name(eclass_id)),
-        // Nest in empty sub-graph so that we can use rank=same
-        // https://stackoverflow.com/a/55562026/907060
-        stmts: vec![d::Stmt::Subgraph(d::Subgraph {
-            id: d::Id::Plain("".to_string()),
-            stmts: fn_calls
-                .iter()
-                .enumerate()
-                .map(|(index, fn_call)| {
-                    d::Stmt::Node(d::Node::new(
-                        d::NodeId(
-                            d::Id::Plain(quote(format!("e_{}_{}", eclass_id, index))),
-                            None,
-                        ),
-                        label_attributes(fn_call.0.name.clone()),
-                    ))
-                })
-                .collect(),
-        })],
-    }));
-    stmts
-}
-
-impl PrimOutput {
-    /// A primitive output, should be a node with the value and function call
-    fn to_graphviz(&self) -> Vec<d::Stmt> {
-        let mut stmts = Vec::new();
-        let label = format!("{}: {}", self.0 .0.name, self.1.to_string());
-        let res_id = format!("po_{}_{}", self.0 .0.name, self.2);
-        stmts.push(d::Stmt::Node(d::Node::new(
-            d::NodeId(
-                d::Id::Plain(quote(res_id.clone())),
-                None,
-            ),
-            label_attributes(label),
-        )));
-        stmts.extend(self.0 .1.iter().flat_map(|arg| arg.to_graphviz(res_id.clone())));
-        stmts
-    }
-}
-
-impl Arg {
-    /// Returns an edge from the result to the argument
-    /// If it's an e-class, use the e-class-id as the target
-    /// Otherwise, create a node for the primitive value and use that as the target
-    fn to_graphviz(&self, result_id:String) -> Vec<d::Stmt> {
-        let result_node = d::Vertex::N(d::NodeId(d::Id::Plain(quote(result_id.clone())), None));
-        match self {
-            Arg::Prim(p) => {
-                let arg_id = d::NodeId(
-                    d::Id::Plain(quote(format!("p_{}_{}", result_id, p.to_string()))),
-                    None,
-                );
-                vec![
-                    d::Stmt::Node(d::Node::new(
-                        arg_id.clone(),
-                        label_attributes(p.to_string()),
-                    )),
-                    d::Stmt::Edge(d::Edge {
-                        ty: d::EdgeTy::Pair(result_node, d::Vertex::N(arg_id)),
-                        attributes: vec![],
-                    }),
-                ]
-            }
-            Arg::Eq(eclass_id) => {
-                vec![d::Stmt::Edge(d::Edge {
-                    ty: d::EdgeTy::Pair(result_node, d::Vertex::N(eclass_node_id(eclass_id))),
-                    attributes: vec![graphviz_rust::attributes::EdgeAttributes::lhead(
-                        eclass_cluster_name(eclass_id),
-                    )],
-                })]
-            }
-        }
-    }
-}
-
 /// Implement conversion of Graph to graphviz Graph
 impl Graph {
     pub fn to_graphviz(&self) -> d::Graph {
@@ -135,6 +37,101 @@ impl Graph {
     }
 }
 
+/// An e-class is converted into a cluster with a node for each function call
+fn eclass_to_graphviz(eclass_id: &EClassID, fn_calls: &[FnCall]) -> Vec<d::Stmt> {
+    let calls_and_ids: Vec<(&FnCall, String)> = fn_calls
+        .iter()
+        .enumerate()
+        .map(|(index, fn_call)| (fn_call, enode_fn_id(eclass_id, index)))
+        .collect();
+
+    // Create node for all arguments of every function call
+    let mut stmts: Vec<d::Stmt> = calls_and_ids
+        .iter()
+        .flat_map(|(fn_call, id)| {
+            fn_call
+                .1
+                .iter()
+                .flat_map(|arg| arg.to_graphviz(id.clone()))
+                .collect::<Vec<d::Stmt>>()
+        })
+        .collect();
+    // Add a node for each function call in one e-class
+    stmts.push(d::Stmt::Subgraph(d::Subgraph {
+        id: d::Id::Plain(cluster_name(eclass_id)),
+        // Nest in empty sub-graph so that we can use rank=same
+        // https://stackoverflow.com/a/55562026/907060
+        stmts: vec![d::Stmt::Subgraph(d::Subgraph {
+            id: d::Id::Plain("".to_string()),
+            stmts: calls_and_ids
+                .iter()
+                .map(|(fn_call, id)| {
+                    d::Stmt::Node(d::Node::new(
+                        d::NodeId(d::Id::Plain(quote(id.clone())), None),
+                        label_attributes(fn_call.0.name.clone()),
+                    ))
+                })
+                .collect(),
+        })],
+    }));
+    stmts
+}
+
+impl PrimOutput {
+    /// A primitive output, should be a node with the value and function call
+    fn to_graphviz(&self) -> Vec<d::Stmt> {
+        let mut stmts = Vec::new();
+        let label = format!("{}: {}", self.0 .0.name, self.1.to_string());
+        let res_id = prim_output_id(self);
+        stmts.push(d::Stmt::Node(d::Node::new(
+            d::NodeId(d::Id::Plain(quote(res_id.clone())), None),
+            label_attributes(label),
+        )));
+        stmts.extend(
+            self.0
+                 .1
+                .iter()
+                .flat_map(|arg| arg.to_graphviz(res_id.clone())),
+        );
+        stmts
+    }
+}
+
+impl Arg {
+    /// Returns an edge from the result to the argument
+    /// If it's an e-class, use the e-class-id as the target
+    /// Otherwise, create a node for the primitive value and use that as the target
+    fn to_graphviz(&self, result_id: String) -> Vec<d::Stmt> {
+        let result_node = d::Vertex::N(d::NodeId(d::Id::Plain(quote(result_id.clone())), None));
+        match self {
+            Arg::Prim(p) => {
+                let arg_id = d::NodeId(d::Id::Plain(quote(prim_value_id(result_id, p))), None);
+                vec![
+                    d::Stmt::Node(d::Node::new(
+                        arg_id.clone(),
+                        label_attributes(p.to_string()),
+                    )),
+                    d::Stmt::Edge(d::Edge {
+                        ty: d::EdgeTy::Pair(result_node, d::Vertex::N(arg_id)),
+                        attributes: vec![],
+                    }),
+                ]
+            }
+            Arg::Eq(id) => {
+                vec![d::Stmt::Edge(d::Edge {
+                    ty: d::EdgeTy::Pair(
+                        result_node,
+                        d::Vertex::N(d::NodeId(d::Id::Plain(quote(enode_fn_id(id, 0))), None)),
+                    ),
+                    attributes: vec![graphviz_rust::attributes::EdgeAttributes::lhead(
+                        cluster_name(id),
+                    )],
+                })]
+            }
+        }
+    }
+}
+
 fn label_attributes(label: String) -> Vec<d::Attribute> {
     vec![graphviz_rust::attributes::NodeAttributes::label(quote(
         label,
@@ -142,4 +139,20 @@ fn label_attributes(label: String) -> Vec<d::Attribute> {
 }
 fn quote(s: String) -> String {
     format!("{:?}", s)
+}
+
+fn cluster_name(canonical_id: &EClassID) -> String {
+    format!("cluster_{}", canonical_id)
+}
+
+fn enode_fn_id(eclass_id: &EClassID, index: usize) -> String {
+    format!("{}_{}", eclass_id, index)
+}
+
+fn prim_output_id(prim_output: &PrimOutput) -> String {
+    format!("{}_{}", prim_output.0 .0.name, prim_output.2)
+}
+
+fn prim_value_id(parent_name: String, value: &PrimValue) -> String {
+    format!("{}_{}", parent_name, value.to_string())
 }

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -12,242 +12,213 @@ use graphviz_rust::{
     },
 };
 
+/// Mapping from e-class id to the ID of the node representing particular function call
+type EClasses = HashMap<EClassID, VecDeque<String>>;
+/// Mapping from subgraph id to the sort, whether it's an e-class, and the nodes in the subgraph
+type Nodes = HashMap<String, (String, bool, Vec<Node>)>;
+type Edges = Vec<Edge>;
+
+/// Set of all sorts
+type Sorts = HashSet<String>;
+// Mapping of sort name to graphviz color
+type SortColors = HashMap<String, usize>;
+
 /// Creates a graphviz graph from an exported graph
 ///
 /// Each function call is a node, and each edge is an argument to the function
-/// e-classes are grouped in clusters
-/// values are also nodes, and are grouped together in a cluster with functions that return that value.
-/// (except for unit values which are not shown as nodes and each exist in their own cluster)
+/// E-classes are grouped in clusters
+/// Functions which return primitive values are shown as a cluster with two items, the function node and the value node.
 ///
 /// Each cluster is also labeled with the sort of the values it contains and colored by the sort
-pub(crate) fn to_graphviz(g: ExportedGraph) -> Graph {
-    GraphExporter::new(g).into_graphviz()
+pub(crate) fn to_graphviz(g: &ExportedGraph) -> Graph {
+    let eclasses = build_eclasses(g);
+    let (nodes, edges, sorts) = build_nodes_edges(g, eclasses);
+    let colors = build_colors(&sorts);
+    build_graph(nodes, edges, &colors)
 }
 
-#[derive(Default)]
-struct GraphExporter {
-    statements: Vec<Stmt>,
-    // Use VecDeque so we can rotate efficiently
-    e_class_id_to_node_ids: HashMap<usize, VecDeque<String>>,
-    // Map from subgraph id to sort and map of node id to label
-    subgraph_to_node_to_label: HashMap<String, (String, HashMap<String, String>)>,
-    // Nodes to process and add
-    values_to_add: VecDeque<ExportedValueWithSort>,
-    // Nodes already added to the values_to_add queue
-    added_value: HashSet<ExportedValueWithSort>,
-    // Unique list of sorts, to be used for colors
-    sorts: HashSet<String>,
+/// Splits the calls into those returning primitive values and those returning e-classes, grouping the e-classes by id
+fn build_eclasses(g: &ExportedGraph) -> EClasses {
+    let mut eclasses: EClasses = HashMap::default();
+    for call in g {
+        if let ExportedValue::EClass(id) = call.output.0 {
+            eclasses
+                .entry(id)
+                .or_default()
+                .push_front(call.function_node_id());
+        }
+    }
+    eclasses
 }
 
-impl GraphExporter {
-    fn new(g: ExportedGraph) -> Self {
-        // let mut exporter = Self {  ...Self::default()};
-        let mut exporter = Self {
-            statements: vec![
-                // Set to compound so we can have edge to clusters
-                stmt!(GraphAttributes::compound(true)),
-                // Set default sub-graph rank to be same so that all nodes in e-class are on same level
-                stmt!(SubgraphAttributes::rank(rank::same)),
-                stmt!(GraphAttributes::fontname("helvetica".to_string())),
-                stmt!(GraphAttributes::fontsize(9.0)),
-                stmt!(GraphAttributes::margin(3.0)),
-                stmt!(GraphAttributes::nodesep(0.0)),
-                stmt!(GraphAttributes::colorscheme("set312".to_string())),
-                stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
-                stmt!(GA::Node(vec![
-                    NodeAttributes::shape(shape::none),
-                    NodeAttributes::margin(0.0)
-                ])),
-            ],
-            ..Self::default()
+fn build_nodes_edges(calls: &ExportedGraph, eclasses: EClasses) -> (Nodes, Edges, Sorts) {
+    let mut builder = SubgraphBuilder::new(eclasses);
+    for call in calls {
+        builder.add_call(call);
+    }
+    (builder.nodes, builder.edges, builder.sorts)
+}
+
+struct SubgraphBuilder {
+    eclasses: EClasses,
+    nodes: Nodes,
+    edges: Edges,
+    sorts: Sorts,
+}
+
+impl SubgraphBuilder {
+    fn new(eclasses: EClasses) -> Self {
+        Self {
+            eclasses,
+            nodes: Nodes::default(),
+            sorts: Sorts::default(),
+            edges: Edges::default(),
+        }
+    }
+
+    fn add_call(&mut self, call: &ExportedCall) {
+        let sort: &str = &call.output.1;
+        self.sorts.insert(sort.to_string());
+
+        let function_node_id = call.function_node_id();
+
+        let mut nodes = vec![self.add_node(&function_node_id, &call.fn_name, &call.inputs)];
+        match &call.output.0 {
+            ExportedValue::EClass(eclass_id) => {
+                let subgraph_id = format!("cluster_{}", eclass_id);
+                let subgraph_entry = self.nodes.entry(subgraph_id).or_default();
+                subgraph_entry.1 = true;
+                subgraph_entry.0 = sort.to_string();
+                subgraph_entry.2.extend(nodes);
+            }
+            ExportedValue::Prim(name, inner, _) => {
+                let subgraph_id = format!("cluster_{}", function_node_id);
+                let value_node_id = format!("{}_value", function_node_id);
+                nodes.push(self.add_node(&value_node_id, name, inner));
+                self.add_value_subgraph(&subgraph_id, sort, nodes);
+            }
         };
-        // Store what nodes are in each e-class, so we can create edges to them
-        for call in g.iter() {
-            if let ExportedValue::EClass(id) = call.output.0 {
-                let node_id = format!("{}_{}", call.fn_name, call.input_hash);
-                exporter
-                    .e_class_id_to_node_ids
-                    .entry(id)
-                    .or_default()
-                    .push_back(node_id);
-            }
-        }
-
-        // Create subgraphs and nodes
-        for ExportedCall {
-            fn_name,
-            inputs,
-            output,
-            input_hash,
-        } in g
-        {
-            // Add function node
-            let fn_id = format!("{}_{}", fn_name, input_hash);
-
-            exporter.add_node(&output, fn_id.clone(), fn_name, inputs.len());
-            exporter.add_value(&output);
-            // Add edges from function node to input nodes
-            for (i, input) in inputs.into_iter().enumerate() {
-                exporter.add_edge(fn_id.clone(), i, &input);
-                exporter.add_value(&input);
-            }
-        }
-        exporter
     }
 
-    fn into_graphviz(mut self) -> Graph {
-        // Add nodes for primitive values. Skip e-classes, since these appear as subgraphs
-        while let Some(value) = self.values_to_add.pop_front() {
-            match &value.0 {
-                ExportedValue::EClass(_) => {}
-                ExportedValue::Prim(p) => self.add_node(&value, prim_id(p), p.into(), 0),
-                ExportedValue::Container {
-                    name,
-                    inner,
-                    inner_hash,
-                } => {
-                    let value_id = container_id(name, *inner_hash);
-                    self.add_node(&value, value_id.clone(), name.to_string(), inner.len());
-                    for (i, inner_value) in inner.iter().enumerate() {
-                        self.add_value(inner_value);
-                        self.add_edge(value_id.clone(), i, inner_value);
-                    }
-                }
-            }
-        }
-        // Create a mapping from sort to the color index they are
-        let sort_color = self
-            .sorts
-            .iter()
-            .enumerate()
-            .map(|(i, s)| (s.clone(), i % 12 + 1))
-            .collect::<HashMap<_, _>>();
-
-        // Export each subgraph to nodes
-        for (subgraph_id, (sort, node_id_to_label)) in self.subgraph_to_node_to_label {
-            let subgraph_stmts = node_id_to_label
-                .into_iter()
-                .map(|(node_id, label)| {
-                    let node_id = quote(node_id);
-                    stmt!(node!(node_id;NodeAttributes::label(label)))
-                })
-                .collect();
-            let subgraph_style = if subgraph_id.starts_with("\"cluster_eclass_") {
-                "dashed,rounded,filled".to_string()
-            } else {
-                "dotted,rounded,filled".to_string()
-            };
-            let color = sort_color[&sort];
-            // Nest in empty sub-graph so that we can use rank=same
-            // https://stackoverflow.com/a/55562026/907060
-            self.statements.push(stmt!(subgraph!(subgraph_id;
-                NodeAttributes::label(subgraph_html_label(sort)),
-                attr!("fillcolor", color),
-                GA::Graph(vec![GraphAttributes::style(quote(subgraph_style))]),
-                subgraph!("", subgraph_stmts)
-            )));
-        }
-        graph!(di id!(), self.statements)
-    }
-
-    fn get_enode_id(&mut self, e_class_id: usize) -> String {
-        let node_ids = self.e_class_id_to_node_ids.entry(e_class_id).or_default();
-        // Lookup the first node id for this eclass id
-        let node_id = node_ids.front().unwrap().clone();
-        // Rotate the node ids so that we can point to different ones each time for better graph layout
-        node_ids.rotate_left(1);
-        node_id
-    }
-
-    fn add_value(&mut self, value: &ExportedValueWithSort) {
-        // Don't add nodes for unit values, since they only show up in return types and is redundant with sort
-        if !self.added_value.contains(value) && value.1 != "Unit" {
-            self.values_to_add.push_back(value.clone());
-            self.added_value.insert(value.clone());
+    /// Adds a node with some children
+    fn add_node(&mut self, node_id: &str, label: &str, children: &[ExportedValueWithSort]) -> Node {
+        let html_label = html_label(label, children.len());
+        let quoted_node_id = quote(node_id);
+        for (i, value) in children.iter().enumerate() {
+            let source = node_id!(quote(node_id), port!(id!(port_id(i))));
             self.sorts.insert(value.1.clone());
+            let (child_node_id, child_subgraph_id) = match &value.0 {
+                // Functions should point to one of the function nodes of the e-class.
+                // We rotate between them in a round robin, to balance where the edgs point to
+                ExportedValue::EClass(e_class_id) => {
+                    let node_ids = self.eclasses.entry(*e_class_id).or_default();
+                    // Lookup the first node id for this eclass id
+                    let node_id = node_ids.front().unwrap().clone();
+                    // Rotate the node ids so that we can point to different ones each time for better graph layout
+                    node_ids.rotate_left(1);
+                    (node_id, format!("cluster_{}", e_class_id))
+                }
+                // For primitives, we make a new node for each input, based on the function name and the index of the input
+                ExportedValue::Prim(name, inner, _) => {
+                    let child_node_id = format!("{}_{}", node_id, i);
+                    let child_subgraph_id = format!("cluster_{}", child_node_id);
+                    let subgraph_node = self.add_node(&child_node_id, name, inner);
+                    self.add_value_subgraph(&child_subgraph_id, &value.1, vec![subgraph_node]);
+                    (child_node_id, child_subgraph_id)
+                }
+            };
+            let target = node_id!(quote(&child_node_id));
+            self.edges
+                .push(edge!(source => target; EdgeAttributes::lhead(child_subgraph_id)));
         }
+        node!(quoted_node_id;NodeAttributes::label(html_label))
     }
 
-    fn add_node(
-        &mut self,
-        subgraph_value_and_sort: &ExportedValueWithSort,
-        node_id: String,
-        name: String,
-        n_args: usize,
-    ) {
-        let entry = self
-            .subgraph_to_node_to_label
-            .entry(subgraph_id(subgraph_value_and_sort, node_id.clone()))
-            .or_default();
-        entry.0 = subgraph_value_and_sort.1.to_string();
-        self.sorts.insert(entry.0.to_string());
-        entry.1.insert(node_id, html_label(name, n_args));
-    }
-
-    fn gen_value_id(&mut self, value: &ExportedValue) -> String {
-        match value {
-            ExportedValue::EClass(id) => self.get_enode_id(*id),
-            ExportedValue::Prim(p) => prim_id(p),
-            ExportedValue::Container {
-                name,
-                inner: _,
-                inner_hash,
-            } => container_id(name, *inner_hash),
+    /// Adds a new subgraph, panics if it already exists. Used for values
+    fn add_value_subgraph(&mut self, subgraph_id: &str, sort: &str, nodes: Vec<Node>) {
+        let is_eclass = false;
+        if self.nodes.contains_key(subgraph_id) {
+            panic!("Subgraph already exists")
         }
-    }
-
-    fn add_edge(
-        &mut self,
-        source_node_id: String,
-        source_index: usize,
-        target_value: &ExportedValueWithSort,
-    ) {
-        let source = node_id!(quote(source_node_id.clone()), port!(id!(port_id(source_index))));
-        let target = node_id!(quote(self.gen_value_id(&target_value.0)));
-        let target_subgraph_id = subgraph_id(
-            target_value,
-            format!("from_{}_{}", source_node_id, source_index),
+        self.nodes.insert(
+            subgraph_id.to_string(),
+            (sort.to_string(), is_eclass, nodes),
         );
-        let edge = edge!(source => target; EdgeAttributes::lhead(target_subgraph_id));
-        self.statements.push(stmt!(edge));
     }
 }
 
-fn subgraph_id(exported_value: &ExportedValueWithSort, path: String) -> String {
-    quote(if exported_value.1 == "Unit" {
-        format!("cluster_{}", path)
-    } else {
-        match &exported_value.0 {
-            ExportedValue::EClass(eclass_id) => format!("cluster_eclass_{}", eclass_id),
-            ExportedValue::Prim(p) => format!("cluster_prim_{}", p),
-            ExportedValue::Container {
-                name,
-                inner: _,
-                inner_hash,
-            } => format!("cluster_container_{}_{}", name, inner_hash),
-        }
-    })
+fn build_colors(sorts: &Sorts) -> SortColors {
+    sorts
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (s.clone(), i % 12 + 1))
+        .collect::<HashMap<_, _>>()
 }
 
-fn prim_id(prim: &str) -> String {
-    format!("prim_{}", prim)
+fn build_graph(nodes: Nodes, edges: Edges, sort_colors: &SortColors) -> Graph {
+    let mut stmts = configuration_statements();
+    for (subgraph_id, (sort, is_eclass, nodes)) in nodes {
+        let subgraph_style = if is_eclass {
+            "dashed,rounded,filled"
+        } else {
+            "dotted,rounded,filled"
+        };
+        let color = sort_colors[&sort];
+        // Nest in empty sub-graph so that we can use rank=same
+        // https://stackoverflow.com/a/55562026/907060
+        let quoted_subgraph_id = quote(&subgraph_id);
+        let subgraph_stmts = nodes.into_iter().map(|s| stmt!(s)).collect();
+        let s = stmt!(subgraph!(quoted_subgraph_id;
+            NodeAttributes::label(subgraph_html_label(&sort)),
+            attr!("fillcolor", color),
+            GA::Graph(vec![GraphAttributes::style(quote(subgraph_style))]),
+            subgraph!("", subgraph_stmts)
+        ));
+        stmts.push(s);
+    }
+    stmts.extend(edges.into_iter().map(|s| stmt!(s)));
+    graph!(di id!(), stmts)
 }
 
-fn container_id(name: &str, inner_hash: Hash) -> String {
-    format!("container_{}_{}", name, inner_hash)
+fn configuration_statements() -> Vec<Stmt> {
+    vec![
+        // Set to compound so we can have edge to clusters
+        stmt!(GraphAttributes::compound(true)),
+        // Set default sub-graph rank to be same so that all nodes in e-class are on same level
+        stmt!(SubgraphAttributes::rank(rank::same)),
+        stmt!(GraphAttributes::fontname("helvetica".to_string())),
+        stmt!(GraphAttributes::fontsize(9.0)),
+        stmt!(GraphAttributes::margin(3.0)),
+        stmt!(GraphAttributes::nodesep(0.0)),
+        stmt!(GraphAttributes::colorscheme("set312".to_string())),
+        stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
+        stmt!(GA::Node(vec![
+            NodeAttributes::shape(shape::none),
+            NodeAttributes::margin(0.0)
+        ])),
+        // Draw edges first, so that they are behind nodes
+        stmt!(GraphAttributes::outputorder(outputorder::edgesfirst)),
+    ]
 }
 
-/// Adds double quotes and
-fn quote(s: String) -> String {
+impl ExportedCall {
+    /// The ID of the graphviz node for the function call
+    fn function_node_id(&self) -> String {
+        format!("{}_{}", self.fn_name, self.input_hash)
+    }
+}
+
+/// Adds double quotes and escapes the quotes in the string
+fn quote(s: &str) -> String {
     format!("{:?}", s)
 }
 
 /// Returns an html label for the node with the function name and ports for each argumetn
-fn html_label(label: String, n_args: usize) -> String {
+fn html_label(label: &str, n_args: usize) -> String {
     format!(
         "<<TABLE BGCOLOR=\"white\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" style=\"rounded\"><tr><td CELLPADDING=\"4\" WIDTH=\"30\" HEIGHT=\"30\" colspan=\"{}\">{}</td></tr>{}</TABLE>>",
         n_args,
-        Escape(&label),
+        Escape(label),
         (if n_args == 0 {
             "".to_string()
         } else {
@@ -261,8 +232,8 @@ fn html_label(label: String, n_args: usize) -> String {
         })
     )
 }
-fn subgraph_html_label(label: String) -> String {
-    format!("<<TABLE CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" border=\"0\"><tr><td><i>{}</i></td></tr></TABLE>>", Escape(&label))
+fn subgraph_html_label(label: &str) -> String {
+    format!("<<TABLE CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" border=\"0\"><tr><td><i>{}</i></td></tr></TABLE>>", Escape(label))
 }
 
 fn port_id(i: usize) -> String {

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -190,7 +190,9 @@ fn build_graph(nodes: Nodes, edges: Edges, sort_colors: &SortColors) -> Graph {
             for (subgraph_id, nodes) in subgraphs {
                 let quoted_subgraph_id = quote(&subgraph_id);
                 let subgraph_stmts = nodes.into_iter().map(|s| stmt!(s)).collect();
-                let s = stmt!(subgraph!("";
+                // Outer subgraph cluster must have name, otherwise we get "Two clusters named" error
+                let outer_subgraph_id = quote(&format!("outer_{}", subgraph_id));
+                let s = stmt!(subgraph!(outer_subgraph_id;
                     // Disable label for now, to reduce size
                     // NodeAttributes::label(subgraph_html_label(&sort)),
 

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -218,6 +218,7 @@ fn configuration_statements() -> Vec<Stmt> {
         ])),
         // Draw edges first, so that they are behind nodes
         stmt!(GraphAttributes::outputorder(outputorder::edgesfirst)),
+        stmt!(GraphAttributes::concentrate(true)),
     ]
 }
 

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -110,8 +110,7 @@ impl SubgraphBuilder {
     /// Adds a node with some children
     fn add_node(&mut self, node_id: &str, label: &str, children: &[ExportedValueWithSort]) -> Node {
         let quoted_node_id = quote(node_id);
-        let mut i = 0;
-        for value in children {
+        for (i, value) in children.iter().enumerate() {
             let source = node_id!(quote(node_id), port!(id!(port_id(i))));
             self.sorts.insert(value.1.clone());
             let (child_node_id, child_subgraph_id) = match &value.0 {
@@ -142,9 +141,8 @@ impl SubgraphBuilder {
             let target = node_id!(quote(&child_node_id));
             self.edges
                 .push(edge!(source => target; EdgeAttributes::lhead(quote(&child_subgraph_id))));
-            i += 1;
         }
-        let html_label = html_label(label, i);
+        let html_label = html_label(label, children.len());
         node!(quoted_node_id;NodeAttributes::label(html_label))
     }
 

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -223,7 +223,7 @@ fn configuration_statements() -> Vec<Stmt> {
         stmt!(GraphAttributes::fontname("helvetica".to_string())),
         stmt!(GraphAttributes::fontsize(9.0)),
         stmt!(GraphAttributes::margin(3.0)),
-        stmt!(GraphAttributes::nodesep(0.05)),
+        stmt!(GraphAttributes::nodesep(0.0)),
         stmt!(GraphAttributes::ranksep(0.6)),
         stmt!(GraphAttributes::colorscheme("set312".to_string())),
         stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -214,7 +214,7 @@ fn configuration_statements() -> Vec<Stmt> {
         stmt!(GraphAttributes::fontname("helvetica".to_string())),
         stmt!(GraphAttributes::fontsize(9.0)),
         stmt!(GraphAttributes::margin(3.0)),
-        stmt!(GraphAttributes::nodesep(0.0)),
+        stmt!(GraphAttributes::nodesep(0.05)),
         stmt!(GraphAttributes::colorscheme("set312".to_string())),
         stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
         stmt!(GA::Node(vec![

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -214,7 +214,8 @@ fn configuration_statements() -> Vec<Stmt> {
         stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
         stmt!(GA::Node(vec![
             NodeAttributes::shape(shape::none),
-            NodeAttributes::margin(0.0)
+            NodeAttributes::margin(0.0),
+            NodeAttributes::fontname("helvetica".to_string())
         ])),
         // Draw edges first, so that they are behind nodes
         stmt!(GraphAttributes::outputorder(outputorder::edgesfirst)),

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -223,7 +223,7 @@ fn configuration_statements() -> Vec<Stmt> {
         stmt!(GraphAttributes::fontname("helvetica".to_string())),
         stmt!(GraphAttributes::fontsize(9.0)),
         stmt!(GraphAttributes::margin(3.0)),
-        stmt!(GraphAttributes::nodesep(0.0)),
+        stmt!(GraphAttributes::nodesep(0.05)),
         stmt!(GraphAttributes::ranksep(0.6)),
         stmt!(GraphAttributes::colorscheme("set312".to_string())),
         stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -1,26 +1,28 @@
 use super::*;
-use graphviz_rust::{attributes as a, dot_structures as d};
+use graphviz_rust::{
+    attributes::*,
+    dot_generator::*,
+    dot_structures::{
+        Edge, EdgeTy, Graph, GraphAttributes as GA, Id, Node, NodeId, Stmt, Subgraph, Vertex,
+    },
+};
 
 /// Implement conversion of Graph to graphviz Graph
 impl ExportedGraph {
-    pub fn to_graphviz(&self) -> d::Graph {
+    pub fn to_graphviz(&self) -> Graph {
         let mut statements = vec![
             // Set to compound so we can have edge to clusters
-            d::Stmt::Attribute(a::GraphAttributes::compound(true)),
+            stmt!(GraphAttributes::compound(true)),
             // Set default sub-graph rank to be same so that all nodes in e-class are on same level
-            d::Stmt::Attribute(a::SubgraphAttributes::rank(a::rank::same)),
-            d::Stmt::Attribute(a::GraphAttributes::fontname("helvetica".to_string())),
-            d::Stmt::Attribute(a::GraphAttributes::style(quote(
-                "rounded,dashed".to_string(),
-            ))),
-            d::Stmt::GAttribute(d::GraphAttributes::Edge(vec![
-                a::EdgeAttributes::arrowsize(0.5),
-            ])),
-            d::Stmt::GAttribute(d::GraphAttributes::Node(vec![
-                a::NodeAttributes::shape(a::shape::box_),
-                a::NodeAttributes::style("rounded".to_string()),
-                a::NodeAttributes::width(0.4),
-                a::NodeAttributes::height(0.4),
+            stmt!(SubgraphAttributes::rank(rank::same)),
+            stmt!(GraphAttributes::fontname("helvetica".to_string())),
+            stmt!(GraphAttributes::style("rounded".to_string())),
+            stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
+            stmt!(GA::Node(vec![
+                NodeAttributes::shape(shape::box_),
+                NodeAttributes::style("rounded".to_string()),
+                NodeAttributes::width(0.4),
+                NodeAttributes::height(0.4),
             ])),
         ];
         statements.extend(
@@ -33,62 +35,45 @@ impl ExportedGraph {
                 eclass_to_graphviz(eclass_id, eclass, &self.eclasses)
             }),
         );
-        d::Graph::DiGraph {
-            id: d::Id::Plain("egg_smol".to_string()),
-            strict: false,
-            stmts: statements,
-        }
+        graph!(di id!(), statements)
     }
 }
 
 /// An e-class is converted into a cluster with a node for each function call
-fn eclass_to_graphviz(
-    eclass_id: &EClassID,
-    fn_calls: &[FnCall],
-    eclasses: &EClasses,
-) -> Vec<d::Stmt> {
+fn eclass_to_graphviz(eclass_id: &EClassID, fn_calls: &[FnCall], eclasses: &EClasses) -> Vec<Stmt> {
     // Create node for all arguments of every function call
-    let mut stmts: Vec<d::Stmt> = fn_calls
+    let mut stmts: Vec<Stmt> = fn_calls
         .iter()
         .flat_map(|fn_call| {
             fn_call
                 .1
                 .iter()
                 .flat_map(|arg| arg.to_graphviz(fn_call_id(fn_call), eclasses))
-                .collect::<Vec<d::Stmt>>()
+                .collect::<Vec<Stmt>>()
         })
         .collect();
     // Add a node for each function call in one e-class
-    stmts.push(d::Stmt::Subgraph(d::Subgraph {
-        id: d::Id::Plain(cluster_name(eclass_id)),
-        // Nest in empty sub-graph so that we can use rank=same
-        // https://stackoverflow.com/a/55562026/907060
-        stmts: vec![d::Stmt::Subgraph(d::Subgraph {
-            id: d::Id::Plain("".to_string()),
-            stmts: fn_calls
-                .iter()
-                .map(|fn_call| {
-                    d::Stmt::Node(d::Node::new(
-                        d::NodeId(d::Id::Plain(quote(fn_call_id(fn_call))), None),
-                        label_attributes(fn_call.0.name.clone()),
-                    ))
-                })
-                .collect(),
-        })],
-    }));
+    let subgraph_stmts = fn_calls
+        .iter()
+        .map(|fn_call| {
+            let id = fn_call_id(fn_call);
+            stmt!(node!(esc id; NodeAttributes::label(quote(fn_call.0.name.clone()))))
+        })
+        .collect::<Vec<Stmt>>();
+    let cluster_id = cluster_name(eclass_id);
+    // Nest in empty sub-graph so that we can use rank=same
+    // https://stackoverflow.com/a/55562026/907060
+    stmts.push(stmt!(subgraph!(cluster_id; subgraph!("", subgraph_stmts))));
     stmts
 }
 
 impl PrimOutput {
     /// A primitive output, should be a node with the value and function call
-    fn to_graphviz(&self, eclasses: &EClasses) -> Vec<d::Stmt> {
-        let mut stmts = Vec::new();
+    fn to_graphviz(&self, eclasses: &EClasses) -> Vec<Stmt> {
         let label = format!("{}: {}", self.0 .0.name, self.1.to_string());
         let res_id = fn_call_id(&self.0);
-        stmts.push(d::Stmt::Node(d::Node::new(
-            d::NodeId(d::Id::Plain(quote(res_id.clone())), None),
-            label_attributes(label),
-        )));
+        let node_id = quote(res_id.clone());
+        let mut stmts = vec![stmt!(node!(node_id; NodeAttributes::label(quote(label))))];
         stmts.extend(
             self.0
                  .1
@@ -103,45 +88,26 @@ impl Arg {
     /// Returns an edge from the result to the argument
     /// If it's an e-class, use the e-class-id as the target
     /// Otherwise, create a node for the primitive value and use that as the target
-    fn to_graphviz(&self, result_id: String, eclasses: &EClasses) -> Vec<d::Stmt> {
-        let result_node = d::Vertex::N(d::NodeId(d::Id::Plain(quote(result_id.clone())), None));
+    fn to_graphviz(&self, result_id: String, eclasses: &EClasses) -> Vec<Stmt> {
+        let result_name = quote(result_id.clone());
         match self {
             Arg::Prim(p) => {
-                let arg_id = d::NodeId(d::Id::Plain(quote(prim_value_id(result_id, p))), None);
+                let arg_id = quote(prim_value_id(result_id, p));
                 vec![
-                    d::Stmt::Node(d::Node::new(
-                        arg_id.clone(),
-                        label_attributes(p.to_string()),
-                    )),
-                    d::Stmt::Edge(d::Edge {
-                        ty: d::EdgeTy::Pair(result_node, d::Vertex::N(arg_id)),
-                        attributes: vec![],
-                    }),
+                    stmt!(node!(arg_id; NodeAttributes::label(quote(p.to_string())))),
+                    stmt!(edge!(node_id!(result_name) => node_id!(arg_id))),
                 ]
             }
             Arg::Eq(id) => {
-                vec![d::Stmt::Edge(d::Edge {
-                    ty: d::EdgeTy::Pair(
-                        result_node,
-                        d::Vertex::N(d::NodeId(
-                            d::Id::Plain(quote(enode_fn_id(id, eclasses))),
-                            None,
-                        )),
-                    ),
-                    attributes: vec![graphviz_rust::attributes::EdgeAttributes::lhead(
-                        cluster_name(id),
-                    )],
-                })]
+                vec![stmt!(edge!(
+                    node_id!(result_name) => node_id!(quote(enode_fn_id(id, eclasses)));
+                    EdgeAttributes::lhead(cluster_name(id))
+                ))]
             }
         }
     }
 }
 
-fn label_attributes(label: String) -> Vec<d::Attribute> {
-    vec![graphviz_rust::attributes::NodeAttributes::label(quote(
-        label,
-    ))]
-}
 fn quote(s: String) -> String {
     format!("{:?}", s)
 }

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -172,7 +172,8 @@ fn build_graph(nodes: Nodes, edges: Edges, sort_colors: &SortColors) -> Graph {
         let quoted_subgraph_id = quote(&subgraph_id);
         let subgraph_stmts = nodes.into_iter().map(|s| stmt!(s)).collect();
         let s = stmt!(subgraph!(quoted_subgraph_id;
-            NodeAttributes::label(subgraph_html_label(&sort)),
+            // Disable label for now, to reduce size
+            // NodeAttributes::label(subgraph_html_label(&sort)),
             attr!("fillcolor", color),
             GA::Graph(vec![GraphAttributes::style(quote(subgraph_style))]),
             subgraph!("", subgraph_stmts)
@@ -235,9 +236,9 @@ fn html_label(label: &str, n_args: usize) -> String {
         })
     )
 }
-fn subgraph_html_label(label: &str) -> String {
-    format!("<<TABLE CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" border=\"0\"><tr><td><i>{}</i></td></tr></TABLE>>", Escape(label))
-}
+// fn subgraph_html_label(label: &str) -> String {
+//     format!("<<TABLE CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" border=\"0\"><tr><td><i>{}</i></td></tr></TABLE>>", Escape(label))
+// }
 
 fn port_id(i: usize) -> String {
     format!("i{}", i)

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -1,5 +1,5 @@
 use super::*;
-use graphviz_rust::{dot_structures as d, attributes as a};
+use graphviz_rust::{attributes as a, dot_structures as d};
 
 fn eclass_cluster_name(eclass_id: &EClassID) -> String {
     format!("cluster_{}", eclass_id)
@@ -114,8 +114,12 @@ impl Graph {
         let mut statements = vec![
             d::Stmt::Attribute(a::GraphAttributes::compound(true)),
             d::Stmt::Attribute(a::GraphAttributes::fontname("helvetica".to_string())),
-            d::Stmt::Attribute(a::GraphAttributes::style(quote("rounded,dashed".to_string()))),
-            d::Stmt::GAttribute(d::GraphAttributes::Edge(vec![a::EdgeAttributes::arrowsize(0.5)])),
+            d::Stmt::Attribute(a::GraphAttributes::style(quote(
+                "rounded,dashed".to_string(),
+            ))),
+            d::Stmt::GAttribute(d::GraphAttributes::Edge(vec![
+                a::EdgeAttributes::arrowsize(0.5),
+            ])),
             d::Stmt::GAttribute(d::GraphAttributes::Node(vec![
                 a::NodeAttributes::shape(a::shape::box_),
                 a::NodeAttributes::style("rounded".to_string()),

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -218,6 +218,7 @@ fn configuration_statements() -> Vec<Stmt> {
         stmt!(GraphAttributes::fontsize(9.0)),
         stmt!(GraphAttributes::margin(3.0)),
         stmt!(GraphAttributes::nodesep(0.05)),
+        stmt!(GraphAttributes::ranksep(0.6)),
         stmt!(GraphAttributes::colorscheme("set312".to_string())),
         stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
         stmt!(GA::Node(vec![

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -1,144 +1,176 @@
+use crate::util::HashMap;
+use std::collections::VecDeque;
+
 use super::*;
 use graphviz_rust::{
     attributes::*,
     dot_generator::*,
     dot_structures::{
-        Attribute, Edge, EdgeTy, Graph, GraphAttributes as GA, Id, Node, NodeId, Port, Stmt,
-        Subgraph, Vertex,
+        Edge, EdgeTy, Graph, GraphAttributes as GA, Id, Node, NodeId, Port, Stmt, Subgraph, Vertex,
     },
 };
 
 /// Implement conversion of Graph to graphviz Graph
-impl ExportedGraph {
-    pub fn to_graphviz(&self) -> Graph {
-        let mut statements = vec![
-            // Set to compound so we can have edge to clusters
-            stmt!(GraphAttributes::compound(true)),
-            // Set default sub-graph rank to be same so that all nodes in e-class are on same level
-            stmt!(SubgraphAttributes::rank(rank::same)),
-            stmt!(GraphAttributes::fontname("helvetica".to_string())),
-            stmt!(GraphAttributes::style(quote("rounded,dashed".to_string()))),
-            stmt!(GraphAttributes::margin(3.0)),
-            stmt!(GraphAttributes::nodesep(0.0)),
-            stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
-            stmt!(GA::Node(vec![
-                NodeAttributes::shape(shape::none),
-                NodeAttributes::margin(0.0)
-            ])),
-        ];
-        statements.extend(
-            self.prim_outputs
-                .iter()
-                .flat_map(|po| po.to_graphviz(&self.eclasses)),
-        );
-        statements.extend(
-            self.eclasses.iter().flat_map(|(eclass_id, eclass)| {
-                eclass_to_graphviz(eclass_id, eclass, &self.eclasses)
-            }),
-        );
-        graph!(strict di id!(), statements)
-    }
-}
+/// Places all equivalent nodes in the same cluster
+/// For e-nodes these are are all in the same e-class
+/// For
+pub(crate) fn to_graphviz(g: ExportedGraph) -> Graph {
+    let mut statements = vec![
+        // Set to compound so we can have edge to clusters
+        stmt!(GraphAttributes::compound(true)),
+        // Set default sub-graph rank to be same so that all nodes in e-class are on same level
+        stmt!(SubgraphAttributes::rank(rank::same)),
+        stmt!(GraphAttributes::fontname("helvetica".to_string())),
+        stmt!(GraphAttributes::style(quote("rounded,dashed".to_string()))),
+        stmt!(GraphAttributes::margin(3.0)),
+        stmt!(GraphAttributes::nodesep(0.0)),
+        stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
+        stmt!(GA::Node(vec![
+            NodeAttributes::shape(shape::none),
+            NodeAttributes::margin(0.0)
+        ])),
+    ];
 
-/// An e-class is converted into a cluster with a node for each function call
-fn eclass_to_graphviz(eclass_id: &EClassID, fn_calls: &[FnCall], eclasses: &EClasses) -> Vec<Stmt> {
-    // Create node for all arguments of every function call
-    let mut stmts: Vec<Stmt> = fn_calls
-        .iter()
-        .flat_map(|fn_call| {
-            fn_call
-                .1
-                .iter()
-                .enumerate()
-                .flat_map(|(index, arg)| arg.to_graphviz(index, fn_call_id(fn_call), eclasses))
-                .collect::<Vec<Stmt>>()
-        })
-        .collect();
-    // Add a node for each function call in one e-class
-    let subgraph_stmts = fn_calls
-        .iter()
-        .map(|fn_call| {
-            let id = fn_call_id(fn_call);
-            stmt!(node!(esc id; html_label(fn_call.0.name.clone(), fn_call.1.len())))
-        })
-        .collect::<Vec<Stmt>>();
-    let cluster_id = cluster_name(eclass_id);
-    // Nest in empty sub-graph so that we can use rank=same
-    // https://stackoverflow.com/a/55562026/907060
-    stmts.push(stmt!(subgraph!(cluster_id; subgraph!("", subgraph_stmts))));
-    stmts
-}
-
-impl PrimOutput {
-    /// A primitive output, should be a node with the value and function call
-    fn to_graphviz(&self, eclasses: &EClasses) -> Vec<Stmt> {
-        let label = format!("{}: {}", self.0 .0.name, self.1.to_string());
-        let res_id = fn_call_id(&self.0);
-        let node_id = quote(res_id.clone());
-        let args = &self.0 .1;
-        let mut stmts = vec![stmt!(node!(node_id; html_label(label, args.len())))];
-        stmts.extend(
-            args.iter()
-                .enumerate()
-                .flat_map(|(index, arg)| arg.to_graphviz(index, res_id.clone(), eclasses)),
-        );
-        stmts
-    }
-}
-
-impl Arg {
-    /// Returns an edge from the result to the argument
-    /// If it's an e-class, use the e-class-id as the target
-    /// Otherwise, create a node for the primitive value and use that as the target
-    fn to_graphviz(&self, index: usize, result_id: String, eclasses: &EClasses) -> Vec<Stmt> {
-        let source = node_id!(quote(result_id.clone()), port!(id!(format!("a{}", index))));
-        match self {
-            Arg::Prim(p) => {
-                let arg_id = quote(prim_value_id(result_id, p));
-                vec![
-                    stmt!(node!(arg_id; html_label(p.to_string(), 0))),
-                    stmt!(edge!(source => node_id!(arg_id))),
-                ]
+    // Use VecDeque so we can rotate efficiently
+    let mut e_class_id_to_node_ids = g.iter().fold(
+        HashMap::<usize, VecDeque<String>>::default(),
+        |mut acc, call| {
+            if let ExportedValue::EClass(id) = call.output {
+                let node_id = format!("{}_{}", call.fn_name, call.input_hash);
+                acc.entry(id).or_default().push_back(node_id);
             }
-            Arg::Eq(id) => {
-                vec![stmt!(edge!(
-                    source => node_id!(quote(enode_fn_id(id, eclasses)));
-                    EdgeAttributes::lhead(cluster_name(id))
-                ))]
+            acc
+        },
+    );
+    // Get the node id for a given e-class id
+    let mut get_enode_id = |e_class_id| -> String {
+        let node_ids = e_class_id_to_node_ids.entry(e_class_id).or_default();
+        // Lookup the first node id for this eclass id
+        let node_id = node_ids.front().unwrap().clone();
+        // Rotate the node ids so that we can point to different ones each time for better graph layout
+        node_ids.rotate_left(1);
+        node_id
+    };
+
+    // Map from subgraph id to map of node id to label
+    let mut subgraph_to_node_to_label = HashMap::<String, HashMap<String, String>>::default();
+    // Nodes to process and add
+    let mut values_to_add = VecDeque::<ExportedValue>::default();
+
+    let mut add_node =
+        |subgraph_value: &ExportedValue, node_id: String, name: String, n_args: usize| {
+            subgraph_to_node_to_label
+                .entry(subgraph_id(subgraph_value))
+                .or_default()
+                .insert(node_id, html_label(name, n_args));
+        };
+
+    let mut gen_value_id = |value: &ExportedValue| match value {
+        ExportedValue::EClass(id) => get_enode_id(*id),
+        ExportedValue::Prim(p) => prim_id(p),
+        ExportedValue::Container {
+            name,
+            inner: _,
+            inner_hash,
+        } => container_id(name, *inner_hash),
+    };
+
+    let mut add_edge =
+        |source_node_id: String, source_index: usize, target_value: &ExportedValue| {
+            let source = node_id!(
+                quote(source_node_id),
+                port!(id!(port_id(source_index)))
+            );
+            let target = node_id!(quote(gen_value_id(target_value)));
+            let target_subgraph_id = subgraph_id(target_value);
+            let edge = edge!(source => target; EdgeAttributes::lhead(target_subgraph_id));
+            statements.push(stmt!(edge));
+        };
+
+    // Create subgraphs and nodes
+    for ExportedCall {
+        fn_name,
+        inputs,
+        output,
+        input_hash,
+    } in g
+    {
+        // Add function node
+        let fn_id = format!("{}_{}", fn_name, input_hash);
+        add_node(&output, fn_id.clone(), fn_name, inputs.len());
+        values_to_add.push_back(output.clone());
+        // Add edges from function node to input nodes
+        for (i, input) in inputs.into_iter().enumerate() {
+            add_edge(fn_id.clone(), i, &input);
+            values_to_add.push_back(input.clone());
+        }
+    }
+
+    // Add nodes for primitive values. Skip e-classes, since these appear as subgraphs
+    while let Some(value) = values_to_add.pop_front() {
+        match &value {
+            ExportedValue::EClass(_) => {}
+            ExportedValue::Prim(p) => add_node(&value, prim_id(p), p.into(), 0),
+            ExportedValue::Container {
+                name,
+                inner,
+                inner_hash,
+            } => {
+                let value_id = container_id(name, *inner_hash);
+                add_node(&value, value_id.clone(), name.to_string(), inner.len());
+                for (i, inner_value) in inner.iter().enumerate() {
+                    values_to_add.push_back(inner_value.clone());
+                    add_edge(value_id.clone(), i, &value);
+                }
             }
         }
     }
+
+    // Export each subgraph to nodes
+    for (subgraph_id, node_id_to_label) in subgraph_to_node_to_label {
+        let subgraph_stmts = node_id_to_label
+            .into_iter()
+            .map(|(node_id, label)| {
+                let node_id = quote(node_id);
+                stmt!(node!(node_id;NodeAttributes::label(label)))
+            })
+            .collect();
+        // Nest in empty sub-graph so that we can use rank=same
+        // https://stackoverflow.com/a/55562026/907060
+        statements.push(stmt!(subgraph!(subgraph_id; subgraph!("", subgraph_stmts))));
+    }
+    graph!(di id!(), statements)
 }
 
+fn subgraph_id(exported_value: &ExportedValue) -> String {
+    quote(match exported_value {
+        ExportedValue::EClass(eclass_id) => format!("cluster_eclass_{}", eclass_id),
+        ExportedValue::Prim(p) => format!("cluster_prim_{}", p),
+        ExportedValue::Container {
+            name,
+            inner: _,
+            inner_hash,
+        } => format!("cluster_container_{}_{}", name, inner_hash),
+    })
+}
+
+fn prim_id(prim: &str) -> String {
+    format!("prim_{}", prim)
+}
+
+fn container_id(name: &str, inner_hash: Hash) -> String {
+    format!("container_{}_{}", name, inner_hash)
+}
+
+/// Adds double quotes and
 fn quote(s: String) -> String {
     format!("{:?}", s)
 }
 
-fn cluster_name(canonical_id: &EClassID) -> String {
-    format!("cluster_{}", canonical_id)
-}
-
-// Edges to enodes should point to the first function call in the e-class
-fn enode_fn_id(eclass_id: &EClassID, eclasses: &EClasses) -> String {
-    fn_call_id(&eclasses[eclass_id][0])
-}
-
-// Function calls are uniquely identified by the function name and the hash of the arguments
-fn fn_call_id(fn_call: &FnCall) -> String {
-    format!("{}_{}", fn_call.0.name, fn_call.2)
-}
-
-fn prim_value_id(parent_name: String, value: &PrimValue) -> String {
-    format!("{}_{}", parent_name, value.to_string())
-}
-
 /// Returns an html label for the node with the function name and ports for each argumetn
-fn html_label(label: String, n_args: usize) -> Attribute {
-    NodeAttributes::label(format!(
-        "<<TABLE CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" style=\"rounded\">
-        <tr><td CELLPADDING=\"4\" WIDTH=\"30\" HEIGHT=\"30\" colspan=\"{}\">{}</td></tr>
-        {}
-        </TABLE>>",
+fn html_label(label: String, n_args: usize) -> String {
+    format!(
+        "<<TABLE CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" style=\"rounded\"><tr><td CELLPADDING=\"4\" WIDTH=\"30\" HEIGHT=\"30\" colspan=\"{}\">{}</td></tr>{}</TABLE>>",
         n_args,
         label,
         (if n_args == 0 {
@@ -147,10 +179,14 @@ fn html_label(label: String, n_args: usize) -> Attribute {
             format!(
                 "<TR>{}</TR>",
                 (0..n_args)
-                    .map(|i| format!("<TD PORT=\"a{}\"></TD>", i))
+                    .map(|i| format!("<TD PORT=\"{}\"></TD>", port_id(i)))
                     .collect::<Vec<String>>()
                     .join("")
             )
         })
-    ))
+    )
+}
+
+fn port_id(i: usize) -> String {
+    format!("i{}", i)
 }

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -188,14 +188,20 @@ fn build_graph(nodes: Nodes, edges: Edges, sort_colors: &SortColors) -> Graph {
             let color = sort_colors[&sort];
             stmts.push(stmt!(attr!("fillcolor", color)));
             for (subgraph_id, nodes) in subgraphs {
-                // Nest in empty sub-graph so that we can use rank=same
-                // https://stackoverflow.com/a/55562026/907060
                 let quoted_subgraph_id = quote(&subgraph_id);
                 let subgraph_stmts = nodes.into_iter().map(|s| stmt!(s)).collect();
-                let s = stmt!(subgraph!(quoted_subgraph_id;
+                let s = stmt!(subgraph!("";
                     // Disable label for now, to reduce size
                     // NodeAttributes::label(subgraph_html_label(&sort)),
-                    subgraph!("", subgraph_stmts)
+
+                    // Nest in empty sub-graph so that we can use rank=same
+                    // https://stackoverflow.com/a/55562026/907060
+                    subgraph!(quoted_subgraph_id; subgraph!("", subgraph_stmts)),
+
+                    // Make outer subgraph a cluster but make it invisible, so just used for padding
+                    // https://forum.graphviz.org/t/how-to-add-space-between-clusters/1209/3
+                    SubgraphAttributes::style(quote("invis")),
+                    attr!("cluster", "true")
                 ));
                 stmts.push(s);
             }

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -202,6 +202,9 @@ fn build_graph(nodes: Nodes, edges: Edges, sort_colors: &SortColors) -> Graph {
         }
     }
     stmts.extend(edges.into_iter().map(|s| stmt!(s)));
+    // Set margin to 0 at the end again, so that total graph margin is 0, but all the clusters
+    // defined above have some margins
+    stmts.push(stmt!(GraphAttributes::margin(0.0)));
     graph!(di id!(), stmts)
 }
 

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -94,7 +94,10 @@ impl SubgraphBuilder {
             ExportedValue::Prim(name, inner, _) => {
                 let subgraph_id = format!("cluster_{}", function_node_id);
                 let value_node_id = format!("{}_value", function_node_id);
-                nodes.push(self.add_node(&value_node_id, name, inner));
+                // Add the function return value, unless it's a unit sort
+                if sort != "Unit" {
+                    nodes.push(self.add_node(&value_node_id, name, inner));
+                }
                 self.add_value_subgraph(&subgraph_id, sort, nodes);
             }
         };
@@ -129,7 +132,7 @@ impl SubgraphBuilder {
             };
             let target = node_id!(quote(&child_node_id));
             self.edges
-                .push(edge!(source => target; EdgeAttributes::lhead(child_subgraph_id)));
+                .push(edge!(source => target; EdgeAttributes::lhead(quote(&child_subgraph_id))));
         }
         node!(quoted_node_id;NodeAttributes::label(html_label))
     }

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -4,12 +4,12 @@ use graphviz_rust::{attributes as a, dot_structures as d};
 fn eclass_cluster_name(eclass_id: &EClassID) -> String {
     format!("cluster_{}", eclass_id)
 }
-// The Node ID for the eclass is the first node in the eclass cluster
+/// The Node ID for the eclass is the first node in the eclass cluster
 fn eclass_node_id(eclass_id: &EClassID) -> d::NodeId {
     d::NodeId(d::Id::Plain(quote(format!("{}_0", eclass_id))), None)
 }
 
-// An e-class is converted into a cluster with a node for each function call
+/// An e-class is converted into a cluster with a node for each function call
 fn eclass_to_graphviz(
     eclass_id: &EClassID,
     fn_calls: &[FnCall],
@@ -59,7 +59,7 @@ fn eclass_to_graphviz(
 }
 
 impl PrimOutput {
-    // A primitive output, should be a node with the value and function call
+    /// A primitive output, should be a node with the value and function call
     fn to_graphviz(&self, id_gen: &mut NodeIDGenerator) -> Vec<d::Stmt> {
         let mut stmts = Vec::new();
         let label = format!("{}: {}", self.0 .0.name, self.1.to_string());
@@ -79,9 +79,9 @@ impl PrimOutput {
 }
 
 impl Arg {
-    // Returns an edge from the result to the argument
-    // If it's an e-class, use the e-class-id as the target
-    // Otherwise, create a node for the primitive value and use that as the target
+    /// Returns an edge from the result to the argument
+    /// If it's an e-class, use the e-class-id as the target
+    /// Otherwise, create a node for the primitive value and use that as the target
     fn to_graphviz(&self, id_gen: &mut NodeIDGenerator, result_id: d::NodeId) -> Vec<d::Stmt> {
         match self {
             Arg::Prim(p) => {
@@ -112,7 +112,7 @@ impl Arg {
     }
 }
 
-// Implement conversion of Graph to graphviz Graph
+/// Implement conversion of Graph to graphviz Graph
 impl Graph {
     pub fn to_graphviz(&self) -> d::Graph {
         let id_generator = &mut NodeIDGenerator::new();
@@ -153,7 +153,7 @@ impl Graph {
     }
 }
 
-// Struct which generates an incrementing ID for each node
+/// Struct which generates an incrementing ID for each node
 struct NodeIDGenerator {
     next_id: usize,
 }

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -1,12 +1,12 @@
 use super::*;
-use graphviz_rust::dot_structures as g;
+use graphviz_rust::{dot_structures as d, attributes as a};
 
 fn eclass_cluster_name(eclass_id: &EClassID) -> String {
     format!("cluster_{}", eclass_id)
 }
 // The Node ID for the eclass is the first node in the eclass cluster
-fn eclass_node_id(eclass_id: &EClassID) -> g::NodeId {
-    g::NodeId(g::Id::Plain(quote(format!("{}_0", eclass_id))), None)
+fn eclass_node_id(eclass_id: &EClassID) -> d::NodeId {
+    d::NodeId(d::Id::Plain(quote(format!("{}_0", eclass_id))), None)
 }
 
 // An e-class is converted into a cluster with a node for each function call
@@ -14,8 +14,8 @@ fn eclass_to_graphviz(
     eclass_id: &EClassID,
     fn_calls: &[FnCall],
     id_gen: &mut NodeIDGenerator,
-) -> Vec<g::Stmt> {
-    let mut stmts: Vec<g::Stmt> = fn_calls
+) -> Vec<d::Stmt> {
+    let mut stmts: Vec<d::Stmt> = fn_calls
         .iter()
         .enumerate()
         .flat_map(|(index, fn_call)| {
@@ -25,24 +25,24 @@ fn eclass_to_graphviz(
                 .flat_map(|arg| {
                     arg.to_graphviz(
                         id_gen,
-                        g::NodeId(
-                            g::Id::Plain(quote(format!("{}_{}", eclass_id, index))),
+                        d::NodeId(
+                            d::Id::Plain(quote(format!("{}_{}", eclass_id, index))),
                             None,
                         ),
                     )
                 })
-                .collect::<Vec<g::Stmt>>()
+                .collect::<Vec<d::Stmt>>()
         })
         .collect();
-    stmts.push(g::Stmt::Subgraph(g::Subgraph {
-        id: g::Id::Plain(eclass_cluster_name(eclass_id)),
+    stmts.push(d::Stmt::Subgraph(d::Subgraph {
+        id: d::Id::Plain(eclass_cluster_name(eclass_id)),
         stmts: fn_calls
             .iter()
             .enumerate()
             .map(|(index, fn_call)| {
-                g::Stmt::Node(g::Node::new(
-                    g::NodeId(
-                        g::Id::Plain(quote(format!("{}_{}", eclass_id, index))),
+                d::Stmt::Node(d::Node::new(
+                    d::NodeId(
+                        d::Id::Plain(quote(format!("{}_{}", eclass_id, index))),
                         None,
                     ),
                     label_attributes(fn_call.0.name.clone()),
@@ -55,11 +55,11 @@ fn eclass_to_graphviz(
 
 impl PrimOutput {
     // A primitive output, should be a node with the value and function call
-    fn to_graphviz(&self, id_gen: &mut NodeIDGenerator) -> Vec<g::Stmt> {
+    fn to_graphviz(&self, id_gen: &mut NodeIDGenerator) -> Vec<d::Stmt> {
         let mut stmts = Vec::new();
         let label = format!("{}: {}", self.0 .0.name, self.1.to_string());
         let res_id = id_gen.next();
-        stmts.push(g::Stmt::Node(g::Node::new(
+        stmts.push(d::Stmt::Node(d::Node::new(
             res_id.clone(),
             label_attributes(label),
         )));
@@ -77,26 +77,26 @@ impl Arg {
     // Returns an edge from the result to the argument
     // If it's an e-class, use the e-class-id as the target
     // Otherwise, create a node for the primitive value and use that as the target
-    fn to_graphviz(&self, id_gen: &mut NodeIDGenerator, result_id: g::NodeId) -> Vec<g::Stmt> {
+    fn to_graphviz(&self, id_gen: &mut NodeIDGenerator, result_id: d::NodeId) -> Vec<d::Stmt> {
         match self {
             Arg::Prim(p) => {
                 let arg_id = id_gen.next();
                 vec![
-                    g::Stmt::Node(g::Node::new(
+                    d::Stmt::Node(d::Node::new(
                         arg_id.clone(),
                         label_attributes(p.to_string()),
                     )),
-                    g::Stmt::Edge(g::Edge {
-                        ty: g::EdgeTy::Pair(g::Vertex::N(result_id), g::Vertex::N(arg_id)),
+                    d::Stmt::Edge(d::Edge {
+                        ty: d::EdgeTy::Pair(d::Vertex::N(result_id), d::Vertex::N(arg_id)),
                         attributes: vec![],
                     }),
                 ]
             }
             Arg::Eq(eclass_id) => {
-                vec![g::Stmt::Edge(g::Edge {
-                    ty: g::EdgeTy::Pair(
-                        g::Vertex::N(result_id),
-                        g::Vertex::N(eclass_node_id(eclass_id)),
+                vec![d::Stmt::Edge(d::Edge {
+                    ty: d::EdgeTy::Pair(
+                        d::Vertex::N(result_id),
+                        d::Vertex::N(eclass_node_id(eclass_id)),
                     ),
                     attributes: vec![graphviz_rust::attributes::EdgeAttributes::lhead(
                         eclass_cluster_name(eclass_id),
@@ -109,10 +109,20 @@ impl Arg {
 
 // Implement conversion of Graph to graphviz Graph
 impl Graph {
-    pub fn to_graphviz(&self) -> g::Graph {
+    pub fn to_graphviz(&self) -> d::Graph {
         let id_generator = &mut NodeIDGenerator::new();
-        // Set compound to true
-        let mut statements = vec![g::Stmt::Attribute(GraphAttributes::compound(true))];
+        let mut statements = vec![
+            d::Stmt::Attribute(a::GraphAttributes::compound(true)),
+            d::Stmt::Attribute(a::GraphAttributes::fontname("helvetica".to_string())),
+            d::Stmt::Attribute(a::GraphAttributes::style(quote("rounded,dashed".to_string()))),
+            d::Stmt::GAttribute(d::GraphAttributes::Edge(vec![a::EdgeAttributes::arrowsize(0.5)])),
+            d::Stmt::GAttribute(d::GraphAttributes::Node(vec![
+                a::NodeAttributes::shape(a::shape::box_),
+                a::NodeAttributes::style("rounded".to_string()),
+                a::NodeAttributes::width(0.4),
+                a::NodeAttributes::height(0.4),
+            ])),
+        ];
         statements.extend(
             self.prim_outputs
                 .iter()
@@ -123,8 +133,8 @@ impl Graph {
                 eclass_to_graphviz(eclass_id, eclass, id_generator)
             }),
         );
-        g::Graph::DiGraph {
-            id: g::Id::Plain("egg_smol".to_string()),
+        d::Graph::DiGraph {
+            id: d::Id::Plain("egg_smol".to_string()),
             strict: false,
             stmts: statements,
         }
@@ -141,14 +151,14 @@ impl NodeIDGenerator {
         Self { next_id: 0 }
     }
 
-    fn next(&mut self) -> g::NodeId {
+    fn next(&mut self) -> d::NodeId {
         let id = self.next_id;
         self.next_id += 1;
-        g::NodeId(g::Id::Plain(id.to_string()), None)
+        d::NodeId(d::Id::Plain(id.to_string()), None)
     }
 }
 
-fn label_attributes(label: String) -> Vec<g::Attribute> {
+fn label_attributes(label: String) -> Vec<d::Attribute> {
     vec![graphviz_rust::attributes::NodeAttributes::label(quote(
         label,
     ))]

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -13,140 +13,168 @@ use graphviz_rust::{
 /// Implement conversion of Graph to graphviz Graph
 /// Places all equivalent nodes in the same cluster
 /// For e-nodes these are are all in the same e-class
-/// For
 pub(crate) fn to_graphviz(g: ExportedGraph) -> Graph {
-    let mut statements = vec![
-        // Set to compound so we can have edge to clusters
-        stmt!(GraphAttributes::compound(true)),
-        // Set default sub-graph rank to be same so that all nodes in e-class are on same level
-        stmt!(SubgraphAttributes::rank(rank::same)),
-        stmt!(GraphAttributes::fontname("helvetica".to_string())),
-        stmt!(GraphAttributes::style(quote("rounded,dashed".to_string()))),
-        stmt!(GraphAttributes::margin(3.0)),
-        stmt!(GraphAttributes::nodesep(0.0)),
-        stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
-        stmt!(GA::Node(vec![
-            NodeAttributes::shape(shape::none),
-            NodeAttributes::margin(0.0)
-        ])),
-    ];
+    GraphExporter::new(g).into_graphviz()
+}
 
+#[derive(Default)]
+struct GraphExporter {
+    statements: Vec<Stmt>,
     // Use VecDeque so we can rotate efficiently
-    let mut e_class_id_to_node_ids = g.iter().fold(
-        HashMap::<usize, VecDeque<String>>::default(),
-        |mut acc, call| {
+    e_class_id_to_node_ids: HashMap<usize, VecDeque<String>>,
+    // Map from subgraph id to map of node id to label
+    subgraph_to_node_to_label: HashMap<String, HashMap<String, String>>,
+    // Nodes to process and add
+    values_to_add: VecDeque<ExportedValue>,
+    // Nodes already added to the values_to_add queue
+    added_value: HashSet<ExportedValue>,
+}
+
+impl GraphExporter {
+    fn new(g: ExportedGraph) -> Self {
+        // let mut exporter = Self {  ...Self::default()};
+        let mut exporter = Self {
+            statements: vec![
+                // Set to compound so we can have edge to clusters
+                stmt!(GraphAttributes::compound(true)),
+                // Set default sub-graph rank to be same so that all nodes in e-class are on same level
+                stmt!(SubgraphAttributes::rank(rank::same)),
+                stmt!(GraphAttributes::fontname("helvetica".to_string())),
+                stmt!(GraphAttributes::style(quote("rounded,dashed".to_string()))),
+                stmt!(GraphAttributes::margin(3.0)),
+                stmt!(GraphAttributes::nodesep(0.0)),
+                stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
+                stmt!(GA::Node(vec![
+                    NodeAttributes::shape(shape::none),
+                    NodeAttributes::margin(0.0)
+                ])),
+            ],
+            ..Self::default()
+        };
+        for call in g.iter() {
             if let ExportedValue::EClass(id) = call.output {
                 let node_id = format!("{}_{}", call.fn_name, call.input_hash);
-                acc.entry(id).or_default().push_back(node_id);
+                exporter
+                    .e_class_id_to_node_ids
+                    .entry(id)
+                    .or_default()
+                    .push_back(node_id);
             }
-            acc
-        },
-    );
-    // Get the node id for a given e-class id
-    let mut get_enode_id = |e_class_id| -> String {
-        let node_ids = e_class_id_to_node_ids.entry(e_class_id).or_default();
+        }
+
+        // Create subgraphs and nodes
+        for ExportedCall {
+            fn_name,
+            inputs,
+            output,
+            input_hash,
+        } in g
+        {
+            // Add function node
+            let fn_id = format!("{}_{}", fn_name, input_hash);
+
+            exporter.add_node(&output, fn_id.clone(), fn_name, inputs.len());
+            exporter.add_value(&output);
+            // Add edges from function node to input nodes
+            for (i, input) in inputs.into_iter().enumerate() {
+                exporter.add_edge(fn_id.clone(), i, &input);
+                exporter.add_value(&input);
+            }
+        }
+        exporter
+    }
+
+    fn into_graphviz(mut self) -> Graph {
+        // Add nodes for primitive values. Skip e-classes, since these appear as subgraphs
+        while let Some(value) = self.values_to_add.pop_front() {
+            match &value {
+                ExportedValue::EClass(_) => {}
+                ExportedValue::Prim(p) => self.add_node(&value, prim_id(p), p.into(), 0),
+                ExportedValue::Container {
+                    name,
+                    inner,
+                    inner_hash,
+                } => {
+                    let value_id = container_id(name, *inner_hash);
+                    self.add_node(&value, value_id.clone(), name.to_string(), inner.len());
+                    for (i, inner_value) in inner.iter().enumerate() {
+                        self.add_value(inner_value);
+                        self.add_edge(value_id.clone(), i, inner_value);
+                    }
+                }
+            }
+        }
+
+        // Export each subgraph to nodes
+        for (subgraph_id, node_id_to_label) in self.subgraph_to_node_to_label {
+            let subgraph_stmts = node_id_to_label
+                .into_iter()
+                .map(|(node_id, label)| {
+                    let node_id = quote(node_id);
+                    stmt!(node!(node_id;NodeAttributes::label(label)))
+                })
+                .collect();
+            // Nest in empty sub-graph so that we can use rank=same
+            // https://stackoverflow.com/a/55562026/907060
+            self.statements
+                .push(stmt!(subgraph!(subgraph_id; subgraph!("", subgraph_stmts))));
+        }
+        graph!(di id!(), self.statements)
+    }
+
+    fn get_enode_id(&mut self, e_class_id: usize) -> String {
+        let node_ids = self.e_class_id_to_node_ids.entry(e_class_id).or_default();
         // Lookup the first node id for this eclass id
         let node_id = node_ids.front().unwrap().clone();
         // Rotate the node ids so that we can point to different ones each time for better graph layout
         node_ids.rotate_left(1);
         node_id
-    };
+    }
 
-    // Map from subgraph id to map of node id to label
-    let mut subgraph_to_node_to_label = HashMap::<String, HashMap<String, String>>::default();
-    // Nodes to process and add
-    let mut values_to_add = VecDeque::<ExportedValue>::default();
-    // Nodes already added to the values_to_add queue
-    let mut added_value: HashSet<ExportedValue> = HashSet::default();
-
-    let mut add_value = |value: &ExportedValue| {
-        if !added_value.contains(value) {
-            values_to_add.push_back(value.clone());
-            added_value.insert(value.clone());
-        }
-    };
-
-    let mut add_node =
-        |subgraph_value: &ExportedValue, node_id: String, name: String, n_args: usize| {
-            subgraph_to_node_to_label
-                .entry(subgraph_id(subgraph_value))
-                .or_default()
-                .insert(node_id, html_label(name, n_args));
-        };
-
-    let mut gen_value_id = |value: &ExportedValue| match value {
-        ExportedValue::EClass(id) => get_enode_id(*id),
-        ExportedValue::Prim(p) => prim_id(p),
-        ExportedValue::Container {
-            name,
-            inner: _,
-            inner_hash,
-        } => container_id(name, *inner_hash),
-    };
-
-    let mut add_edge =
-        |source_node_id: String, source_index: usize, target_value: &ExportedValue| {
-            let source = node_id!(quote(source_node_id), port!(id!(port_id(source_index))));
-            let target = node_id!(quote(gen_value_id(target_value)));
-            let target_subgraph_id = subgraph_id(target_value);
-            let edge = edge!(source => target; EdgeAttributes::lhead(target_subgraph_id));
-            statements.push(stmt!(edge));
-        };
-
-    // Create subgraphs and nodes
-    for ExportedCall {
-        fn_name,
-        inputs,
-        output,
-        input_hash,
-    } in g
-    {
-        // Add function node
-        let fn_id = format!("{}_{}", fn_name, input_hash);
-
-        add_node(&output, fn_id.clone(), fn_name, inputs.len());
-        add_value(&output);
-        // Add edges from function node to input nodes
-        for (i, input) in inputs.into_iter().enumerate() {
-            add_edge(fn_id.clone(), i, &input);
-            add_value(&input);
+    fn add_value(&mut self, value: &ExportedValue) {
+        if !self.added_value.contains(value) {
+            self.values_to_add.push_back(value.clone());
+            self.added_value.insert(value.clone());
         }
     }
 
-    // Add nodes for primitive values. Skip e-classes, since these appear as subgraphs
-    while let Some(value) = values_to_add.pop_front() {
-        match &value {
-            ExportedValue::EClass(_) => {}
-            ExportedValue::Prim(p) => add_node(&value, prim_id(p), p.into(), 0),
+    fn add_node(
+        &mut self,
+        subgraph_value: &ExportedValue,
+        node_id: String,
+        name: String,
+        n_args: usize,
+    ) {
+        self.subgraph_to_node_to_label
+            .entry(subgraph_id(subgraph_value))
+            .or_default()
+            .insert(node_id, html_label(name, n_args));
+    }
+
+    fn gen_value_id(&mut self, value: &ExportedValue) -> String {
+        match value {
+            ExportedValue::EClass(id) => self.get_enode_id(*id),
+            ExportedValue::Prim(p) => prim_id(p),
             ExportedValue::Container {
                 name,
-                inner,
+                inner: _,
                 inner_hash,
-            } => {
-                let value_id = container_id(name, *inner_hash);
-                add_node(&value, value_id.clone(), name.to_string(), inner.len());
-                for (i, inner_value) in inner.iter().enumerate() {
-                    add_value(&inner_value);
-                    add_edge(value_id.clone(), i, inner_value);
-                }
-            }
+            } => container_id(name, *inner_hash),
         }
     }
 
-    // Export each subgraph to nodes
-    for (subgraph_id, node_id_to_label) in subgraph_to_node_to_label {
-        let subgraph_stmts = node_id_to_label
-            .into_iter()
-            .map(|(node_id, label)| {
-                let node_id = quote(node_id);
-                stmt!(node!(node_id;NodeAttributes::label(label)))
-            })
-            .collect();
-        // Nest in empty sub-graph so that we can use rank=same
-        // https://stackoverflow.com/a/55562026/907060
-        statements.push(stmt!(subgraph!(subgraph_id; subgraph!("", subgraph_stmts))));
+    fn add_edge(
+        &mut self,
+        source_node_id: String,
+        source_index: usize,
+        target_value: &ExportedValue,
+    ) {
+        let source = node_id!(quote(source_node_id), port!(id!(port_id(source_index))));
+        let target = node_id!(quote(self.gen_value_id(target_value)));
+        let target_subgraph_id = subgraph_id(target_value);
+        let edge = edge!(source => target; EdgeAttributes::lhead(target_subgraph_id));
+        self.statements.push(stmt!(edge));
     }
-    graph!(di id!(), statements)
 }
 
 fn subgraph_id(exported_value: &ExportedValue) -> String {

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -111,7 +111,7 @@ impl SubgraphBuilder {
     fn add_node(&mut self, node_id: &str, label: &str, children: &[ExportedValueWithSort]) -> Node {
         let quoted_node_id = quote(node_id);
         for (i, value) in children.iter().enumerate() {
-            let source = node_id!(quote(node_id), port!(id!(port_id(i))));
+            let source = node_id!(quote(node_id), port!(id!(port_id(i)), "s"));
             self.sorts.insert(value.1.clone());
             let (child_node_id, child_subgraph_id) = match &value.0 {
                 // Functions should point to one of the function nodes of the e-class.

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -2,7 +2,7 @@ use super::*;
 use graphviz_rust::{attributes as a, dot_structures as d};
 
 /// Implement conversion of Graph to graphviz Graph
-impl Graph {
+impl ExportedGraph {
     pub fn to_graphviz(&self) -> d::Graph {
         let mut statements = vec![
             // Set to compound so we can have edge to clusters

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -41,7 +41,6 @@ impl GraphExporter {
                 stmt!(SubgraphAttributes::rank(rank::same)),
                 stmt!(GraphAttributes::fontname("helvetica".to_string())),
                 stmt!(GraphAttributes::fontsize(9.0)),
-                stmt!(GraphAttributes::style(quote("rounded,dashed".to_string()))),
                 stmt!(GraphAttributes::margin(3.0)),
                 stmt!(GraphAttributes::nodesep(0.0)),
                 stmt!(GA::Edge(vec![EdgeAttributes::arrowsize(0.5)])),
@@ -115,10 +114,18 @@ impl GraphExporter {
                     stmt!(node!(node_id;NodeAttributes::label(label)))
                 })
                 .collect();
+            let subgraph_style = if subgraph_id.starts_with("\"cluster_eclass_") {
+                "dashed,rounded".to_string()
+            } else {
+                "dotted,rounded".to_string()
+            };
             // Nest in empty sub-graph so that we can use rank=same
             // https://stackoverflow.com/a/55562026/907060
-            self.statements
-                .push(stmt!(subgraph!(subgraph_id; NodeAttributes::label(subgraph_html_label(sort)), subgraph!("", subgraph_stmts))));
+            self.statements.push(stmt!(subgraph!(subgraph_id;
+                NodeAttributes::label(subgraph_html_label(sort)),
+                GA::Graph(vec![GraphAttributes::style(quote(subgraph_style))]),
+                subgraph!("", subgraph_stmts)
+            )));
         }
         graph!(di id!(), self.statements)
     }

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -242,8 +242,8 @@ fn quote(s: &str) -> String {
 /// Returns an html label for the node with the function name and ports for each argumetn
 fn html_label(label: &str, n_args: usize) -> String {
     format!(
-        "<<TABLE BGCOLOR=\"white\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" style=\"rounded\"><tr><td CELLPADDING=\"4\" WIDTH=\"30\" HEIGHT=\"30\" colspan=\"{}\">{}</td></tr>{}</TABLE>>",
-        n_args,
+        "<<TABLE BGCOLOR=\"white\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\" style=\"rounded\"><tr><td CELLPADDING=\"4\" WIDTH=\"30\" HEIGHT=\"30\"{}>{}</td></tr>{}</TABLE>>",
+        (if n_args  == 0 {"".to_string()} else {format!(" colspan=\"{}\"", n_args)}),
         Escape(label),
         (if n_args == 0 {
             "".to_string()

--- a/src/graph/to_graphviz.rs
+++ b/src/graph/to_graphviz.rs
@@ -120,7 +120,7 @@ pub(crate) fn to_graphviz(g: ExportedGraph) -> Graph {
                 add_node(&value, value_id.clone(), name.to_string(), inner.len());
                 for (i, inner_value) in inner.iter().enumerate() {
                     values_to_add.push_back(inner_value.clone());
-                    add_edge(value_id.clone(), i, &value);
+                    add_edge(value_id.clone(), i, inner_value);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub struct EGraph {
     pub(crate) proof_state: ProofState,
     functions: HashMap<Symbol, Function>,
     rulesets: HashMap<Symbol, HashMap<Symbol, Rule>>,
-    pub(crate) proofs_enabled: bool,
+    proofs_enabled: bool,
     timestamp: u32,
     pub test_proofs: bool,
     pub match_limit: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1209,7 +1209,6 @@ impl EGraph {
         .map_err(|e| Error::IoError(path.as_ref().to_path_buf(), e))?;
         Ok(())
     }
-
 }
 
 #[derive(Debug, Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ pub mod util;
 mod value;
 
 use crate::graph::from_egraph::graph_from_egraph;
-pub use graph::from_egraph::IncludeTempFunctions;
 use graphviz_rust::printer::DotPrinter;
 use hashbrown::hash_map::Entry;
 use index::ColumnIndex;
@@ -1225,15 +1224,15 @@ impl EGraph {
     }
 
     /// Exports the egraph as a Graphviz dot string
-    pub fn to_graphviz_string(&self, temp_functions: IncludeTempFunctions) -> String {
-        graph_from_egraph(self, temp_functions)
+    pub fn to_graphviz_string(&self) -> String {
+        graph_from_egraph(self)
             .to_graphviz()
             .print(&mut graphviz_rust::printer::PrinterContext::default())
     }
 
     /// Saves the egraph as a DOT file at the given path
-    pub fn save_graph_as_dot<P: AsRef<Path>>(&self, path: P, temp_functions: IncludeTempFunctions) -> Result<(), Error> {
-        let dot = self.to_graphviz_string(temp_functions);
+    pub fn save_graph_as_dot<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+        let dot = self.to_graphviz_string();
         let mut file =
             File::create(&path).map_err(|e| Error::IoError(path.as_ref().to_path_buf(), e))?;
         std::io::Write::write_all(&mut file, dot.as_bytes())
@@ -1242,8 +1241,8 @@ impl EGraph {
     }
 
     /// Saves the egraph as an SVG file at the given path
-    pub fn save_graph_as_svg<P: AsRef<Path>>(&self, path: P, temp_functions: IncludeTempFunctions) -> Result<(), Error> {
-        let dot = self.to_graphviz_string(temp_functions);
+    pub fn save_graph_as_svg<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+        let dot = self.to_graphviz_string();
         graphviz_rust::exec_dot(
             dot,
             vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod util;
 mod value;
 
 use crate::graph::from_egraph::graph_from_egraph;
+pub use graph::from_egraph::IncludeTempFunctions;
 use graphviz_rust::printer::DotPrinter;
 use hashbrown::hash_map::Entry;
 use index::ColumnIndex;
@@ -1224,15 +1225,15 @@ impl EGraph {
     }
 
     /// Exports the egraph as a Graphviz dot string
-    pub fn to_graphviz_string(&self) -> String {
-        graph_from_egraph(self)
+    pub fn to_graphviz_string(&self, temp_functions: IncludeTempFunctions) -> String {
+        graph_from_egraph(self, temp_functions)
             .to_graphviz()
             .print(&mut graphviz_rust::printer::PrinterContext::default())
     }
 
     /// Saves the egraph as a DOT file at the given path
-    pub fn save_graph_as_dot<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
-        let dot = self.to_graphviz_string();
+    pub fn save_graph_as_dot<P: AsRef<Path>>(&self, path: P, temp_functions: IncludeTempFunctions) -> Result<(), Error> {
+        let dot = self.to_graphviz_string(temp_functions);
         let mut file =
             File::create(&path).map_err(|e| Error::IoError(path.as_ref().to_path_buf(), e))?;
         std::io::Write::write_all(&mut file, dot.as_bytes())
@@ -1241,8 +1242,8 @@ impl EGraph {
     }
 
     /// Saves the egraph as an SVG file at the given path
-    pub fn save_graph_as_svg<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
-        let dot = self.to_graphviz_string();
+    pub fn save_graph_as_svg<P: AsRef<Path>>(&self, path: P, temp_functions: IncludeTempFunctions) -> Result<(), Error> {
+        let dot = self.to_graphviz_string(temp_functions);
         graphviz_rust::exec_dot(
             dot,
             vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1225,7 +1225,7 @@ impl EGraph {
 
     /// Exports the egraph as a Graphviz dot string
     pub fn to_graphviz_string(&self) -> String {
-        to_graphviz(graph_from_egraph(self))
+        to_graphviz(&graph_from_egraph(self))
             .print(&mut graphviz_rust::printer::PrinterContext::default())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub struct EGraph {
     pub(crate) proof_state: ProofState,
     functions: HashMap<Symbol, Function>,
     rulesets: HashMap<Symbol, HashMap<Symbol, Rule>>,
-    proofs_enabled: bool,
+    pub(crate) proofs_enabled: bool,
     timestamp: u32,
     pub test_proofs: bool,
     pub match_limit: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,7 @@ impl EGraph {
                     .iter()
                     .chain(once(&function.schema.output)),
             ) {
+                assert!(sort.is_eq_container_sort() == rix.is_some());
                 if sort.is_eq_container_sort() {
                     let rix = rix.as_ref().unwrap();
                     for ix in rix.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod util;
 mod value;
 
 use crate::graph::from_egraph::graph_from_egraph;
+use graph::to_graphviz::to_graphviz;
 use graphviz_rust::printer::DotPrinter;
 use hashbrown::hash_map::Entry;
 use index::ColumnIndex;
@@ -266,7 +267,6 @@ impl EGraph {
                     .iter()
                     .chain(once(&function.schema.output)),
             ) {
-                assert!(sort.is_eq_container_sort() == rix.is_some());
                 if sort.is_eq_container_sort() {
                     let rix = rix.as_ref().unwrap();
                     for ix in rix.iter() {
@@ -1225,8 +1225,7 @@ impl EGraph {
 
     /// Exports the egraph as a Graphviz dot string
     pub fn to_graphviz_string(&self) -> String {
-        graph_from_egraph(self)
-            .to_graphviz()
+        to_graphviz(graph_from_egraph(self))
             .print(&mut graphviz_rust::printer::PrinterContext::default())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use egg_smol::EGraph;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
-
 #[derive(Debug, Parser)]
 struct Args {
     #[clap(short = 'F', long)]
@@ -85,7 +84,6 @@ fn main() {
                 Err(err) => log::error!("Failed to save graph as SVG file: {}", err),
             }
         }
-
 
         // no need to drop the egraph if we are going to exit
         if idx == args.inputs.len() - 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use egg_smol::EGraph;
-use egg_smol::IncludeTempFunctions;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
@@ -14,12 +13,8 @@ struct Args {
     save_dot: bool,
     #[clap(long)]
     save_svg: bool,
-    #[clap(long)]
-    #[clap(value_enum, default_value_t=IncludeTempFunctions::IfProofsEnabled)]
-    viz_include_temp: IncludeTempFunctions,
     inputs: Vec<PathBuf>,
 }
-
 
 fn main() {
     env_logger::Builder::new()
@@ -75,7 +70,7 @@ fn main() {
         // Save the graph as a DOT file if the `save_dot` flag is set
         if args.save_dot {
             let dot_path = input.with_extension("dot");
-            match egraph.save_graph_as_dot(&dot_path, args.viz_include_temp) {
+            match egraph.save_graph_as_dot(&dot_path) {
                 Ok(()) => log::info!("Saved graph as DOT file: {}", dot_path.display()),
                 Err(err) => log::error!("Failed to save graph as DOT file: {}", err),
             }
@@ -84,7 +79,7 @@ fn main() {
         // Save the graph as an SVG file if the `save_svg` flag is set
         if args.save_svg {
             let svg_path = input.with_extension("svg");
-            match egraph.save_graph_as_svg(&svg_path, args.viz_include_temp) {
+            match egraph.save_graph_as_svg(&svg_path) {
                 Ok(()) => log::info!("Saved graph as SVG file: {}", svg_path.display()),
                 Err(err) => log::error!("Failed to save graph as SVG file: {}", err),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use egg_smol::EGraph;
+use egg_smol::IncludeTempFunctions;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
@@ -13,8 +14,12 @@ struct Args {
     save_dot: bool,
     #[clap(long)]
     save_svg: bool,
+    #[clap(long)]
+    #[clap(value_enum, default_value_t=IncludeTempFunctions::IfProofsEnabled)]
+    viz_include_temp: IncludeTempFunctions,
     inputs: Vec<PathBuf>,
 }
+
 
 fn main() {
     env_logger::Builder::new()
@@ -70,7 +75,7 @@ fn main() {
         // Save the graph as a DOT file if the `save_dot` flag is set
         if args.save_dot {
             let dot_path = input.with_extension("dot");
-            match egraph.save_graph_as_dot(&dot_path) {
+            match egraph.save_graph_as_dot(&dot_path, args.viz_include_temp) {
                 Ok(()) => log::info!("Saved graph as DOT file: {}", dot_path.display()),
                 Err(err) => log::error!("Failed to save graph as DOT file: {}", err),
             }
@@ -79,7 +84,7 @@ fn main() {
         // Save the graph as an SVG file if the `save_svg` flag is set
         if args.save_svg {
             let svg_path = input.with_extension("svg");
-            match egraph.save_graph_as_svg(&svg_path) {
+            match egraph.save_graph_as_svg(&svg_path, args.viz_include_temp) {
                 Ok(()) => log::info!("Saved graph as SVG file: {}", svg_path.display()),
                 Err(err) => log::error!("Failed to save graph as SVG file: {}", err),
             }

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -73,6 +73,24 @@ impl Sort for MapSort {
         result
     }
 
+    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
+        // TODO: Potential duplication of code
+        let maps = self.maps.lock().unwrap();
+        let map = maps.get_index(value.bits as usize).unwrap();
+
+        if self.key.is_eq_sort() {
+            for key in map.keys() {
+                f(*key)
+            }
+        }
+
+        if self.value.is_eq_sort() {
+            for value in map.values() {
+                f(*value)
+            }
+        }
+    }
+
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {
         let maps = self.maps.lock().unwrap();
         let map = maps.get_index(value.bits as usize).unwrap();

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -67,7 +67,7 @@ impl Sort for MapSort {
         let maps = self.maps.lock().unwrap();
         let map = maps.get_index(value.bits as usize).unwrap();
         let mut result = Vec::new();
-        for (k, v) in map.into_iter() {
+        for (k, v) in map.iter() {
             result.push((&self.key, *k));
             result.push((&self.value, *v));
         }

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -62,23 +62,18 @@ impl Sort for MapSort {
         self.key.is_eq_sort() || self.value.is_eq_sort()
     }
 
-    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
-        // TODO: Potential duplication of code
+
+    fn inner_values(&self, value: &Value) -> Vec<(&ArcSort, Value)>   {
         let maps = self.maps.lock().unwrap();
         let map = maps.get_index(value.bits as usize).unwrap();
-
-        if self.key.is_eq_sort() {
-            for key in map.keys() {
-                f(*key)
-            }
+        let mut result = Vec::new();
+        for (k, v) in map.into_iter() {
+            result.push((&self.key, *k));
+            result.push((&self.value, *v));
         }
-
-        if self.value.is_eq_sort() {
-            for value in map.values() {
-                f(*value)
-            }
-        }
+        result
     }
+
 
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {
         let maps = self.maps.lock().unwrap();

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -62,8 +62,7 @@ impl Sort for MapSort {
         self.key.is_eq_sort() || self.value.is_eq_sort()
     }
 
-
-    fn inner_values(&self, value: &Value) -> Vec<(&ArcSort, Value)>   {
+    fn inner_values(&self, value: &Value) -> Vec<(&ArcSort, Value)> {
         let maps = self.maps.lock().unwrap();
         let map = maps.get_index(value.bits as usize).unwrap();
         let mut result = Vec::new();
@@ -73,7 +72,6 @@ impl Sort for MapSort {
         }
         result
     }
-
 
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {
         let maps = self.maps.lock().unwrap();

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -73,24 +73,6 @@ impl Sort for MapSort {
         result
     }
 
-    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
-        // TODO: Potential duplication of code
-        let maps = self.maps.lock().unwrap();
-        let map = maps.get_index(value.bits as usize).unwrap();
-
-        if self.key.is_eq_sort() {
-            for key in map.keys() {
-                f(*key)
-            }
-        }
-
-        if self.value.is_eq_sort() {
-            for value in map.values() {
-                f(*value)
-            }
-        }
-    }
-
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {
         let maps = self.maps.lock().unwrap();
         let map = maps.get_index(value.bits as usize).unwrap();

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -42,10 +42,12 @@ pub trait Sort: Any + Send + Sync + Debug {
 
     // Only eq_container_sort need to implement this method,
     // which returns a list of ids to be tracked.
-    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, f: Box<dyn FnMut(Value) + 'a>) {
-        let _ = value;
-        let _ = f;
-        unreachable!();
+    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
+        for (sort, value) in self.inner_values(value) {
+            if sort.is_eq_sort() {
+                f(value)
+            }
+        }
     }
 
     // Sort-wise canonicalization. Return true if value is modified.

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -62,7 +62,7 @@ pub trait Sort: Any + Send + Sync + Debug {
     /// Only eq_container_sort need to implement this method,
     fn inner_values(&self, value: &Value) -> Vec<(&ArcSort, Value)> {
         let _ = value;
-        unreachable!();
+        vec![]
     }
 
     fn register_primitives(self: Arc<Self>, info: &mut TypeInfo) {

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -42,10 +42,12 @@ pub trait Sort: Any + Send + Sync + Debug {
 
     // Only eq_container_sort need to implement this method,
     // which returns a list of ids to be tracked.
-    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, f: Box<dyn FnMut(Value) + 'a>) {
-        let _ = value;
-        let _ = f;
-        unreachable!();
+    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
+        for (sort, value) in self.inner_values(value) {
+            if sort.is_eq_sort() {
+                f(value)
+            }
+        }
     }
 
     // Sort-wise canonicalization. Return true if value is modified.
@@ -54,6 +56,13 @@ pub trait Sort: Any + Send + Sync + Debug {
         debug_assert_eq!(self.name(), value.tag);
         let _ = unionfind;
         false
+    }
+
+    /// Return the inner values and sorts.
+    /// Only eq_container_sort need to implement this method,
+    fn inner_values(&self, value: &Value) -> Vec<(&ArcSort, Value)> {
+        let _ = value;
+        unreachable!();
     }
 
     fn register_primitives(self: Arc<Self>, info: &mut TypeInfo) {

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -42,12 +42,10 @@ pub trait Sort: Any + Send + Sync + Debug {
 
     // Only eq_container_sort need to implement this method,
     // which returns a list of ids to be tracked.
-    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
-        for (sort, value) in self.inner_values(value) {
-            if sort.is_eq_sort() {
-                f(value)
-            }
-        }
+    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, f: Box<dyn FnMut(Value) + 'a>) {
+        let _ = value;
+        let _ = f;
+        unreachable!();
     }
 
     // Sort-wise canonicalization. Return true if value is modified.

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -70,18 +70,6 @@ impl Sort for SetSort {
         result
     }
 
-    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
-        // TODO: Potential duplication of code
-        let sets = self.sets.lock().unwrap();
-        let set = sets.get_index(value.bits as usize).unwrap();
-
-        if self.element.is_eq_sort() {
-            for e in set.iter() {
-                f(*e)
-            }
-        }
-    }
-
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {
         let sets = self.sets.lock().unwrap();
         let set = sets.get_index(value.bits as usize).unwrap();

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -70,6 +70,18 @@ impl Sort for SetSort {
         result
     }
 
+    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
+        // TODO: Potential duplication of code
+        let sets = self.sets.lock().unwrap();
+        let set = sets.get_index(value.bits as usize).unwrap();
+
+        if self.element.is_eq_sort() {
+            for e in set.iter() {
+                f(*e)
+            }
+        }
+    }
+
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {
         let sets = self.sets.lock().unwrap();
         let set = sets.get_index(value.bits as usize).unwrap();

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -64,7 +64,7 @@ impl Sort for SetSort {
         let sets = self.sets.lock().unwrap();
         let set = sets.get_index(value.bits as usize).unwrap();
         let mut result = Vec::new();
-        for e in set.into_iter() {
+        for e in set.iter() {
             result.push((&self.element, *e));
         }
         result

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -59,16 +59,15 @@ impl Sort for SetSort {
         self.element.is_eq_sort()
     }
 
-    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
+    fn inner_values(&self, value: &Value) -> Vec<(&ArcSort, Value)> {
         // TODO: Potential duplication of code
         let sets = self.sets.lock().unwrap();
         let set = sets.get_index(value.bits as usize).unwrap();
-
-        if self.element.is_eq_sort() {
-            for e in set.iter() {
-                f(*e)
-            }
+        let mut result = Vec::new();
+        for e in set.into_iter() {
+            result.push((&self.element, *e));
         }
+        result
     }
 
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -58,16 +58,15 @@ impl Sort for VecSort {
         self.element.is_eq_sort()
     }
 
-    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
+    fn inner_values(&self, value: &Value) -> Vec<(&ArcSort, Value)> {
         // TODO: Potential duplication of code
         let vecs = self.vecs.lock().unwrap();
         let vec = vecs.get_index(value.bits as usize).unwrap();
-
-        if self.element.is_eq_sort() {
-            for e in vec.iter() {
-                f(*e)
-            }
+        let mut result: Vec<(&Arc<dyn Sort>, Value)> = Vec::new();
+        for e in vec.into_iter() {
+            result.push((&self.element, *e));
         }
+        result
     }
 
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -57,6 +57,7 @@ impl Sort for VecSort {
     fn is_eq_container_sort(&self) -> bool {
         self.element.is_eq_sort()
     }
+
     fn inner_values(&self, value: &Value) -> Vec<(&ArcSort, Value)> {
         // TODO: Potential duplication of code
         let vecs = self.vecs.lock().unwrap();
@@ -66,18 +67,6 @@ impl Sort for VecSort {
             result.push((&self.element, *e));
         }
         result
-    }
-
-    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
-        // TODO: Potential duplication of code
-        let vecs = self.vecs.lock().unwrap();
-        let vec = vecs.get_index(value.bits as usize).unwrap();
-
-        if self.element.is_eq_sort() {
-            for e in vec.iter() {
-                f(*e)
-            }
-        }
     }
 
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -57,7 +57,6 @@ impl Sort for VecSort {
     fn is_eq_container_sort(&self) -> bool {
         self.element.is_eq_sort()
     }
-
     fn inner_values(&self, value: &Value) -> Vec<(&ArcSort, Value)> {
         // TODO: Potential duplication of code
         let vecs = self.vecs.lock().unwrap();
@@ -67,6 +66,18 @@ impl Sort for VecSort {
             result.push((&self.element, *e));
         }
         result
+    }
+
+    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
+        // TODO: Potential duplication of code
+        let vecs = self.vecs.lock().unwrap();
+        let vec = vecs.get_index(value.bits as usize).unwrap();
+
+        if self.element.is_eq_sort() {
+            for e in vec.iter() {
+                f(*e)
+            }
+        }
     }
 
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -63,7 +63,7 @@ impl Sort for VecSort {
         let vecs = self.vecs.lock().unwrap();
         let vec = vecs.get_index(value.bits as usize).unwrap();
         let mut result: Vec<(&Arc<dyn Sort>, Value)> = Vec::new();
-        for e in vec.into_iter() {
+        for e in vec.iter() {
             result.push((&self.element, *e));
         }
         result

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -12,7 +12,7 @@ use std::mem;
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde-1", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnionFind {
-    pub(crate) parents: Vec<Cell<Id>>,
+    parents: Vec<Cell<Id>>,
     n_unions: usize,
     recent_ids: HashMap<Symbol, Vec<Id>>,
     staged_ids: HashMap<Symbol, Vec<Id>>,

--- a/tests/eqsat-basic.egg
+++ b/tests/eqsat-basic.egg
@@ -5,7 +5,7 @@
   (Mul Math Math))
 
 ;; expr1 = 2 * (x + 3)
-(define expr1 (Mul (Num 2) (Add (Var "x") (Num 3)))) 
+(define expr1 (Mul (Num 2) (Add (Var "x") (Num 3))))
 ;; expr2 = 6 + 2 * x
 (define expr2 (Add (Num 6) (Mul (Num 2) (Var "x"))))
 
@@ -16,7 +16,7 @@
          (Add b a))
 (rewrite (Mul a (Add b c))
          (Add (Mul a b) (Mul a c)))
-(rewrite (Add (Num a) (Num b)) 
+(rewrite (Add (Num a) (Num b))
          (Num (+ a b)))
 (rewrite (Mul (Num a) (Num b))
          (Num (* a b)))

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -62,7 +62,7 @@ impl Run {
                     for msg in msgs {
                         log::info!("  {}", msg);
                     }
-                    egraph.to_graphviz_string(egg_smol::IncludeTempFunctions::Never);
+                    egraph.to_graphviz_string();
                 }
             }
             Err(err) => {

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -55,6 +55,7 @@ impl Run {
                     for msg in msgs {
                         log::info!("  {}", msg);
                     }
+                    egraph.to_graphviz_string();
                 }
             }
             Err(err) => {

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -62,7 +62,7 @@ impl Run {
                     for msg in msgs {
                         log::info!("  {}", msg);
                     }
-                    egraph.to_graphviz_string();
+                    egraph.to_graphviz_string(egg_smol::IncludeTempFunctions::Never);
                 }
             }
             Err(err) => {

--- a/web-demo/src/lib.rs
+++ b/web-demo/src/lib.rs
@@ -7,7 +7,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 #[wasm_bindgen(getter_with_clone)]
 pub struct Result {
     pub text: String,
-    pub dot: String
+    pub dot: String,
 }
 
 #[wasm_bindgen]
@@ -24,10 +24,9 @@ pub fn run_program(input: &str) -> Result {
         Err(e) => {
             log::info!("egg failed");
             Result {
-                text:  e.to_string(),
+                text: e.to_string(),
                 dot: "".to_string(),
             }
-
         }
     }
 }

--- a/web-demo/src/lib.rs
+++ b/web-demo/src/lib.rs
@@ -4,17 +4,30 @@ use wasm_bindgen::prelude::*;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
+#[wasm_bindgen(getter_with_clone)]
+pub struct Result {
+    pub text: String,
+    pub dot: String
+}
+
 #[wasm_bindgen]
-pub fn run_program(input: &str) -> String {
+pub fn run_program(input: &str) -> Result {
     let mut egraph = egg_smol::EGraph::default();
     match egraph.parse_and_run_program(input) {
         Ok(outputs) => {
             log::info!("egg ok, {} outputs", outputs.len());
-            outputs.join("<br>")
+            Result {
+                text: outputs.join("<br>"),
+                dot: egraph.to_graphviz_string(),
+            }
         }
         Err(e) => {
             log::info!("egg failed");
-            e.to_string()
+            Result {
+                text:  e.to_string(),
+                dot: "".to_string(),
+            }
+
         }
     }
 }

--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -23,7 +23,6 @@
         }
 
         #panel {
-            padding: 10px;
             flex: 1 1 0;
             border-left: 2px solid gray;
 
@@ -31,32 +30,53 @@
             flex-flow: column;
         }
 
+        #toolbar {
+            padding: 10px;
+        }
+
         #toolbar button {
             margin-right: 5px;
         }
 
         #output {
+            padding-left: 10px;
             font-family: monospace;
-            margin-top: 10px;
-            flex-grow: 1;
             white-space: pre-wrap;
             overflow-y: scroll;
+            resize: vertical;
+            height: 60%;
+        }
+
+        #graph {
+            border-top: 2px solid gray;
+            flex-grow: 1;
         }
     </style>
 
     <link rel="stylesheet" href="//unpkg.com/codemirror@5.65.2/lib/codemirror.css">
     <script src="//unpkg.com/codemirror@5.65.2/lib/codemirror.js"></script>
-
+    <script src="https://unpkg.com/@hpcc-js/wasm/dist/graphviz.umd.js" type="javascript/worker"></script>
+    <script type="importmap">
+        {
+          "imports": {
+            "d3": "https://cdn.skypack.dev/pin/d3@v7.8.4-U7lzM69QcKPxzv4xSvs7/mode=imports,min/optimized/d3.js",
+            "d3-graphviz": "https://cdn.skypack.dev/pin/d3-graphviz@v5.0.2-ZoIcpbOADQcAxREohmOW/mode=imports,min/optimized/d3-graphviz.js"
+          }
+        }
+      </script>
     <script type="module">
-        import { compressUrlSafe, decompressUrlSafe } from './lzma-url.mjs'
+        import * as d3 from 'd3';
+        import 'd3-graphviz';
 
         let editor, output, examples;
-
         console.log("Main script is running");
         let worker = new Worker("worker.js");
         worker.onmessage = function (message) {
             console.log("got message", message);
-            output.innerHTML = message.data;
+            output.innerHTML = message.data.text;
+            d3.select("#graph")
+                .graphviz()
+                .renderDot(message.data.dot);
         }
 
         window.onpopstate = function (event) {
@@ -168,6 +188,7 @@
             </select>
         </div>
         <div id="output">Click "Run" to run code</div>
+        <div id="graph"></div>
     </div>
 </body>
 

--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -91,6 +91,8 @@
                 .width(width)
                 .height(height)
                 .fit(true)
+                .tweenShapes(false)
+                .tweenPaths(false)
                 // .scale(0.9)
                 .renderDot(message.data.dot);
         }

--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -79,6 +79,7 @@
     <script src="//unpkg.com/codemirror@5.65.2/lib/codemirror.js"></script>
     <script src="https://unpkg.com/@hpcc-js/wasm/dist/graphviz.umd.js" type="javascript/worker"></script>
     <script type="module">
+        import { compressUrlSafe, decompressUrlSafe } from './lzma-url.mjs';
         import * as d3 from 'https://cdn.skypack.dev/pin/d3@v7.8.4-U7lzM69QcKPxzv4xSvs7/mode=imports,min/optimized/d3.js';
         import 'https://cdn.skypack.dev/pin/d3-graphviz@v5.0.2-ZoIcpbOADQcAxREohmOW/mode=imports,min/optimized/d3-graphviz.js';
 

--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -50,6 +50,16 @@
         #graph {
             border-top: 2px solid gray;
             flex-grow: 1;
+            position: relative;
+            overflow: auto;
+        }
+        /* Don't let graph expand https://stackoverflow.com/a/38852981/907060 */
+        #graph-inner {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
         }
     </style>
 
@@ -74,8 +84,14 @@
         worker.onmessage = function (message) {
             console.log("got message", message);
             output.innerHTML = message.data.text;
-            d3.select("#graph")
-                .graphviz()
+            const graphContainer = d3.select("#graph-inner")
+            const width = graphContainer.node().clientWidth;
+            const height = graphContainer.node().clientHeight;
+            graphContainer.graphviz()
+                .width(width)
+                .height(height)
+                .fit(true)
+                // .scale(0.9)
                 .renderDot(message.data.dot);
         }
 
@@ -188,7 +204,9 @@
             </select>
         </div>
         <div id="output">Click "Run" to run code</div>
-        <div id="graph"></div>
+        <div id="graph">
+            <div id="graph-inner"></div>
+        </div>
     </div>
 </body>
 

--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -100,7 +100,7 @@
                 .transition(d3.transition().duration(2000))
                 .dot(message.data.dot).render();
             // If we have made a zoom selection, reset that before transitioning
-            // TODO: figure out how to transition BOTH zoom an dot at once
+            // TODO: figure out how to transition BOTH zoom and dot at once
             if (graphviz._zoomSelection) {
                 graphviz.resetZoom();
             }

--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -88,12 +88,16 @@
             const width = graphContainer.node().clientWidth;
             const height = graphContainer.node().clientHeight;
             graphContainer.graphviz()
+                // Set to be as big as container
                 .width(width)
                 .height(height)
+                // Fit graph to that size, so that all is visible
                 .fit(true)
+                // Don't animate transitions between shapes for performance
                 .tweenShapes(false)
                 .tweenPaths(false)
-                // .scale(0.9)
+                // Transition between graphs
+                .transition(d3.transition().duration(2000))
                 .renderDot(message.data.dot);
         }
 

--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -87,18 +87,23 @@
             const graphContainer = d3.select("#graph-inner")
             const width = graphContainer.node().clientWidth;
             const height = graphContainer.node().clientHeight;
-            graphContainer.graphviz()
-                // Set to be as big as container
-                .width(width)
-                .height(height)
+            const graphviz = graphContainer.graphviz({
                 // Fit graph to that size, so that all is visible
-                .fit(true)
+                fit: true,
+                // Set to be as big as container
+                width,
+                height,
                 // Don't animate transitions between shapes for performance
-                .tweenShapes(false)
-                .tweenPaths(false)
-                // Transition between graphs
+                tweenPaths: false,
+                tweenShapes: false,
+            })
                 .transition(d3.transition().duration(2000))
-                .renderDot(message.data.dot);
+                .dot(message.data.dot).render();
+            // If we have made a zoom selection, reset that before transitioning
+            // TODO: figure out how to transition BOTH zoom an dot at once
+            if (graphviz._zoomSelection) {
+                graphviz.resetZoom();
+            }
         }
 
         window.onpopstate = function (event) {

--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -78,17 +78,9 @@
     <link rel="stylesheet" href="//unpkg.com/codemirror@5.65.2/lib/codemirror.css">
     <script src="//unpkg.com/codemirror@5.65.2/lib/codemirror.js"></script>
     <script src="https://unpkg.com/@hpcc-js/wasm/dist/graphviz.umd.js" type="javascript/worker"></script>
-    <script type="importmap">
-        {
-          "imports": {
-            "d3": "https://cdn.skypack.dev/pin/d3@v7.8.4-U7lzM69QcKPxzv4xSvs7/mode=imports,min/optimized/d3.js",
-            "d3-graphviz": "https://cdn.skypack.dev/pin/d3-graphviz@v5.0.2-ZoIcpbOADQcAxREohmOW/mode=imports,min/optimized/d3-graphviz.js"
-          }
-        }
-      </script>
     <script type="module">
-        import * as d3 from 'd3';
-        import 'd3-graphviz';
+        import * as d3 from 'https://cdn.skypack.dev/pin/d3@v7.8.4-U7lzM69QcKPxzv4xSvs7/mode=imports,min/optimized/d3.js';
+        import 'https://cdn.skypack.dev/pin/d3-graphviz@v5.0.2-ZoIcpbOADQcAxREohmOW/mode=imports,min/optimized/d3-graphviz.js';
 
         let editor, output, examples;
         console.log("Main script is running");

--- a/web-demo/static/worker.js
+++ b/web-demo/static/worker.js
@@ -9,7 +9,7 @@ async function work() {
     self.onmessage = async event => {
         try {
             let result = run_program(event.data);
-            console.log("Got result from worker");
+            console.log("Got result from worker", result);
             // Can't send the result directly, since it contains a reference to the
             // wasm memory. Instead, we send the dot and text separately.
             self.postMessage({dot: result.dot, text: result.text});

--- a/web-demo/static/worker.js
+++ b/web-demo/static/worker.js
@@ -10,10 +10,12 @@ async function work() {
         try {
             let result = run_program(event.data);
             console.log("Got result from worker");
-            self.postMessage(result);
+            // Can't send the result directly, since it contains a reference to the
+            // wasm memory. Instead, we send the dot and text separately.
+            self.postMessage({dot: result.dot, text: result.text});
         } catch (error) {
             console.log(error);
-            self.postMessage("Something panicked! Check the console logs...");
+            self.postMessage({dot: "", text: "Something panicked! Check the console logs..."});
         }
     };
 }


### PR DESCRIPTION
Adds the ability to visualize the state of an `EGraph` using Graphviz (addressing #144).

Goals:

* Help educate new users on what e-graphs are and how egglog implements them
* Help with debugging the state of an e-graph after some transitions
* Serve as a launching point for interactive visualizations down the road

Features:

* Colors each cluster based on it's sort
* Caps size of graph to reduce memory/time blowups with unreadable output
* Shows container values as nodes by adding `inner_values` method to `Sort`s
* Creates intermediate graph IR before encoding to graphviz. Could be exposed at a later time to allow other visualization frontends from say Python.
* Adds visualizer to web view, with dynamic transitions, and ability to pan and zoom.
* Adds CLI flags `--output-dot` and `--output-svg` to visualize any program
* Adds `make graphs` command to create SVG & dots of all examples
* Tests graph creation in CI

Possible next steps/follow-up issues:

* Graphviz does not allow edges to point to a cluster directly. [The best we can do is point to a node in the cluster and then set the `lhead` to clip at the cluster edge](https://graphviz.org/faq/#FaqClusterEdge). Currently we are doing a round-robin to point to nodes in each e-cluster. 
* Currently, e-classes that have nodes that point to themselves aren't rendered that well. The arrow won't stop at the cluster edge, but instead point directly to one of the nodes in the e-class. This is a [known issue with graphviz edges in clusters](https://stackoverflow.com/questions/46646181/connect-graphviz-cluster-to-itself). There are some workarounds in that linked issue we could explore.
* If we create a subgraph with `push` or `simplify` than that graph will not be included in the resulting graphviz. 

## Examples

### `eqsat-basic` in web viewer

<img width="1641" alt="Screenshot 2023-06-07 at 1 43 16 PM" src="https://github.com/egraphs-good/egglog/assets/1186124/1bf0f34a-7604-41f8-af6e-b1bec1468418">

It will also transition between graphs smoothly:

https://github.com/egraphs-good/egglog/assets/1186124/f83c9bc6-7c33-42d5-ae0f-6cd2661cf3f5

### `eqsat-basic`
![eqsat-basic](https://github.com/egraphs-good/egglog/assets/1186124/a8527002-e446-41f0-b4ee-31091bfe3cf1)

### `fibonacci`

![fibonacci](https://github.com/egraphs-good/egglog/assets/1186124/919c43d1-02e5-4085-9f2c-b41d6794014b)


### `fibonacci-demand`
![fibonacci-demand](https://github.com/egraphs-good/egglog/assets/1186124/14fbc6d9-5666-4b36-bdd1-40ebdb9fcda4)


### `map`
![map](https://github.com/egraphs-good/egglog/assets/1186124/ac1b47e3-0e58-4ac7-bf9a-7df4b840318c)


### `rw-analysis`
![rw-analysis](https://github.com/egraphs-good/egglog/assets/1186124/4380aad6-0c7a-444d-b617-fb332c168527)


### `proofs`
![proofs](https://github.com/egraphs-good/egglog/assets/1186124/0dc36af8-ded8-4689-a00d-62e95f5b1b39)



<details><summary><h3>eqsat-basic in Python</h3></summary>
<p>

I've also been working on some Python examples, though they're not part of this PR.  I wanted to show them here to just give a sense of how that could work eventually:

*note that these screenshots were taken at a @recursecenter presentation previously and don't reflect the current graphviz styles*

In [this notebook](https://gist.github.com/saulshanabrook/b711f6f0f0d0db60aed64bc8da22774f#file-eqsat-basic-ipynb) we can see how the graph changes before and after running:
![Screenshot 2023-05-15 at 4 05 02 PM](https://github.com/egraphs-good/egglog/assets/1186124/069f092b-f751-4853-87f3-4d661bf7eec1)


In [this other notebook](https://gist.github.com/saulshanabrook/b711f6f0f0d0db60aed64bc8da22774f#file-graphviz-interacitve-ipynb) we use [`d3-graphviz`](https://github.com/magjac/d3-graphviz) to animate the transitions between different graphs, doing one run in between each snapshot:

https://github.com/egraphs-good/egglog/assets/1186124/ad63c29f-59c2-4d95-8b4b-705491539aa9




</p>
</details> 

<details><summary><h2>TODO</h2></summary>
<p>

- [x] Resolve all clippy errors
- [x] Rename `Graph` to something more descriptive such as`EGraphState` or `ExportedEGraph`
- [x] Initially, keep `Graph` structure private to this crate. This could later be useful for the Python bindings to use with other visualization formats like [cytoscape.js](https://js.cytoscape.org/)
- [x] Add CLI commands to output `.dot` as well as `.svg`, instead of always emitting it
- [x] Test graph output on all examples (`make test-graphs`)
- [x] Investigate why some functions are added twice (realized it was based on ordering of arguments)
- [x] Make style closer to [e-graphs good website](https://egraphs-good.github.io/), by making e-class borders dotted, and decreasing size of arrowheads, making nodes square, and making borders round
- [x] Ensure all docstrings comments have `///`
- [x] Make node IDs stable
- [x] Fix self arrows (to make `lhead` work with self arrows, seem to [need a dummy point](https://stackoverflow.com/questions/46646181/connect-graphviz-cluster-to-itself) outside the cluster, which ends up looking odd, so leaving as is for now)
- [x] Switch functions that return built-in values to represent those as nodes instead of as strings, so that we can represent those that points to eqsats, like maps, sets, or vecs.
- [x] Position where arrows are coming from based on argument ordering.
- [x] Add graphviz to web
- [x] on web, set size to size of container
- [x] On web, animate transitions
- [x] On web, test on large graphs
- [x] Fix proof execution
- [x] Add CLI flag to switch between showing temp nodes, and not
- [x] Fix inconsistent node spacing
- [x] Switch so that unit isn't combined
- [x] add sort as cluster label
- [x] change outline of clusters which are e-classes vs not
- [x] try adding colors based on sort of clusters
- [x] Change font of nodes to helvetica


</p>
</details> 
