### PR TITLE
Add support for third party sorts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use proofs::ProofState;
 use symbolic_expressions::Sexp;
 
 use ast::*;
-use typechecking::{TypeInfo, UNIT_SYM};
+pub use typechecking::{TypeInfo, UNIT_SYM};
 
 use std::fmt::{Formatter, Write};
 use std::fs::File;
@@ -35,7 +35,7 @@ use std::rc::Rc;
 use std::{fmt::Debug, sync::Arc};
 use typecheck::Program;
 
-type ArcSort = Arc<dyn Sort>;
+pub type ArcSort = Arc<dyn Sort>;
 
 pub use value::*;
 
@@ -1230,6 +1230,10 @@ impl EGraph {
 
     pub(crate) fn get_sort(&self, value: &Value) -> Option<&ArcSort> {
         self.proof_state.type_info.sorts.get(&value.tag)
+    }
+
+    pub fn add_sort<S: Sort + 'static>(&mut self, sort: S) {
+        self.proof_state.type_info.add_sort(sort);
     }
 
     // Gets the last extract report and returns it, if the last command saved it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1236,7 +1236,6 @@ impl EGraph {
         self.proof_state.type_info.add_arcsort(arcsort)
     }
 
-
     // Gets the last extract report and returns it, if the last command saved it.
     pub fn get_extract_report(&self) -> &Option<ExtractReport> {
         &self.extract_report

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -719,7 +719,7 @@ impl EGraph {
         Ok(())
     }
 
-    fn eval_expr(
+    pub fn eval_expr(
         &mut self,
         expr: &Expr,
         expected_type: Option<ArcSort>,
@@ -1232,9 +1232,10 @@ impl EGraph {
         self.proof_state.type_info.sorts.get(&value.tag)
     }
 
-    pub fn add_sort<S: Sort + 'static>(&mut self, sort: S) {
-        self.proof_state.type_info.add_sort(sort);
+    pub fn add_arcsort(&mut self, arcsort: ArcSort) -> Result<(), TypeError> {
+        self.proof_state.type_info.add_arcsort(arcsort)
     }
+
 
     // Gets the last extract report and returns it, if the last command saved it.
     pub fn get_extract_report(&self) -> &Option<ExtractReport> {


### PR DESCRIPTION
This PR adds support for third party packages to add their own sorts.

I am using it in https://github.com/metadsl/egglog-python/pull/31 to add a custom `PyObject` sort, with primitive operations for executing code and converting.