### PR TITLE
Make match_term_app! support arbitrary patterns

### DIFF
--- a/src/termdag.rs
+++ b/src/termdag.rs
@@ -34,19 +34,13 @@ pub struct TermDag {
 #[macro_export]
 macro_rules! match_term_app {
     ($e:expr; { $(
-        ($head:expr, $args:pat) => $body:expr $(,)?
+        $p:pat => $body:expr $(,)?
     ),*}) => {
         match $e {
             Term::App(head, args) => {
-                $(
-                    if head.as_str() == $head {
-                        match args.as_slice() {
-                            $args => $body,
-                            _ => panic!("arg mismatch"),
-                        }
-                    } else
-                )* {
-                    panic!("Failed to match any of the heads of the patterns. Got: {}", head);
+                match (head.as_str(), args.as_slice()) {
+                    $($p => $body,)*
+                    _ => { panic!("Failed to match any of the heads of the patterns. Got: {}", head); }
                 }
             }
             _ => panic!("not an app")

--- a/src/termdag.rs
+++ b/src/termdag.rs
@@ -33,15 +33,11 @@ pub struct TermDag {
 
 #[macro_export]
 macro_rules! match_term_app {
-    ($e:expr; { $(
-        $p:pat => $body:expr $(,)?
-    ),*}) => {
+    ($e:expr; $body:tt) => {
         match $e {
             Term::App(head, args) => {
-                match (head.as_str(), args.as_slice()) {
-                    $($p => $body,)*
-                    _ => { panic!("Failed to match any of the heads of the patterns. Got: {}", head); }
-                }
+                match (head.as_str(), args.as_slice())
+                    $body
             }
             _ => panic!("not an app")
         }

--- a/src/termdag.rs
+++ b/src/termdag.rs
@@ -7,6 +7,8 @@ use crate::{
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct TermId(usize);
 
+
+#[allow(rustdoc::private_intra_doc_links)]
 /// Like [`Expr`]s but with sharing and deduplication.
 ///
 /// Terms refer to their children indirectly via opaque [TermId]s (internally
@@ -236,7 +238,8 @@ mod tests {
         let (td, t) = parse_term(s);
         match_term_app!(t; {
             ("f", [_, x, _, _]) =>
-                assert_eq!(td.term_to_expr(&td.get(*x)), ast::Expr::Var(Symbol::new("x")))
+                assert_eq!(td.term_to_expr(&td.get(*x)), ast::Expr::Var(Symbol::new("x"))),
+            (head, _) => panic!("unexpected head {}, in {}:{}:{}", head, file!(), line!(), column!())
         })
     }
 


### PR DESCRIPTION
Now you can write arbitrary patterns in `match_term_app!`. I will use this in
eggcc as I refactor CFG conversion to use terms instead of expressions.