### PR TITLE
Rename ExtractReport::{expr -> term}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub struct RunReport {
 #[derive(Debug, Clone)]
 pub struct ExtractReport {
     pub cost: usize,
-    pub expr: Term,
+    pub term: Term,
     pub variants: Vec<Term>,
     pub termdag: TermDag,
 }
@@ -1093,7 +1093,7 @@ impl EGraph {
                 for expr in exprs {
                     use std::io::Write;
                     let res = self.extract_expr(expr, 1)?;
-                    writeln!(f, "{}", res.termdag.to_string(&res.expr))
+                    writeln!(f, "{}", res.termdag.to_string(&res.term))
                         .map_err(|e| Error::IoError(filename.clone(), e))?;
                 }
 
@@ -1128,7 +1128,7 @@ impl EGraph {
         };
         Ok(ExtractReport {
             cost,
-            expr,
+            term: expr,
             variants,
             termdag,
         })


### PR DESCRIPTION
The old name was confusing because `Expr` refers to a different data structure
without sharing.

cc @oflatt