### PR TITLE
Builtin Lambda Calculus Experiment

### DIFF
--- a/src/function/table.rs
+++ b/src/function/table.rs
@@ -51,7 +51,7 @@ pub(crate) struct Table {
     max_ts: u32,
     n_stale: usize,
     table: RawTable<TableOffset>,
-    vals: Vec<(Input, TupleOutput)>,
+    pub(crate) vals: Vec<(Input, TupleOutput)>,
 }
 
 /// Used for the RawTable probe sequence.
@@ -304,7 +304,7 @@ fn hash_values(vs: &[Value]) -> u64 {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct Input {
+pub(crate) struct Input {
     data: ValueVec,
     /// The timestamp at which the given input became "stale"
     stale_at: u32,

--- a/src/gj.rs
+++ b/src/gj.rs
@@ -183,7 +183,7 @@ impl<'b> Context<'b> {
                     })
                 }
 
-                if let Some(res) = prim.apply(&values) {
+                if let Some(res) = prim.apply(&values, None) {
                     match out {
                         AtomTerm::Var(v) => {
                             let i = self.query.vars.get_index_of(v).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -817,7 +817,8 @@ impl EGraph {
             NCommand::Sort(name, _presort_and_args) => {
                 let arcsort = self.proof_state.type_info.sorts.get(&name).unwrap().clone();
                 arcsort.register_egraph(self);
-                format!("Declared sort {}.", name)},
+                format!("Declared sort {}.", name)
+            }
             NCommand::Function(fdecl) => {
                 self.declare_function(&fdecl, false)?;
                 format!("Declared function {}.", fdecl.name)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -814,7 +814,10 @@ impl EGraph {
                 str
             }
             // Sorts are already declared during typechecking
-            NCommand::Sort(name, _presort_and_args) => format!("Declared sort {}.", name),
+            NCommand::Sort(name, _presort_and_args) => {
+                let arcsort = self.proof_state.type_info.sorts.get(&name).unwrap().clone();
+                arcsort.register_egraph(self);
+                format!("Declared sort {}.", name)},
             NCommand::Function(fdecl) => {
                 self.declare_function(&fdecl, false)?;
                 format!("Declared function {}.", fdecl.name)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub type Subst = IndexMap<Symbol, Value>;
 pub trait PrimitiveLike {
     fn name(&self) -> Symbol;
     fn accept(&self, types: &[ArcSort]) -> Option<ArcSort>;
-    fn apply(&self, values: &[Value], unionfind: Option<&mut UnionFind>) -> Option<Value>;
+    fn apply(&self, values: &[Value], egraph: Option<&mut EGraph>) -> Option<Value>;
 }
 
 #[derive(Debug, Clone, Default)]
@@ -144,7 +144,7 @@ impl PrimitiveLike for SimplePrimitive {
             .all(|(a, b)| a.name() == b.name())
             .then(|| self.output.clone())
     }
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         (self.f)(values)
     }
 }
@@ -152,9 +152,9 @@ impl PrimitiveLike for SimplePrimitive {
 #[derive(Clone)]
 pub struct EGraph {
     egraphs: Vec<Self>,
-    unionfind: UnionFind,
+    pub(crate) unionfind: UnionFind,
     pub(crate) proof_state: ProofState,
-    functions: HashMap<Symbol, Function>,
+    pub(crate) functions: HashMap<Symbol, Function>,
     rulesets: HashMap<Symbol, HashMap<Symbol, Rule>>,
     proofs_enabled: bool,
     interactive_mode: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub type Subst = IndexMap<Symbol, Value>;
 pub trait PrimitiveLike {
     fn name(&self) -> Symbol;
     fn accept(&self, types: &[ArcSort]) -> Option<ArcSort>;
-    fn apply(&self, values: &[Value]) -> Option<Value>;
+    fn apply(&self, values: &[Value], unionfind: Option<&mut UnionFind>) -> Option<Value>;
 }
 
 #[derive(Debug, Clone, Default)]
@@ -144,7 +144,7 @@ impl PrimitiveLike for SimplePrimitive {
             .all(|(a, b)| a.name() == b.name())
             .then(|| self.output.clone())
     }
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         (self.f)(values)
     }
 }

--- a/src/sort/lambda.rs
+++ b/src/sort/lambda.rs
@@ -1,0 +1,251 @@
+use std::{collections::BTreeMap, sync::Mutex};
+
+use super::*;
+
+#[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
+struct ValueLambda {
+    var_id: Id,
+    body: Value,
+}
+
+#[derive(Debug)]
+pub struct LambdaSort {
+    name: Symbol,
+    input: ArcSort,
+    output: ArcSort,
+    lambdas: Mutex<IndexSet<ValueLambda>>,
+    // Map from vars to their ID
+    symbol_to_id: Mutex<BTreeMap<Symbol, Id>>,
+    // Inverse map
+    id_to_symbol: Mutex<BTreeMap<Id, Symbol>>,
+}
+
+impl LambdaSort {
+    pub fn make_sort(
+        typeinfo: &mut TypeInfo,
+        name: Symbol,
+        args: &[Expr],
+    ) -> Result<ArcSort, TypeError> {
+        if let [Expr::Var(input), Expr::Var(output)] = args {
+            let input = typeinfo
+                .sorts
+                .get(input)
+                .ok_or(TypeError::UndefinedSort(*input))?;
+            let output = typeinfo
+                .sorts
+                .get(output)
+                .ok_or(TypeError::UndefinedSort(*output))?;
+
+            if output.is_eq_container_sort() {
+                return Err(TypeError::UndefinedSort(
+                    "Lambdasreturning other EqSort containers are not allowed".into(),
+                ));
+            }
+
+            Ok(Arc::new(Self {
+                name,
+                input: input.clone(),
+                output: output.clone(),
+                lambdas: Default::default(),
+                symbol_to_id: Default::default(),
+                id_to_symbol: Default::default(),
+            }))
+        } else {
+            panic!()
+        }
+    }
+}
+
+impl Sort for LambdaSort {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
+        self
+    }
+
+    fn is_container_sort(&self) -> bool {
+        true
+    }
+
+    fn is_eq_container_sort(&self) -> bool {
+        self.output.is_eq_sort()
+    }
+
+    fn foreach_tracked_values<'a>(&'a self, value: &'a Value, mut f: Box<dyn FnMut(Value) + 'a>) {
+        // TODO: Potential duplication of code
+        let lambdas = self.lambdas.lock().unwrap();
+        let lambda = lambdas.get_index(value.bits as usize).unwrap();
+
+        if self.output.is_eq_sort() {
+            f(lambda.body)
+        }
+    }
+
+    fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {
+        println!("Canonicalizing lambda");
+        let lambdas = self.lambdas.lock().unwrap();
+        let lambda = lambdas.get_index(value.bits as usize).unwrap();
+        let mut body = lambda.body;
+        let changed = self.output.canonicalize(&mut body, unionfind);
+        let new_lambda = ValueLambda {
+            var_id: lambda.var_id,
+            body,
+        };
+        // drop(lambda);
+        *value = new_lambda.store(self).unwrap();
+        changed
+    }
+
+    fn register_primitives(self: Arc<Self>, typeinfo: &mut TypeInfo) {
+        typeinfo.add_primitive(Lambda {
+            name: "lambda".into(),
+            lambda: self.clone(),
+        });
+        typeinfo.add_primitive(Var {
+            name: "var".into(),
+            lambda: self.clone(),
+            string: typeinfo.get_sort(),
+        });
+        typeinfo.add_primitive(Apply {
+            name: "apply".into(),
+            lambda: self,
+        });
+    }
+
+    fn make_expr(&self, egraph: &EGraph, value: Value) -> Expr {
+        let lambda = ValueLambda::load(self, &value);
+        let var_string = self.id_to_symbol.lock().unwrap()[&lambda.var_id];
+        // Generate (lambda (var vv) body)
+        Expr::call(
+            "lambda",
+            [
+                Expr::call("var", [Expr::Lit(Literal::String(var_string))]),
+                egraph.extract(lambda.body, &self.output).1,
+            ],
+        )
+    }
+}
+
+impl IntoSort for ValueLambda {
+    type Sort = LambdaSort;
+    fn store(self, sort: &Self::Sort) -> Option<Value> {
+        let mut lambdas = sort.lambdas.lock().unwrap();
+        let (i, _) = lambdas.insert_full(self);
+        Some(Value {
+            tag: sort.name,
+            bits: i as u64,
+        })
+    }
+}
+
+impl FromSort for ValueLambda {
+    type Sort = LambdaSort;
+    fn load(sort: &Self::Sort, value: &Value) -> Self {
+        let lambdas = sort.lambdas.lock().unwrap();
+        *lambdas.get_index(value.bits as usize).unwrap()
+    }
+}
+
+struct Var {
+    name: Symbol,
+    lambda: Arc<LambdaSort>,
+    string: Arc<StringSort>,
+}
+
+impl PrimitiveLike for Var {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
+        if let [sort] = types {
+            if sort.name() == self.string.name() {
+                return Some(self.lambda.input.clone());
+            }
+        }
+        None
+    }
+
+    fn apply(&self, values: &[Value], unionfind: Option<&mut UnionFind>) -> Option<Value> {
+        let var = Symbol::load(&self.string, &values[0]);
+        let mut var_to_id = self.lambda.symbol_to_id.lock().unwrap();
+        let id = match var_to_id.entry(var) {
+            // If we have already saved a var for this ID used it
+            std::collections::btree_map::Entry::Occupied(o) => *o.get(),
+            // Otherwise, if we have the unionfind, make an ID and return it
+            // If we don't the unionfind, we are in type checking and return a dummy ID
+            std::collections::btree_map::Entry::Vacant(v) => unionfind.map_or(Id::from(0), |u| {
+                let id = u.make_set();
+                v.insert(id);
+                self.lambda.id_to_symbol.lock().unwrap().insert(id, var);
+                id
+            }),
+        };
+        Some(Value::from_id(self.lambda.input.name(), id))
+    }
+}
+
+struct Lambda {
+    name: Symbol,
+    lambda: Arc<LambdaSort>,
+}
+
+impl PrimitiveLike for Lambda {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
+        if let [var_tp, body_tp] = types {
+            if var_tp.name() == self.lambda.input.name()
+                && body_tp.name() == self.lambda.output.name()
+            {
+                return Some(self.lambda.clone());
+            }
+        }
+        None
+    }
+
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+        ValueLambda {
+            var_id: Id::from(values[0].bits as usize),
+            body: values[1],
+        }
+        .store(&self.lambda)
+    }
+}
+
+struct Apply {
+    name: Symbol,
+    lambda: Arc<LambdaSort>,
+}
+
+impl PrimitiveLike for Apply {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
+        // Types should be lambda and then input type and return outputs type
+        if let [lambda_tp, input_tp] = types {
+            if lambda_tp.name() == self.lambda.name() && input_tp.name() == self.lambda.input.name()
+            {
+                return Some(self.lambda.output.clone());
+            }
+        }
+        None
+    }
+
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+        let lambda = ValueLambda::load(&self.lambda, &values[0]);
+        let var_value = Value::from_id(self.lambda.input.name(), lambda.var_id);
+        let body = lambda.body;
+        let input_value = values[1];
+        // In body replace all instances of var_value with input_value
+        Some(body)
+
+
+    }
+}

--- a/src/sort/lambda.rs
+++ b/src/sort/lambda.rs
@@ -82,10 +82,7 @@ impl Sort for LambdaSort {
         // TODO: Potential duplication of code
         let lambdas = self.lambdas.lock().unwrap();
         let lambda = lambdas.get_index(value.bits as usize).unwrap();
-
-        if self.output.is_eq_sort() {
-            f(lambda.body)
-        }
+        f(lambda.body)
     }
 
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {
@@ -253,8 +250,9 @@ impl PrimitiveLike for Apply {
             Some(e) => {
                 // If we do have an e-graph, we need to substitute the var with the input
                 // In body replace all instances of var_value with input_value
+
                 Some(
-                    substitute(e, &body, &var_value, &input_value)
+                    substitute(e, &body, &var_value, &input_value, &mut HashMap::default())
                         .unwrap_or(body),
                 )
             }
@@ -326,7 +324,7 @@ fn substitute(
                         any_new_inputs = true;
                         new_input_value.unwrap()
                     }
-                    None => *i
+                    None => *i,
                 })
             }
             if !any_new_inputs {

--- a/src/sort/lambda.rs
+++ b/src/sort/lambda.rs
@@ -1,7 +1,6 @@
 /// A sort for lambdas
 ///
 /// They pretend to be an e-sort, but just with more type info and registration functions provided.
-
 use crate::typechecking::FuncType;
 
 use super::*;
@@ -44,7 +43,7 @@ impl LambdaSort {
             Ok(Arc::new(Self {
                 name,
                 input: input.clone(),
-                output: output.clone()
+                output: output.clone(),
             }))
         } else {
             panic!()

--- a/src/sort/lambda.rs
+++ b/src/sort/lambda.rs
@@ -1,25 +1,16 @@
-use std::{collections::BTreeMap, sync::Mutex};
+/// A sort for lambdas
+///
+/// They pretend to be an e-sort, but just with more type info and registration functions provided.
 
 use crate::typechecking::FuncType;
 
 use super::*;
-
-// #[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
-// struct ValueLambda {
-//     var: Value,
-//     body: Value,
-// }
 
 #[derive(Debug)]
 pub struct LambdaSort {
     name: Symbol,
     input: ArcSort,
     output: ArcSort,
-    // lambdas: Mutex<IndexSet<ValueLambda>>,
-    // Map from vars to their ID
-    // symbol_to_id: Mutex<BTreeMap<Symbol, Id>>,
-    // Inverse map
-    // id_to_symbol: Mutex<BTreeMap<Id, Symbol>>,
 }
 
 impl LambdaSort {
@@ -53,10 +44,7 @@ impl LambdaSort {
             Ok(Arc::new(Self {
                 name,
                 input: input.clone(),
-                output: output.clone(),
-                // lambdas: Default::default(),
-                // symbol_to_id: Default::default(),
-                // id_to_symbol: Default::default(),
+                output: output.clone()
             }))
         } else {
             panic!()
@@ -83,18 +71,6 @@ impl Sort for LambdaSort {
     }
 
     fn register_primitives(self: Arc<Self>, typeinfo: &mut TypeInfo) {
-        // typeinfo.add_primitive(Lambda {
-        //     name: "lambda".into(),
-        //     lambda: self.clone(),
-        // });
-        // typeinfo.func_types.insert(
-        //     "lambda".into(),
-        //     FuncType::new(
-        //         vec![self.input.clone(), self.output.clone()],
-        //         self.clone(),
-        //         false,
-        //     ),
-        // );
         let string_sort: Arc<StringSort> = typeinfo.get_sort();
         typeinfo.func_types.insert(
             "var".into(),
@@ -108,18 +84,13 @@ impl Sort for LambdaSort {
                 false,
             ),
         );
-        // typeinfo.add_primitive(Var {
-        //     name: "var".into(),
-        //     lambda: self.clone(),
-        //     string: typeinfo.get_sort(),
-        // });
         typeinfo.add_primitive(Apply {
             name: "apply".into(),
             lambda: self,
         });
     }
 
-    fn make_expr(&self, egraph: &EGraph, value: Value) -> Expr {
+    fn make_expr(&self, _egraph: &EGraph, _value: Value) -> Expr {
         unimplemented!("No make_expr for EqSort {}", self.name)
     }
 
@@ -154,95 +125,6 @@ impl Sort for LambdaSort {
     }
 }
 
-// impl IntoSort for ValueLambda {
-//     type Sort = LambdaSort;
-//     fn store(self, sort: &Self::Sort) -> Option<Value> {
-//         let mut lambdas = sort.lambdas.lock().unwrap();
-//         let (i, _) = lambdas.insert_full(self);
-//         Some(Value {
-//             tag: sort.name,
-//             bits: i as u64,
-//         })
-//     }
-// }
-
-// impl FromSort for ValueLambda {
-//     type Sort = LambdaSort;
-//     fn load(sort: &Self::Sort, value: &Value) -> Self {
-//         let lambdas = sort.lambdas.lock().unwrap();
-//         *lambdas.get_index(value.bits as usize).unwrap()
-//     }
-// }
-
-// struct Var {
-//     name: Symbol,
-//     lambda: Arc<LambdaSort>,
-//     string: Arc<StringSort>,
-// }
-
-// impl PrimitiveLike for Var {
-//     fn name(&self) -> Symbol {
-//         self.name
-//     }
-
-//     fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
-//         if let [sort] = types {
-//             if sort.name() == self.string.name() {
-//                 return Some(self.lambda.input.clone());
-//             }
-//         }
-//         None
-//     }
-
-//     fn apply(&self, values: &[Value], egraph: &mut EGraph) -> Option<Value> {
-//         let var = Symbol::load(&self.string, &values[0]);
-//         let mut var_to_id = self.lambda.symbol_to_id.lock().unwrap();
-//         let id = match var_to_id.entry(var) {
-//             // If we have already saved a var for this ID used it
-//             std::collections::btree_map::Entry::Occupied(o) => *o.get(),
-//             // Otherwise, if we have the unionfind, make an ID and return it
-//             // If we don't the unionfind, we are in type checking and return a dummy ID
-//             std::collections::btree_map::Entry::Vacant(v) => egraph.map_or(Id::from(0), |e| {
-//                 let id = e.unionfind.make_set();
-//                 v.insert(id);
-//                 self.lambda.id_to_symbol.lock().unwrap().insert(id, var);
-//                 id
-//             }),
-//         };
-//         Some(Value::from_id(self.lambda.input.name(), id))
-//     }
-// }
-
-// struct Lambda {
-//     name: Symbol,
-//     lambda: Arc<LambdaSort>,
-// }
-
-// impl PrimitiveLike for Lambda {
-//     fn name(&self) -> Symbol {
-//         self.name
-//     }
-
-//     fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
-//         if let [var_tp, body_tp] = types {
-//             if var_tp.name() == self.lambda.input.name()
-//                 && body_tp.name() == self.lambda.output.name()
-//             {
-//                 return Some(self.lambda.clone());
-//             }
-//         }
-//         None
-//     }
-
-//     fn apply(&self, values: &[Value], _egraph: &mut EGraph) -> Option<Value> {
-//         ValueLambda {
-//             var: values[0],
-//             body: values[1],
-//         }
-//         .store(&self.lambda)
-//     }
-// }
-
 pub(crate) struct Apply {
     pub(crate) name: Symbol,
     pub(crate) lambda: Arc<LambdaSort>,
@@ -271,7 +153,6 @@ impl PrimitiveLike for Apply {
                 panic!("Cant use apply when creating a query")
             }
         };
-        // let lambda = ValueLambda::load(&self.lambda, &values[0]);
         let lambda_value = values[0];
         let input_value = values[1];
         let lambda_name: Symbol = "lambda".into();
@@ -283,32 +164,18 @@ impl PrimitiveLike for Apply {
         let (lambda_input, _) = lambda_fn
             .nodes
             .iter()
-            .find(|(input, output)| output.value == lambda_value)
+            .find(|(_, output)| output.value == lambda_value)
             .expect("finding lambda fn call");
         let var_value = lambda_input[0];
         let body_value = lambda_input[1];
-        Some(
-            substitute(
-                egraph,
-                &body_value,
-                &var_value,
-                &input_value,
-                &mut HashMap::default(),
-            )
-            .unwrap_or(body_value),
-        )
-        // match egraph {
-        //     None => Some(body),
-        //     Some(e) => {
-        //         // If we do have an e-graph, we need to substitute the var with the input
-        //         // In body replace all instances of var_value with input_value
-
-        //         Some(
-        //             substitute(e, &body, &var_value, &input_value, &mut HashMap::default())
-        //                 .unwrap_or(body),
-        //         )
-        //     }
-        // }
+        Some(substitute(
+            egraph,
+            &body_value,
+            &var_value,
+            &input_value,
+            &mut HashMap::default(),
+            // "",
+        ))
     }
 }
 
@@ -319,89 +186,125 @@ fn substitute(
     body_value: &Value,
     var_value: &Value,
     input_value: &Value,
-    // Mapping of values to their substituted values, so we don't end up in loops for cyclic graphs
-    subtituted: &mut HashMap<Value, Value>,
-) -> Option<Value> {
-    println!("{:?}[{:?} -> {:?}]", body_value, var_value, input_value);
+    // Mapping of e-class IDs to their substituted values, so we don't end up in loops for cyclic graphs
+    substituted: &mut HashMap<Id, Id>,
+    // prefix: &str,
+) -> Value {
+    // If the body is not an eq sort, we don't need to recurse, just return the primitive
+    let body_sort = egraph.get_sort(body_value).unwrap().clone();
+    if !body_sort.is_eq_sort() {
+        return *body_value;
+    }
+    // println!(
+    //     "{}{:?}[{:?}/{:?}]",
+    //     prefix, body_value.bits, var_value.bits, input_value.bits
+    // );
+    // let print_unionfind = |e: &EGraph| {
+    //     println!(
+    //         " {}{:?}",
+    //         prefix,
+    //         e.unionfind
+    //             .parents
+    //             .iter()
+    //             .enumerate()
+    //             .map(|(i, p)| { (i, p.clone().into_inner().0) })
+    //             .collect::<Vec<_>>()
+    //     );
+    // };
+    // print_unionfind(egraph);
+
     if body_value == var_value {
-        println!("Found var");
-        return Some(*input_value);
+        return *input_value;
     }
     if body_value == input_value {
-        println!("Found input");
-        return None;
+        return *input_value;
     }
-    if subtituted.contains_key(body_value) {
-        println!("Found already substituted");
-        return Some(*subtituted.get(body_value).unwrap());
-    }
-    let body_sort = egraph.get_sort(body_value).unwrap().clone();
+
     if body_sort.is_container_sort() {
         panic!("Container support not implemented")
     }
-    // If the body is not an eq sort, we don't need to recurse, just return
-    if !body_sort.is_eq_sort() {
-        return None;
-    }
-
-    // If the body is an eq sort, we need to recurse
 
     let body_id = Id::from(body_value.bits as usize);
+    if let Some(replaced_id) = substituted.get(&body_id) {
+        // println!(
+        //     "{} Found already substituted {}->{}",
+        //     prefix, body_id.0, replaced_id.0
+        // );
+        return Value::from_id(body_sort.name(), *replaced_id);
+    }
+
+    // Create a new e-class to store all the new bodies
+    let mut new_body_id = egraph.unionfind.make_set();
+    // println!(" -> {}", new_body_id);
+    // Store that we are replacing the old body with the new body
+    substituted.insert(body_id, new_body_id);
+    // Build up a list of all the functions and their inputs which return this body
+    // All of this will need to have their args substituted and unioned to make a new body
     let canonical_body_id = egraph.unionfind.find(body_id);
-
-    let new_body_id = egraph.unionfind.make_set();
-    let new_body_value = Value::from_id(body_sort.name(), new_body_id);
-    subtituted.insert(*body_value, new_body_value);
-
-    let mut made_changes = false;
-
-    // Then, we want to iterate through all functions whose return sort is the body sort
-    for name in egraph.functions.keys().cloned().collect::<Vec<_>>() {
-        let function = egraph.functions.get(&name).unwrap().clone();
-        if function.schema.output.name() != body_sort.name() {
-            continue;
-        }
-        // For each function, we want to iterate through all of its e-nodes
-        for (input, output) in function.nodes.iter() {
-            // If the canonical ID of the output is not the same as the canonical ID of the body, skip it
-            if egraph.unionfind.find(Id::from(output.value.bits as usize)) != canonical_body_id {
-                continue;
+    let fn_calls = find_all_call(egraph, body_sort.name(), canonical_body_id);
+    // println!("{} found {} cals", prefix, fn_calls.len());
+    // println!("  {:?}", body_value);
+    // For every function calls, create a new function call with the substituted args
+    for (f_name, inputs) in fn_calls {
+        // println!("{} {} {:?}", prefix, f_name, inputs);
+        let new_inputs = inputs
+            .iter()
+            .map(|input| {
+                substitute(
+                    egraph,
+                    input,
+                    var_value,
+                    input_value,
+                    substituted,
+                    // format!("{}  ", prefix).as_str(),
+                )
+            })
+            .collect::<Vec<_>>();
+        // let mut new_fn_id = egraph.unionfind.make_set();
+        // println!("{} ->{}", prefix, new_fn_id.0);
+        // println!("{} -> {:?}", prefix, new_inputs);
+        let new_res = egraph.functions.get_mut(&f_name).unwrap().insert(
+            &new_inputs,
+            Value::from_id(body_sort.name(), new_body_id),
+            egraph.timestamp,
+        );
+        // if let Some(id) = new_body_id {
+        //     let res = egraph.union(id, new_fn_id, body_sort.name());
+        //     println!("{} {}∪{}->{}", prefix, new_fn_id.0, id.0, res.0);
+        //     new_fn_id = res;
+        // }
+        // new_body_id = Some(new_fn_id);
+        if let Some(new_res) = new_res {
+            //     // println!(" fr -> {}", res_value.bits as usize);
+            let res_id = new_res.bits as usize;
+            let new_res = Some(egraph.union(new_body_id, Id::from(res_id), body_sort.name()));
+            // println!("{} {}∪{}->{}", prefix, new_fn_id.0, res_id, new_res.unwrap().0);
+            if let Some(new_res) = new_res {
+                new_body_id = new_res;
             }
-            // Now build up new inputs based on substituting the old inputs
-            let mut any_new_inputs = false;
-            let mut new_input = vec![];
-            for i in input {
-                let new_input_value = substitute(egraph, i, var_value, input_value, subtituted);
-                new_input.push(match new_input_value {
-                    Some(_) => {
-                        any_new_inputs = true;
-                        new_input_value.unwrap()
-                    }
-                    None => *i,
-                })
-            }
-            // if !any_new_inputs {
-            //     continue;
-            // }
-            made_changes = true;
-            let res = egraph.functions.get_mut(&name).unwrap().nodes.insert(
-                &new_input[..],
-                new_body_value,
-                egraph.timestamp,
-            );
-            match res {
-                Some(new_value) => {
-                    egraph.union(body_id, Id::from(new_value.bits as usize), body_sort.name());
-                }
-                None => {}
-            }
-            // if res.is_some() && res != Some(new_body_value) {
-            //     panic!("Don't support when inserting returns different node currently for lambda subst {:?}", res)
-            // }
         }
     }
-    // if !made_changes {
-    //     return None;
-    // }
-    Some(new_body_value)
+    // println!("{} ->> {}", prefix, new_body_id.0);
+    // print_unionfind(egraph);
+    Value::from_id(body_sort.name(), new_body_id)
+}
+
+/// Returns all the function calls in the egraph which return the e-class of the given sort
+fn find_all_call(egraph: &EGraph, sort_name: Symbol, id: Id) -> Vec<(Symbol, Vec<Value>)> {
+    // vec![]
+    egraph
+        .functions
+        .iter()
+        // Filter for functions which return this sort and are not variables
+        .filter(|(_, f)| f.schema.output.name() == sort_name && !f.is_variable)
+        .flat_map(|(f_name, f)| {
+            f.nodes
+                .iter()
+                // Filter for nodes where the canonical ID of the output is the same as the canonical ID of the body
+                .filter(|(_, output)| {
+                    egraph.unionfind.find(Id::from(output.value.bits as usize)) == id
+                })
+                .map(|(inputs, _)| (*f_name, inputs.to_vec()))
+        })
+        .collect::<Vec<_>>()
 }

--- a/src/sort/macros.rs
+++ b/src/sort/macros.rs
@@ -54,7 +54,7 @@ macro_rules! add_primitives {
                     }
                 }
 
-                fn apply(&self, values: &[Value]) -> Option<Value> {
+                fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
                     if let [$($param),*] = values {
                         $(let $param: $param_t = <$param_t as FromSort>::load(&self.$param, $param);)*
                         // print!("{}( ", $name);

--- a/src/sort/macros.rs
+++ b/src/sort/macros.rs
@@ -54,7 +54,7 @@ macro_rules! add_primitives {
                     }
                 }
 
-                fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+                fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
                     if let [$($param),*] = values {
                         $(let $param: $param_t = <$param_t as FromSort>::load(&self.$param, $param);)*
                         // print!("{}( ", $name);

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -176,7 +176,7 @@ impl PrimitiveLike for Ctor {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         assert!(values.is_empty());
         ValueMap::default().store(&self.map)
     }
@@ -204,7 +204,7 @@ impl PrimitiveLike for Insert {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let mut map = ValueMap::load(&self.map, &values[0]);
         map.insert(values[1], values[2]);
         map.store(&self.map)
@@ -230,7 +230,7 @@ impl PrimitiveLike for Get {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let map = ValueMap::load(&self.map, &values[0]);
         map.get(&values[1]).copied()
     }
@@ -256,7 +256,7 @@ impl PrimitiveLike for NotContains {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let map = ValueMap::load(&self.map, &values[0]);
         if map.contains_key(&values[1]) {
             None
@@ -286,7 +286,7 @@ impl PrimitiveLike for Contains {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let map = ValueMap::load(&self.map, &values[0]);
         if map.contains_key(&values[1]) {
             Some(Value::unit())
@@ -315,7 +315,7 @@ impl PrimitiveLike for Remove {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let mut map = ValueMap::load(&self.map, &values[0]);
         map.remove(&values[1]);
         map.store(&self.map)

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -176,7 +176,7 @@ impl PrimitiveLike for Ctor {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         assert!(values.is_empty());
         ValueMap::default().store(&self.map)
     }
@@ -204,7 +204,7 @@ impl PrimitiveLike for Insert {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let mut map = ValueMap::load(&self.map, &values[0]);
         map.insert(values[1], values[2]);
         map.store(&self.map)
@@ -230,7 +230,7 @@ impl PrimitiveLike for Get {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let map = ValueMap::load(&self.map, &values[0]);
         map.get(&values[1]).copied()
     }
@@ -256,7 +256,7 @@ impl PrimitiveLike for NotContains {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let map = ValueMap::load(&self.map, &values[0]);
         if map.contains_key(&values[1]) {
             None
@@ -286,7 +286,7 @@ impl PrimitiveLike for Contains {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let map = ValueMap::load(&self.map, &values[0]);
         if map.contains_key(&values[1]) {
             Some(Value::unit())
@@ -315,7 +315,7 @@ impl PrimitiveLike for Remove {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let mut map = ValueMap::load(&self.map, &values[0]);
         map.remove(&values[1]);
         map.store(&self.map)

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -62,6 +62,11 @@ pub trait Sort: Any + Send + Sync + Debug {
         let _ = info;
     }
 
+    /// Do any registration needed on the e-graph, like adding non primitive functions
+    fn register_egraph(self: Arc<Self>, egraph: &mut EGraph) {
+        let _ = egraph;
+    }
+
     fn make_expr(&self, egraph: &EGraph, value: Value) -> Expr;
 }
 

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -19,6 +19,8 @@ mod set;
 pub use set::*;
 mod vec;
 pub use vec::*;
+mod lambda;
+pub use lambda::*;
 
 use crate::*;
 

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -178,7 +178,7 @@ impl PrimitiveLike for SetOf {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let set = ValueSet::from_iter(values.iter().copied());
         set.store(&self.set)
     }
@@ -201,7 +201,7 @@ impl PrimitiveLike for Ctor {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         assert!(values.is_empty());
         ValueSet::default().store(&self.set)
     }
@@ -226,7 +226,7 @@ impl PrimitiveLike for Insert {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let mut set = ValueSet::load(&self.set, &values[0]);
         set.insert(values[1]);
         set.store(&self.set)
@@ -255,7 +255,7 @@ impl PrimitiveLike for NotContains {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let set = ValueSet::load(&self.set, &values[0]);
         if set.contains(&values[1]) {
             None
@@ -285,7 +285,7 @@ impl PrimitiveLike for Contains {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let set = ValueSet::load(&self.set, &values[0]);
         if set.contains(&values[1]) {
             Some(Value::unit())
@@ -314,7 +314,7 @@ impl PrimitiveLike for Union {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let mut set1 = ValueSet::load(&self.set, &values[0]);
         let set2 = ValueSet::load(&self.set, &values[1]);
         set1.extend(set2.iter());
@@ -341,7 +341,7 @@ impl PrimitiveLike for Intersect {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let mut set1 = ValueSet::load(&self.set, &values[0]);
         let set2 = ValueSet::load(&self.set, &values[1]);
         set1.retain(|k| set2.contains(k));
@@ -369,7 +369,7 @@ impl PrimitiveLike for Remove {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let mut set = ValueSet::load(&self.set, &values[0]);
         set.remove(&values[1]);
         set.store(&self.set)
@@ -395,7 +395,7 @@ impl PrimitiveLike for Diff {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let mut set1 = ValueSet::load(&self.set, &values[0]);
         let set2 = ValueSet::load(&self.set, &values[1]);
         set1.retain(|k| !set2.contains(k));

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -178,7 +178,7 @@ impl PrimitiveLike for SetOf {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let set = ValueSet::from_iter(values.iter().copied());
         set.store(&self.set)
     }
@@ -201,7 +201,7 @@ impl PrimitiveLike for Ctor {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         assert!(values.is_empty());
         ValueSet::default().store(&self.set)
     }
@@ -226,7 +226,7 @@ impl PrimitiveLike for Insert {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let mut set = ValueSet::load(&self.set, &values[0]);
         set.insert(values[1]);
         set.store(&self.set)
@@ -255,7 +255,7 @@ impl PrimitiveLike for NotContains {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let set = ValueSet::load(&self.set, &values[0]);
         if set.contains(&values[1]) {
             None
@@ -285,7 +285,7 @@ impl PrimitiveLike for Contains {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let set = ValueSet::load(&self.set, &values[0]);
         if set.contains(&values[1]) {
             Some(Value::unit())
@@ -314,7 +314,7 @@ impl PrimitiveLike for Union {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let mut set1 = ValueSet::load(&self.set, &values[0]);
         let set2 = ValueSet::load(&self.set, &values[1]);
         set1.extend(set2.iter());
@@ -341,7 +341,7 @@ impl PrimitiveLike for Intersect {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let mut set1 = ValueSet::load(&self.set, &values[0]);
         let set2 = ValueSet::load(&self.set, &values[1]);
         set1.retain(|k| set2.contains(k));
@@ -369,7 +369,7 @@ impl PrimitiveLike for Remove {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let mut set = ValueSet::load(&self.set, &values[0]);
         set.remove(&values[1]);
         set.store(&self.set)
@@ -395,7 +395,7 @@ impl PrimitiveLike for Diff {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let mut set1 = ValueSet::load(&self.set, &values[0]);
         let set2 = ValueSet::load(&self.set, &values[1]);
         set1.retain(|k| !set2.contains(k));

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -55,7 +55,7 @@ impl PrimitiveLike for NotEqualPrimitive {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         (values[0] != values[1]).then(Value::unit)
     }
 }

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -55,7 +55,7 @@ impl PrimitiveLike for NotEqualPrimitive {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         (values[0] != values[1]).then(Value::unit)
     }
 }

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -433,10 +433,7 @@ impl PrimitiveLike for Map {
                 lambda: self.lambda.clone(),
             };
             let res = apply_prim.apply(&[lambda, *value], Some(egraph)).expect("result");
-            // self.vec.element.canonicalize(&mut res, &egraph.unionfind);
             new_vec.push(res);
-            // Must re-build between calls or else we get infinite recursion
-            egraph.rebuild_nofail();
         }
         let mut new_value = new_vec.store(&self.vec).expect("new_value");
         // Must canonicalize to get the correct eclass

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -432,7 +432,9 @@ impl PrimitiveLike for Map {
                 name: "apply".into(),
                 lambda: self.lambda.clone(),
             };
-            new_vec.push(apply_prim.apply(&[lambda, *value], Some(egraph))?);
+            let res = apply_prim.apply(&[lambda, *value], Some(egraph)).expect("result");
+            // self.vec.element.canonicalize(&mut res, &egraph.unionfind);
+            new_vec.push(res);
             // Must re-build between calls or else we get infinite recursion
             egraph.rebuild_nofail();
         }

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -179,7 +179,7 @@ impl PrimitiveLike for VecOf {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let vec = ValueVec::from_iter(values.iter().copied());
         vec.store(&self.vec)
     }
@@ -203,7 +203,7 @@ impl PrimitiveLike for Append {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let vec = ValueVec::from_iter(values.iter().flat_map(|v| ValueVec::load(&self.vec, v)));
         vec.store(&self.vec)
     }
@@ -226,7 +226,7 @@ impl PrimitiveLike for Ctor {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         assert!(values.is_empty());
         ValueVec::default().store(&self.vec)
     }
@@ -251,7 +251,7 @@ impl PrimitiveLike for Push {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let mut vec = ValueVec::load(&self.vec, &values[0]);
         vec.push(values[1]);
         vec.store(&self.vec)
@@ -275,7 +275,7 @@ impl PrimitiveLike for Pop {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let mut vec = ValueVec::load(&self.vec, &values[0]);
         vec.pop();
         vec.store(&self.vec)
@@ -304,7 +304,7 @@ impl PrimitiveLike for NotContains {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let vec = ValueVec::load(&self.vec, &values[0]);
         if vec.contains(&values[1]) {
             None
@@ -334,7 +334,7 @@ impl PrimitiveLike for Contains {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let vec = ValueVec::load(&self.vec, &values[0]);
         if vec.contains(&values[1]) {
             Some(Value::unit())
@@ -362,7 +362,7 @@ impl PrimitiveLike for Length {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let vec = ValueVec::load(&self.vec, &values[0]);
         Some(Value::from(vec.len() as i64))
     }
@@ -388,7 +388,7 @@ impl PrimitiveLike for Get {
         }
     }
 
-    fn apply(&self, values: &[Value]) -> Option<Value> {
+    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
         let vec = ValueVec::load(&self.vec, &values[0]);
         let index = i64::load(&self.i64, &values[1]);
         vec.get(index as usize).copied()

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -432,7 +432,9 @@ impl PrimitiveLike for Map {
                 name: "apply".into(),
                 lambda: self.lambda.clone(),
             };
-            let res = apply_prim.apply(&[lambda, *value], Some(egraph)).expect("result");
+            let res = apply_prim
+                .apply(&[lambda, *value], Some(egraph))
+                .expect("result");
             new_vec.push(res);
         }
         let mut new_value = new_vec.store(&self.vec).expect("new_value");

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -128,11 +128,15 @@ impl Sort for VecSort {
             vec: self.clone(),
             i64: typeinfo.get_sort(),
         });
-        typeinfo.add_primitive(Map {
-            name: "vec-map".into(),
-            vec: self,
-            lambda: typeinfo.get_sort(),
-        });
+        // Only add vec-map if we have already registred a lambda
+        let lambda_option: Option<Arc<LambdaSort>> = typeinfo.get_sort_safe();
+        if let Some(lambda) = lambda_option {
+            typeinfo.add_primitive(Map {
+                name: "vec-map".into(),
+                vec: self,
+                lambda,
+            });
+        }
     }
 
     fn make_expr(&self, egraph: &EGraph, value: Value) -> Expr {

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -427,7 +427,9 @@ impl PrimitiveLike for Map {
 
         // If we have no egraph, just return the input, since we are in type checking
         let real_egraph = match egraph {
-            None => {return Some(values[0]) },
+            None => {
+                panic!("Cant use map in matching")
+            }
             Some(e) => e,
         };
         let lambda = values[1];

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -179,7 +179,7 @@ impl PrimitiveLike for VecOf {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let vec = ValueVec::from_iter(values.iter().copied());
         vec.store(&self.vec)
     }
@@ -203,7 +203,7 @@ impl PrimitiveLike for Append {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let vec = ValueVec::from_iter(values.iter().flat_map(|v| ValueVec::load(&self.vec, v)));
         vec.store(&self.vec)
     }
@@ -226,7 +226,7 @@ impl PrimitiveLike for Ctor {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         assert!(values.is_empty());
         ValueVec::default().store(&self.vec)
     }
@@ -251,7 +251,7 @@ impl PrimitiveLike for Push {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let mut vec = ValueVec::load(&self.vec, &values[0]);
         vec.push(values[1]);
         vec.store(&self.vec)
@@ -275,7 +275,7 @@ impl PrimitiveLike for Pop {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let mut vec = ValueVec::load(&self.vec, &values[0]);
         vec.pop();
         vec.store(&self.vec)
@@ -304,7 +304,7 @@ impl PrimitiveLike for NotContains {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let vec = ValueVec::load(&self.vec, &values[0]);
         if vec.contains(&values[1]) {
             None
@@ -334,7 +334,7 @@ impl PrimitiveLike for Contains {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let vec = ValueVec::load(&self.vec, &values[0]);
         if vec.contains(&values[1]) {
             Some(Value::unit())
@@ -362,7 +362,7 @@ impl PrimitiveLike for Length {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let vec = ValueVec::load(&self.vec, &values[0]);
         Some(Value::from(vec.len() as i64))
     }
@@ -388,7 +388,7 @@ impl PrimitiveLike for Get {
         }
     }
 
-    fn apply(&self, values: &[Value], _unionfind: Option<&mut UnionFind>) -> Option<Value> {
+    fn apply(&self, values: &[Value], _egraph: Option<&mut EGraph>) -> Option<Value> {
         let vec = ValueVec::load(&self.vec, &values[0]);
         let index = i64::load(&self.i64, &values[1]);
         vec.get(index as usize).copied()

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -693,7 +693,7 @@ impl EGraph {
                 Instruction::CallPrimitive(p, arity) => {
                     let new_len = stack.len() - arity;
                     let values = &stack[new_len..];
-                    if let Some(value) = p.apply(values, Some(&mut self.unionfind)) {
+                    if let Some(value) = p.apply(values, Some(self)) {
                         stack.truncate(new_len);
                         stack.push(value);
                     } else {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -693,7 +693,7 @@ impl EGraph {
                 Instruction::CallPrimitive(p, arity) => {
                     let new_len = stack.len() - arity;
                     let values = &stack[new_len..];
-                    if let Some(value) = p.apply(values) {
+                    if let Some(value) = p.apply(values, Some(&mut self.unionfind)) {
                         stack.truncate(new_len);
                         stack.push(value);
                     } else {

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -47,6 +47,7 @@ impl Default for TypeInfo {
         res.presorts.insert("Map".into(), MapSort::make_sort);
         res.presorts.insert("Set".into(), SetSort::make_sort);
         res.presorts.insert("Vec".into(), VecSort::make_sort);
+        res.presorts.insert("Lambda".into(), LambdaSort::make_sort);
         res
     }
 }
@@ -539,7 +540,7 @@ pub enum TypeError {
     #[error("Arity mismatch, expected {expected} args: {expr}")]
     Arity { expr: Expr, expected: usize },
     #[error(
-        "Type mismatch: expr = {expr}, expected = {}, actual = {}, reason: {reason}", 
+        "Type mismatch: expr = {expr}, expected = {}, actual = {}, reason: {reason}",
         .expected.name(), .actual.name(),
     )]
     Mismatch {

--- a/tests/lambda-builtin.egg
+++ b/tests/lambda-builtin.egg
@@ -18,4 +18,4 @@
 ; TODO: Define replacement
 (define two (apply double one))
 
-(check (= two (Num 2)))
+; (check (= two (Num 2)))

--- a/tests/lambda-builtin.egg
+++ b/tests/lambda-builtin.egg
@@ -1,0 +1,21 @@
+(datatype Math
+  (Num i64)
+  (Var String)
+  (Add Math Math)
+  (Mul Math Math))
+
+(sort MathFn (Lambda Math Math))
+
+(define one-thunk (lambda (var "x") (Num 1)))
+
+(define one (apply one-thunk (Var "____")))
+
+(run 10)
+(check (= one (Num 1)))
+
+(define double (lambda (var "x") (Mul (var "x") (var "x"))))
+
+; TODO: Define replacement
+(define two (apply double one))
+
+(check (= two (Num 2)))

--- a/tests/lambda-builtin.egg
+++ b/tests/lambda-builtin.egg
@@ -22,5 +22,20 @@
 (define two (apply double one))
 (run 10)
 
-(extract two)
 (check (= two (Num 2)))
+
+(define four (apply double two))
+(run 10)
+
+(check (= four (Num 4)))
+
+; Vec tests
+
+(sort MathVec (Vec Math))
+(define my-vec (vec-of (Num 1) ));(Num 2) (Var "3")))
+
+; (define doubled-vec (vec-map my-vec double))
+
+; (run 20)
+
+; (check (= doubled-vec (vec-of (Num 2) (Num 4) (Mul (Var "3") (Num 2)))))

--- a/tests/lambda-builtin.egg
+++ b/tests/lambda-builtin.egg
@@ -4,18 +4,23 @@
   (Add Math Math)
   (Mul Math Math))
 
+
+(rewrite (Mul (Num x) (Num y)) (Num (* x y)))
+
 (sort MathFn (Lambda Math Math))
 
 (define one-thunk (lambda (var "x") (Num 1)))
 
-(define one (apply one-thunk (Var "____")))
+(define one (apply one-thunk (Var "doesnt matter")))
 
 (run 10)
 (check (= one (Num 1)))
 
-(define double (lambda (var "y") (Mul (var "y") (var "y"))))
+(define double (lambda (var "y") (Mul (var "y") (Num 2))))
+(run 10)
 
-; TODO: Define replacement
 (define two (apply double one))
+(run 10)
 
-; (check (= two (Num 2)))
+(extract two)
+(check (= two (Num 2)))

--- a/tests/lambda-builtin.egg
+++ b/tests/lambda-builtin.egg
@@ -31,8 +31,8 @@
 
 ; Vec tests
 
-(sort MathVec (Vec Math))
-(define my-vec (vec-of (Num 1) ));(Num 2) (Var "3")))
+; (sort MathVec (Vec Math))
+; (define my-vec (vec-of (Num 1) ));(Num 2) (Var "3")))
 
 ; (define doubled-vec (vec-map my-vec double))
 

--- a/tests/lambda-builtin.egg
+++ b/tests/lambda-builtin.egg
@@ -36,7 +36,7 @@
 ; Test apply the double function to a vec
 
 (sort MathVec (Vec Math))
-(define vec (vec-of (Num 1) (Var "3")))
+(define vec (vec-of (Num 1) (Num 2) (Var "3")))
 (define doubled-vec (vec-map vec double))
 (run 1)
-(check (= doubled-vec (vec-of (Num 2) (Mul (Var "3") (Num 2)))))
+(check (= doubled-vec (vec-of (Num 2) (Num 4) (Mul (Var "3") (Num 2)))))

--- a/tests/lambda-builtin.egg
+++ b/tests/lambda-builtin.egg
@@ -18,8 +18,9 @@
 
 (define double (lambda (var "y") (Mul (var "y") (Num 2))))
 (run 10)
-
-(define two (apply double one))
+(Num 1)
+(apply double (Num 1))
+(define two (apply double (Num 1)))
 (run 10)
 
 (check (= two (Num 2)))
@@ -31,11 +32,10 @@
 
 ; Vec tests
 
-; (sort MathVec (Vec Math))
-; (define my-vec (vec-of (Num 1) ));(Num 2) (Var "3")))
+(sort MathVec (Vec Math))
+(define my-vec (vec-of (Num 1)  (Var "3")))
 
-; (define doubled-vec (vec-map my-vec double))
+(define doubled-vec (vec-map my-vec double))
 
-; (run 20)
-
-; (check (= doubled-vec (vec-of (Num 2) (Num 4) (Mul (Var "3") (Num 2)))))
+(run 20)
+(check (= doubled-vec (vec-of (Num 2) (Mul (Var "3") (Num 2)))))

--- a/tests/lambda-builtin.egg
+++ b/tests/lambda-builtin.egg
@@ -13,7 +13,7 @@
 (run 10)
 (check (= one (Num 1)))
 
-(define double (lambda (var "x") (Mul (var "x") (var "x"))))
+(define double (lambda (var "y") (Mul (var "y") (var "y"))))
 
 ; TODO: Define replacement
 (define two (apply double one))

--- a/tests/lambda-builtin.egg
+++ b/tests/lambda-builtin.egg
@@ -1,3 +1,4 @@
+; Tests for the builtin lambda function
 (datatype Math
   (Num i64)
   (Var String)
@@ -6,36 +7,36 @@
 
 
 (rewrite (Mul (Num x) (Num y)) (Num (* x y)))
+; (rewrite (Mul x y) (Mul y x))
 
+; We define a function from math -> Math
 (sort MathFn (Lambda Math Math))
 
+; Test a function that doesn't use its args
+(push)
 (define one-thunk (lambda (var "x") (Num 1)))
-
 (define one (apply one-thunk (Var "doesnt matter")))
-
-(run 10)
 (check (= one (Num 1)))
+(pop)
 
-(define double (lambda (var "y") (Mul (var "y") (Num 2))))
-(run 10)
-(Num 1)
-(apply double (Num 1))
+; Test a function which doubles its arguments
+(define double (lambda (var "x") (Mul (var "x") (Num 2))))
+
+(push)
 (define two (apply double (Num 1)))
-(run 10)
-
+(run 1)
 (check (= two (Num 2)))
-
 (define four (apply double two))
-(run 10)
-
+(run 1)
 (check (= four (Num 4)))
+(pop)
 
-; Vec tests
+
+
+; Test apply the double function to a vec
 
 (sort MathVec (Vec Math))
-(define my-vec (vec-of (Num 1)  (Var "3")))
-
-(define doubled-vec (vec-map my-vec double))
-
-(run 20)
+(define vec (vec-of (Num 1) (Var "3")))
+(define doubled-vec (vec-map vec double))
+(run 1)
 (check (= doubled-vec (vec-of (Num 2) (Mul (Var "3") (Num 2)))))


### PR DESCRIPTION
*[zulip thread](https://egraphs.zulipchat.com/#narrow/stream/375765-egglog/topic/embedded.20lambda.20functions/near/368338074) discussing this PR*

This is a test branch to experiment with a way of allowing users to define lambda terms in the e-graph.

Current (known) limitations:
* Only works when functions input as an e-class not a primitive
* Function with duplicate variable names will break. (Could have a fix for this with desugaring pass)
* Can only use functions with one sort currently, i.e. if you want i64 -> i64, cannot also use i64 -> String in one program. I believe this is partially due to  https://github.com/egraphs-good/egglog/issues/113. This means we can't do higher order functions sadly!

Changes:
* Add new `Lambda` builtin sort, with functions `var`,`lambda`, and `apply`.
* Pass the `EGraph` into `apply()` method on sorts so that when applying a lambda function can muck about in the EGraph
* Add a `register_egraph` method to sorts, so that the Lambda sort can register two regular functions `var` and `lambda`. I couldn't figure out a way to do this otherwise, registering non-primitive functions in a sort based on the types based in.
* Adds a `vec-map` function for vectors map a function across them.


Examples:

```lisp
(define double (lambda (var "x") (Mul (var "x") (Num 2))))
(define two (apply double (Num 1)))
(run 1)
(check (= two (Num 2)))
```
![lambda-builtin](https://github.com/egraphs-good/egglog/assets/1186124/19bd6972-5966-45b9-8890-e6d6c67dcd6c)


```lisp
(sort MathVec (Vec Math))
(define vec (vec-of (Num 1) (Num 2) (Var "3")))
(define doubled-vec (vec-map vec double))
(run 1)
(check (= doubled-vec (vec-of (Num 2) (Num 4) (Mul (Var "3") (Num 2)))))
```
![lambda-builtin](https://github.com/egraphs-good/egglog/assets/1186124/1f5f7603-9425-4436-8f03-b2bbca27afb3)

