### PR TITLE
Show parse error's line number and column number

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use egglog::{CompilerPassStop, EGraph, SerializeConfig};
+use egglog::{CompilerPassStop, EGraph, Error, SerializeConfig};
 use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 
@@ -91,10 +91,11 @@ fn main() {
         });
         let mut egraph = mk_egraph();
         let already_enables = program_read.starts_with("(set-option enable_proofs 1)");
-        let program = if args.proofs && !already_enables {
-            format!("(set-option enable_proofs 1)\n{}", program_read)
+        let (program, program_offset) = if args.proofs && !already_enables {
+            let expr = "(set-option enable_proofs 1)\n";
+            (format!("{}{}", expr, program_read), expr.len())
         } else {
-            program_read
+            (program_read, 0)
         };
 
         if args.desugar || args.resugar {
@@ -121,6 +122,40 @@ fn main() {
                     }
                 }
                 Err(err) => {
+                    let err = match err {
+                        Error::ParseError(err) => err
+                            .map_location(|byte_offset| {
+                                let byte_offset = byte_offset - program_offset;
+                                let (line_num, sum_offset) = std::iter::once(0)
+                                    .chain(program.split_inclusive('\n').scan(
+                                        0,
+                                        |sum_offset, l| {
+                                            *sum_offset += l.len();
+
+                                            if *sum_offset > byte_offset {
+                                                None
+                                            } else {
+                                                Some(*sum_offset)
+                                            }
+                                        },
+                                    ))
+                                    .enumerate()
+                                    .last()
+                                    // No panic because of the initial 0
+                                    .unwrap();
+                                {
+                                    format!(
+                                        "{}:{}:{}",
+                                        input.display(),
+                                        line_num + 1,
+                                        // TODO: Show utf8 aware character count
+                                        byte_offset - sum_offset + 1
+                                    )
+                                }
+                            })
+                            .to_string(),
+                        err => err.to_string(),
+                    };
                     log::error!("{}", err);
                     std::process::exit(1)
                 }


### PR DESCRIPTION
This PR makes a parse error message more readable

Before 
```
[ERROR] Unrecognized token `)` found at 169:170
    Expected one of r#"(([[:alpha:]][\\w-]*)|([-+*/?!=<>&|^/%_]))+"# or r#"(-)?[0-9]+"#
```

After
```
[ERROR] Unrecognized token `)` found at ../tmp/path.egg:11:5:../tmp/path.egg:11:6
    Expected one of r#"(([[:alpha:]][\\w-]*)|([-+*/?!=<>&|^/%_]))+"# or r#"(-)?[0-9]+"#
```

This will be very helpful for new users like me.