### PR TITLE
Fix subtleties in rebuilding

### DIFF
--- a/src/function/index.rs
+++ b/src/function/index.rs
@@ -79,8 +79,8 @@ impl CompositeColumnIndex {
     }
 
     pub(crate) fn add(&mut self, v: Value, i: usize) {
-        if let Some(i) = self.0.iter().position(|index| index.sort() == v.tag) {
-            (self.0)[i].add(v, i);
+        if let Some(index) = self.0.iter().position(|index| index.sort() == v.tag) {
+            (self.0)[index].add(v, i);
         } else {
             let mut index = ColumnIndex::new(v.tag);
             index.add(v, i);

--- a/src/function/table.rs
+++ b/src/function/table.rs
@@ -221,15 +221,6 @@ impl Table {
         true
     }
 
-    /// Remove the entry at the given offset from the table.
-    pub(crate) fn remove_index(&mut self, i: usize, ts: u32) {
-        let (inp, _) = &mut self.vals[i];
-        if inp.live() {
-            inp.stale_at = ts;
-            self.n_stale += 1;
-        }
-    }
-
     /// Returns the entries at the given index if the entry is live and the index in bounds.
     pub(crate) fn get_index(&self, i: usize) -> Option<(&[Value], &TupleOutput)> {
         let (inp, out) = self.vals.get(i)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,7 @@ impl EGraph {
             MergeFn::Expr(e) => Some(e.clone()),
             MergeFn::AssertEq | MergeFn::Union => None,
         };
+
         for (inputs, old, new) in merges {
             if let Some(prog) = function.merge.on_merge.clone() {
                 self.run_actions(&mut stack, &[*old, *new], &prog, true)


### PR DESCRIPTION
Fixes a couple small bugs:

The method `rebuild_at` was slightly wrong in a couple ways:
1. Merge functions should run on canonicalized values, meaning we should take the previous value in a given function row and canonicalize it before merging it.
2. We should not unconditionally remove the old row in a table: the keys to a row may not have changed. Instead, run the merge function first and only remove the old row if needed. 

On top of that there was (I think) an unintentional variable shadowing in the `add` method for "composite" indexes.

Fixes #121 