### PR TITLE
Make TermDag indices opaque, write tests for TermDag

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -193,3 +193,24 @@ impl Display for Expr {
         write!(f, "{}", self.to_sexp())
     }
 }
+
+// currently only used for testing, but no reason it couldn't be used elsewhere later
+#[cfg(test)]
+pub(crate) fn parse_expr(s: &str) -> Result<Expr, lalrpop_util::ParseError<usize, String, String>> {
+    let parser = ast::parse::ExprParser::new();
+    parser
+        .parse(s)
+        .map_err(|e| e.map_token(|tok| tok.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parser_display_roundtrip() {
+        let s = r#"(f (g a 3) 4.0 (H "hello"))"#;
+        let e = parse_expr(s).unwrap();
+        assert_eq!(format!("{}", e), s);
+    }
+}

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -133,7 +133,7 @@ Schema: Schema = {
     <types:List<Type>> <output:Type> => Schema { input: types, output }
 }
 
-Expr: Expr = {
+pub Expr: Expr = {
     <Literal> => Expr::Lit(<>),
     <Ident> => Expr::Var(<>),
     <CallExpr> => <>,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -120,7 +120,7 @@ impl<'a> Extractor<'a> {
             children.push(self.find_best(*value, termdag, arcsort)?.1)
         }
 
-        Some(termdag.make(node.sym, children))
+        Some(termdag.app(node.sym, children))
     }
 
     pub fn find_best(
@@ -172,7 +172,7 @@ impl<'a> Extractor<'a> {
                         if let Some((term_inputs, new_cost)) =
                             self.node_total_cost(func, inputs, termdag)
                         {
-                            let make_new_pair = || (new_cost, termdag.make(sym, term_inputs));
+                            let make_new_pair = || (new_cost, termdag.app(sym, term_inputs));
 
                             let id = self.find(&output.value);
                             match self.costs.entry(id) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,7 +511,7 @@ impl EGraph {
             } else {
                 termdag.expr_to_term(&schema.output.make_expr(self, out.value).1)
             };
-            terms.push((termdag.make(sym, children), out));
+            terms.push((termdag.app(sym, children), out));
         }
         drop(extractor);
 

--- a/src/termdag.rs
+++ b/src/termdag.rs
@@ -74,7 +74,7 @@ impl TermDag {
     /// and insert into the DAG if it is not already present.
     ///
     /// Panics if any of the children are not already in the DAG.
-    pub fn make(&mut self, sym: Symbol, children: Vec<Term>) -> Term {
+    pub fn app(&mut self, sym: Symbol, children: Vec<Term>) -> Term {
         let node = Term::App(sym, children.iter().map(|c| self.lookup(c)).collect());
 
         self.add_node(&node);

--- a/tests/terms.rs
+++ b/tests/terms.rs
@@ -1,0 +1,24 @@
+use egglog::*;
+
+// This file tests the public API to terms.
+
+#[test]
+#[should_panic]
+fn test_termdag_malicious_client() {
+    // here is an example of how TermIds can be misused by passing
+    // them into the wrong DAG.
+
+    let mut td = TermDag::default();
+    let x = td.var("x".into());
+    // at this point, td = [0 |-> x]
+    // snapshot the current td
+    let td2 = td.clone();
+    let y = td.var("y".into());
+    // now td = [0 |-> x, 1 |-> y]
+    let f = td.app("f".into(), vec![x.clone(), y.clone()]);
+    // f is Term::App("f", [0, 1])
+    assert_eq!(td.to_string(&f), "(f x y)");
+    // recall that td2 = [0 |-> x]
+    // notice that f refers to index 1, so this crashes:
+    td2.to_string(&f);
+}

--- a/tests/terms.rs
+++ b/tests/terms.rs
@@ -3,6 +3,15 @@ use egglog::*;
 // This file tests the public API to terms.
 
 #[test]
+fn test_termdag_public() {
+    let mut td = TermDag::default();
+    let x = td.var("x".into());
+    let seven = td.lit(7.into());
+    let f = td.app("f".into(), vec![x, seven]);
+    assert_eq!(td.to_string(&f), "(f x 7)");
+}
+
+#[test]
 #[should_panic]
 fn test_termdag_malicious_client() {
     // here is an example of how TermIds can be misused by passing


### PR DESCRIPTION
@oflatt mentioned he would prefer callers not to be able to construct Terms directly, but still be allowed to pattern match on them. I don't think exactly that is possible in Rust, but here is an alternative. We make the indices into the DAG opaque, but we leave the Term enum fully public. That way the API kinda pushes you toward only constructing one layer of a term at a time, which is exactly how it should be used. Oliver, what do you think?

This PR also adds a bunch of tests about terms (and a bit about exprs). If we decide not to make the term index change, I can split this PR to just merge the tests.

There is also a test that demonstrates how a caller can still shoot themselves in the foot by taking TermId from one TermDag and passing it to a different TermDag. This could cause wrong results or panic. I think this is not a dealbreaker and is a relatively easy failure mode to explain to callers.