### PR TITLE
Vec fix, tests, and improvements

### DIFF
--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -135,7 +135,7 @@ impl Sort for VecSort {
         let mut expr = Expr::call("vec-empty", []);
         for e in vec.iter().rev() {
             let e = egraph.extract(*e, &self.element).1;
-            expr = Expr::call("vec-insert", [expr, e])
+            expr = Expr::call("vec-push", [expr, e])
         }
         expr
     }

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -115,9 +115,19 @@ impl Sort for VecSort {
         });
         typeinfo.add_primitive(Contains {
             name: "vec-contains".into(),
-            vec: self,
+            vec: self.clone(),
             unit: typeinfo.get_sort(),
         });
+        typeinfo.add_primitive(Length {
+            name: "vec-length".into(),
+            vec: self.clone(),
+            i64: typeinfo.get_sort(),
+        });
+        typeinfo.add_primitive(Get {
+            name: "vec-get".into(),
+            vec: self,
+            i64: typeinfo.get_sort(),
+        })
     }
 
     fn make_expr(&self, egraph: &EGraph, value: Value) -> Expr {
@@ -331,5 +341,56 @@ impl PrimitiveLike for Contains {
         } else {
             None
         }
+    }
+}
+
+struct Length {
+    name: Symbol,
+    vec: Arc<VecSort>,
+    i64: Arc<I64Sort>,
+}
+
+impl PrimitiveLike for Length {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
+        match types {
+            [vec] if vec.name() == self.vec.name => Some(self.i64.clone()),
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        let vec = ValueVec::load(&self.vec, &values[0]);
+        Some(Value::from(vec.len() as i64))
+    }
+}
+
+struct Get {
+    name: Symbol,
+    vec: Arc<VecSort>,
+    i64: Arc<I64Sort>,
+}
+
+impl PrimitiveLike for Get {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
+        match types {
+            [vec, index] if (vec.name(), index.name()) == (self.vec.name, "i64".into()) => {
+                Some(self.vec.element.clone())
+            }
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        let vec = ValueVec::load(&self.vec, &values[0]);
+        let index = i64::load(&self.i64, &values[1]);
+        vec.get(index as usize).copied()
     }
 }

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -46,7 +46,7 @@ impl Default for TypeInfo {
         res.add_sort(RationalSort::new("Rational".into()));
         res.presorts.insert("Map".into(), MapSort::make_sort);
         res.presorts.insert("Set".into(), SetSort::make_sort);
-        res.presorts.insert("Vec".into(), SetSort::make_sort);
+        res.presorts.insert("Vec".into(), VecSort::make_sort);
         res
     }
 }

--- a/tests/vec.egg
+++ b/tests/vec.egg
@@ -1,0 +1,16 @@
+(sort IVec (Vec i64))
+
+; Test vec-of
+(check (= (vec-of 1 2) (vec-push (vec-push (vec-empty) 1) 2)))
+
+; Test vec-append
+(check (= (vec-append (vec-of 1 2) (vec-of 3 4)) (vec-of 1 2 3 4)))
+
+; Test vec-pop
+(check (= (vec-pop (vec-of 1 2 3)) (vec-of 1 2)))
+
+; Test vec-not-contains
+(check (vec-not-contains (vec-of 1 2 3) 4))
+
+; Test vec-contains
+(check (vec-contains (vec-of 1 2 3) 2))

--- a/tests/vec.egg
+++ b/tests/vec.egg
@@ -14,3 +14,9 @@
 
 ; Test vec-contains
 (check (vec-contains (vec-of 1 2 3) 2))
+
+; Test length
+(check (= (vec-length (vec-of 1 2 3)) 3))
+
+; Test vec-get
+(check (= (vec-get (vec-of 1 2 3) 1) 2))


### PR DESCRIPTION
* Fixes a typo so that the `Vec` sort will register a Vec instead of a Set
* Fixes the function name for extracted vecs
* Adds test for existing Vec methods
* Add vec get and length (closes #152)