### PR TITLE
Better rule and ruleset timing statistics

### DIFF
--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -584,6 +584,9 @@ pub(crate) fn desugar_command(
         Command::RunSchedule(sched) => {
             vec![NCommand::RunSchedule(desugar_schedule(desugar, &sched))]
         }
+        Command::PrintOverallStatistics => {
+            vec![NCommand::PrintOverallStatistics]
+        }
         Command::Extract { variants, fact } => {
             let fresh = desugar.get_fresh();
             let fresh_ruleset = desugar.get_fresh();

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -100,6 +100,7 @@ pub enum NCommand {
     },
     NormAction(NormAction),
     RunSchedule(NormSchedule),
+    PrintOverallStatistics,
     Check(Vec<NormFact>),
     CheckProof,
     PrintTable(Symbol, usize),
@@ -144,6 +145,7 @@ impl NCommand {
                 rule: rule.to_rule(),
             },
             NCommand::RunSchedule(schedule) => Command::RunSchedule(schedule.to_schedule()),
+            NCommand::PrintOverallStatistics => Command::PrintOverallStatistics,
             NCommand::NormAction(action) => Command::Action(action.to_action()),
             NCommand::Check(facts) => {
                 Command::Check(facts.iter().map(|fact| fact.to_fact()).collect())
@@ -176,6 +178,7 @@ impl NCommand {
             NCommand::Function(f) => NCommand::Function(f.clone()),
             NCommand::AddRuleset(name) => NCommand::AddRuleset(*name),
             NCommand::RunSchedule(schedule) => NCommand::RunSchedule(schedule.clone()),
+            NCommand::PrintOverallStatistics => NCommand::PrintOverallStatistics,
             NCommand::NormRule {
                 name,
                 ruleset,
@@ -346,6 +349,9 @@ pub enum Command {
     BiRewrite(Symbol, Rewrite),
     Action(Action),
     RunSchedule(Schedule),
+    /// Print runtime statistics about rules
+    /// and rulesets so far.
+    PrintOverallStatistics,
     Simplify {
         expr: Expr,
         schedule: Schedule,
@@ -394,6 +400,7 @@ impl ToSexp for Command {
                 rule,
             } => rule.to_sexp(*ruleset, *name),
             Command::RunSchedule(sched) => list!("run-schedule", sched),
+            Command::PrintOverallStatistics => list!("print-stats"),
             Command::Calc(args, exprs) => list!("calc", list!(++ args), ++ exprs),
             Command::Extract { variants, fact } => {
                 list!("query-extract", ":variants", variants, fact)

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -79,6 +79,7 @@ Command: Command = {
     LParen "check" <(Fact)*> RParen => Command::Check(<>),
     LParen "check-proof" RParen => Command::CheckProof,
     LParen "run-schedule" <Schedule*> RParen => Command::RunSchedule(Schedule::Sequence(<>)),
+    LParen "print-stats" RParen => Command::PrintOverallStatistics,
     LParen "push" <UNum?> RParen => Command::Push(<>.unwrap_or(1)),
     LParen "pop" <UNum?> RParen => Command::Pop(<>.unwrap_or(1)),
     LParen "print-table" <sym:Ident> <n:UNum?> RParen => Command::PrintTable(sym, n.unwrap_or(10)),

--- a/tests/math-microbenchmark.egg
+++ b/tests/math-microbenchmark.egg
@@ -67,3 +67,5 @@
 (run 10)
 (print-size Add)
 (print-size Mul)
+
+(print-stats)


### PR DESCRIPTION
This PR improves the run report to report timing information for individual rules and also for rulesets.
It also adds, in addition to the existing run report for the most recently run schedule, a report that collects statistics across all the runs.