### PR TITLE
Make termdag public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use index::ColumnIndex;
 use instant::{Duration, Instant};
 pub use serialize::SerializeConfig;
 use sort::*;
-use termdag::{Term, TermDag};
+pub use termdag::{Term, TermDag};
 use thiserror::Error;
 
 use proofs::ProofState;

--- a/src/termdag.rs
+++ b/src/termdag.rs
@@ -13,8 +13,8 @@ pub enum Term {
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct TermDag {
-    nodes: Vec<Term>,
-    hashcons: HashMap<Term, usize>,
+    pub nodes: Vec<Term>,
+    pub hashcons: HashMap<Term, usize>,
 }
 
 #[macro_export]


### PR DESCRIPTION
Follow up on @oflatt's #176  which introduces a `TermDag` and exposes it via the `ExtractReport`.

This PR makes the `TermDag` public and also makes both fields on it public.

This is needed to update the `ExtractReport` bindings in Python (see https://github.com/metadsl/egglog-python/pull/42).

I wasn't sure whether to expose the `TermDag` and `Term` types at the top level module (what I did) or whether to expose the `egglog::termdag` module as a whole.  I am happy to change it if you prefer.