### PR TITLE
Add to-string function for floats and ints

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Signed 64-bit integers supporting these primitives:
 < > <= >=           ; comparisons
 min max log2
 to-f64
+to-string
 ```
 
 ### Sort: f64
@@ -407,6 +408,7 @@ to-f64
 < > <= >=           ; comparisons
 min max neg
 to-i64
+to-string
 ```
 
 ### Sort: map

--- a/src/sort/f64.rs
+++ b/src/sort/f64.rs
@@ -48,6 +48,8 @@ impl Sort for F64Sort {
 
         add_primitives!(eg, "to-f64" = |a: i64| -> f64 { a as f64 });
         add_primitives!(eg, "to-i64" = |a: f64| -> i64 { a as i64 });
+        // Use debug instead of to_string so that decimal place is always printed
+        add_primitives!(eg, "to-string" = |a: f64| -> Symbol { format!("{:?}", a).into() });
 
     }
 

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -56,6 +56,9 @@ impl Sort for I64Sort {
 
         add_primitives!(typeinfo, "min" = |a: i64, b: i64| -> i64 { a.min(b) });
         add_primitives!(typeinfo, "max" = |a: i64, b: i64| -> i64 { a.max(b) });
+
+        add_primitives!(typeinfo, "to-string" = |a: i64| -> Symbol { a.to_string().into() });
+
     }
 
     fn make_expr(&self, _egraph: &EGraph, value: Value) -> Expr {

--- a/tests/f64.egg
+++ b/tests/f64.egg
@@ -7,3 +7,5 @@
 (fail (check (= (+ 1.5 9.2) 10.6)))
 (check (= (to-f64 1) 1.0))
 (check (= (to-i64 1.0) 1))
+(check (= (to-string 1.2) "1.2"))
+(check (= (to-string 1.0) "1.0"))

--- a/tests/i64.egg
+++ b/tests/i64.egg
@@ -1,0 +1,1 @@
+(check (= (to-string 20) "20"))


### PR DESCRIPTION
Adds a `to-string` function for floats and ints.

For floats, it uses the debug form instead of the `to_string` so that the decimal place is always printed.