### PR TITLE
Fix Web Demo badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # egglog
 
-<a href="https://egraphs-good.github.io/egglog/docs/egglog">
+<a href="https://egraphs-good.github.io/egglog/">
     <img alt="Web Demo" src="https://img.shields.io/badge/-web demo-blue"></a>
 <a href="https://egraphs-good.github.io/egglog/docs/egglog">
     <img alt="Main Branch Documentation" src="https://img.shields.io/badge/docs-main-blue"></a>


### PR DESCRIPTION
Web Demo badge link pointed to the docs, not the web demo. I'm assuming that was not intentional!