### PR TITLE
Update README Python binding doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is repo for the `egglog` tool accompanying the paper
 If you use this work, please use [this citation](./CITATION.bib). 
 
 See also the Python binding, which provides a bit more documentation:
-https://egglog-python.readthedocs.io/en/latest/
+https://egg-smol-python.readthedocs.io/en/latest/
 
 ## Chat
 


### PR DESCRIPTION
README links to https://egglog-python.readthedocs.io/en/latest/, but that page 404s.

It appears these docs are at https://egg-smol-python.readthedocs.io/en/latest/?