### PR TITLE
Add string concatenation

### DIFF
--- a/tests/string.egg
+++ b/tests/string.egg
@@ -1,0 +1,2 @@
+; Tests for the string sort
+(check (= (+ "a" "bc" "de") "abcde"))


### PR DESCRIPTION
This PR adds support for string concatenation and a test for it. It uses the `+` function which is already overloaded for integers and floats.