### PR TITLE
Update link to zulip chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://egg-smol-python.readthedocs.io/en/latest/
 ## Chat
 
 There is a Zulip chat about egglog here:
-https://egraphs.zulipchat.com/#narrow/stream/328979-Implementation/topic/Eggsmol
+https://egraphs.zulipchat.com/#narrow/stream/375765-egglog
 
 ## Prerequisites & compilation
 


### PR DESCRIPTION
There is now a full egglog stream and the egg-smol topic is not used anymore.