### PR TITLE
Add a replace action

### DIFF
--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -411,6 +411,17 @@ fn add_semi_naive_rule(desugar: &mut Desugar, rule: Rule) -> Option<Rule> {
                     new_head_atoms.push(Fact::Eq(vec![fresh_var, expr]));
                 };
             }
+            Action::Replace { new_output, .. } => {
+                var_set.extend(new_output.vars());
+                if let Expr::Call(_, _) = new_output {
+                    add_new_rule = true;
+
+                    let fresh_symbol = desugar.get_fresh();
+                    let fresh_var = Expr::Var(fresh_symbol);
+                    let new_output = std::mem::replace(new_output, fresh_var.clone());
+                    new_head_atoms.push(Fact::Eq(vec![fresh_var, new_output]));
+                };
+            }
             Action::Let(symbol, expr) if var_set.contains(symbol) => {
                 var_set.extend(expr.vars());
                 if let Expr::Call(_, _) = expr {

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -252,21 +252,22 @@ fn flatten_actions(actions: &Vec<Action>, desugar: &mut Desugar) -> Vec<NormActi
                 res.push(set);
             }
             Action::Replace {
-                constructor,
+                old_constructor: constructor,
+                new_constructor: other_constructor,
                 old_args,
                 new_args,
                 new_output,
             } => {
                 let replace = NormAction::Replace(
                     NormExpr::Call(
-                        constructor,
+                        *constructor,
                         old_args
                             .iter()
                             .map(|ex| add_expr(ex.clone(), &mut res))
                             .collect(),
                     ),
                     NormExpr::Call(
-                        constructor,
+                        *other_constructor,
                         new_args
                             .iter()
                             .map(|ex| add_expr(ex.clone(), &mut res))

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -251,6 +251,31 @@ fn flatten_actions(actions: &Vec<Action>, desugar: &mut Desugar) -> Vec<NormActi
                 );
                 res.push(set);
             }
+            Action::Replace {
+                constructor,
+                old_args,
+                new_args,
+                new_output,
+            } => {
+                let replace = NormAction::Replace(
+                    NormExpr::Call(
+                        constructor,
+                        old_args
+                            .iter()
+                            .map(|ex| add_expr(ex.clone(), &mut res))
+                            .collect(),
+                    ),
+                    NormExpr::Call(
+                        constructor,
+                        new_args
+                            .iter()
+                            .map(|ex| add_expr(ex.clone(), &mut res))
+                            .collect(),
+                    ),
+                    add_expr(new_output.clone(), &mut res),
+                );
+                res.push(replace);
+            }
             Action::Extract(expr, variants) => {
                 let added = add_expr(expr.clone(), &mut res);
                 let added_variants = add_expr(variants.clone(), &mut res);

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -107,6 +107,8 @@ Cost: Option<usize> = {
 NonLetAction: Action = {
     LParen "set" LParen <f: Ident> <args:Expr*> RParen <v:Expr> RParen => Action::Set ( f, args, v ),
     LParen "delete" LParen <f: Ident> <args:Expr*> RParen RParen => Action::Delete ( f, args),
+    LParen "replace" LParen <constructor: Ident> <old_args:Expr*> RParen 
+    LParen <constructor: Ident> <new_args:Expr*> RParen <new_output:Expr> RParen => Action::Replace { constructor, old_args, new_args, new_output},
     LParen "union" <e1:Expr> <e2:Expr> RParen => Action::Union(<>),
     LParen "panic" <msg:String> RParen => Action::Panic(msg),
     LParen "extract" <expr:Expr> RParen => Action::Extract(expr, Expr::Lit(Literal::Int(0))),

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -107,8 +107,8 @@ Cost: Option<usize> = {
 NonLetAction: Action = {
     LParen "set" LParen <f: Ident> <args:Expr*> RParen <v:Expr> RParen => Action::Set ( f, args, v ),
     LParen "delete" LParen <f: Ident> <args:Expr*> RParen RParen => Action::Delete ( f, args),
-    LParen "replace" LParen <constructor: Ident> <old_args:Expr*> RParen 
-    LParen <constructor: Ident> <new_args:Expr*> RParen <new_output:Expr> RParen => Action::Replace { constructor, old_args, new_args, new_output},
+    LParen "replace" LParen <old_constructor: Ident> <old_args:Expr*> RParen 
+    LParen <new_constructor: Ident> <new_args:Expr*> RParen <new_output:Expr> RParen => Action::Replace { new_constructor, old_constructor, old_args, new_args, new_output},
     LParen "union" <e1:Expr> <e2:Expr> RParen => Action::Union(<>),
     LParen "panic" <msg:String> RParen => Action::Panic(msg),
     LParen "extract" <expr:Expr> RParen => Action::Extract(expr, Expr::Lit(Literal::Int(0))),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -470,6 +470,28 @@ impl<'a> ActionChecker<'a> {
                 self.instructions.push(Instruction::Set(*f));
                 Ok(())
             }
+            Action::Replace {
+                old_constructor,
+                new_constructor,
+                old_args,
+                new_args,
+                new_output,
+            } => {
+                let fake_call_old = Expr::Call(*old_constructor, old_args.clone());
+                let (_, _ty) = self.infer_expr(&fake_call_old)?;
+                let fake_instr_old = self.instructions.pop().unwrap();
+                assert!(matches!(fake_instr_old, Instruction::CallFunction(..)));
+                let fake_call_new = Expr::Call(*new_constructor, new_args.clone());
+                let (_, ty2) = self.infer_expr(&fake_call_new)?;
+                let fake_instr_new = self.instructions.pop().unwrap();
+                assert!(matches!(fake_instr_new, Instruction::CallFunction(..)));
+                self.check_expr(new_output, ty2)?;
+                self.instructions.push(Instruction::Replace {
+                    old_constructor: *old_constructor,
+                    new_constructor: *new_constructor,
+                });
+                Ok(())
+            }
             Action::Extract(variable, variants) => {
                 let (_, _ty) = self.infer_expr(variable)?;
                 let (_, _ty2) = self.infer_expr(variants)?;
@@ -653,6 +675,10 @@ enum Instruction {
     CallPrimitive(Primitive, usize),
     DeleteRow(Symbol),
     Set(Symbol),
+    Replace {
+        old_constructor: Symbol,
+        new_constructor: Symbol,
+    },
     Union(usize),
     Extract(usize),
     Panic(String),
@@ -712,6 +738,56 @@ impl EGraph {
         };
 
         Ok((t, Program(checker.instructions)))
+    }
+
+    fn perform_set(
+        &mut self,
+        table: Symbol,
+        args: &[Value],
+        new_value: Value,
+        stack: &mut Vec<Value>,
+    ) -> Result<(), Error> {
+        let function = self.functions.get_mut(&table).unwrap();
+        // We should only have canonical values here: omit the canonicalization step
+        let old_value = function.get(args);
+
+        if let Some(old_value) = old_value {
+            if new_value != old_value {
+                let merged: Value = match function.merge.merge_vals.clone() {
+                    MergeFn::AssertEq => {
+                        return Err(Error::MergeError(table, new_value, old_value));
+                    }
+                    MergeFn::Union => {
+                        self.unionfind
+                            .union_values(old_value, new_value, old_value.tag)
+                    }
+                    MergeFn::Expr(merge_prog) => {
+                        let values = [old_value, new_value];
+                        let old_len = stack.len();
+                        self.run_actions(stack, &values, &merge_prog, true)?;
+                        let result = stack.pop().unwrap();
+                        stack.truncate(old_len);
+                        result
+                    }
+                };
+                if merged != old_value {
+                    let function = self.functions.get_mut(&table).unwrap();
+                    function.insert(args, merged, self.timestamp);
+                }
+                // re-borrow
+                let function = self.functions.get_mut(&table).unwrap();
+                if let Some(prog) = function.merge.on_merge.clone() {
+                    let values = [old_value, new_value];
+                    // XXX: we get an error if we pass the current
+                    // stack and then truncate it to the old length.
+                    // Why?
+                    self.run_actions(&mut Vec::new(), &values, &prog, true)?;
+                }
+            }
+        } else {
+            function.insert(args, new_value, self.timestamp);
+        }
+        Ok(())
     }
 
     pub fn run_actions(
@@ -797,6 +873,42 @@ impl EGraph {
                         return Err(Error::PrimitiveError(p.clone(), values.to_vec()));
                     }
                 }
+                Instruction::Replace {
+                    old_constructor,
+                    new_constructor,
+                } => {
+                    let new_value = stack.pop().unwrap();
+
+                    let new_function = self.functions.get_mut(new_constructor).unwrap();
+                    let new_len = stack.len() - new_function.schema.input.len();
+                    let new_args = stack[new_len..].to_vec();
+
+                    let old_function = self.functions.get(old_constructor).unwrap();
+
+                    let old_len = new_len - old_function.schema.input.len();
+                    let old_args = stack[old_len..new_len].to_vec();
+
+                    if old_constructor != new_constructor {
+                        let old_function = self.functions.get_mut(old_constructor).unwrap();
+                        // just do a delete and a set
+                        old_function.remove(&old_args, self.timestamp);
+
+                        self.perform_set(*new_constructor, &new_args, new_value, stack)?;
+                    } else if let Some(old_val) = old_function.get(&old_args) {
+                        if old_val != new_value || old_args != new_args {
+                            let new_function = self.functions.get_mut(new_constructor).unwrap();
+                            new_function.remove(&old_args, self.timestamp);
+
+                            self.perform_set(*new_constructor, &new_args, new_value, stack)?;
+                        } else {
+                            // do nothing when they are the same
+                        }
+                    } else {
+                        // just set the new one, old doesn't exist
+                        self.perform_set(*new_constructor, &new_args, new_value, stack)?;
+                    }
+                    stack.truncate(old_len);
+                }
                 Instruction::Set(f) => {
                     assert!(make_defaults);
                     let function = self.functions.get_mut(f).unwrap();
@@ -805,48 +917,10 @@ impl EGraph {
                     // except for setting the parent relation
                     let new_value = stack.pop().unwrap();
                     let new_len = stack.len() - function.schema.input.len();
-                    let args = &stack[new_len..];
+                    // TODO would be nice to use slice here
+                    let args = stack[new_len..].to_vec();
 
-                    // We should only have canonical values here: omit the canonicalization step
-                    let old_value = function.get(args);
-
-                    if let Some(old_value) = old_value {
-                        if new_value != old_value {
-                            let merged: Value = match function.merge.merge_vals.clone() {
-                                MergeFn::AssertEq => {
-                                    return Err(Error::MergeError(*f, new_value, old_value));
-                                }
-                                MergeFn::Union => {
-                                    self.unionfind
-                                        .union_values(old_value, new_value, old_value.tag)
-                                }
-                                MergeFn::Expr(merge_prog) => {
-                                    let values = [old_value, new_value];
-                                    let old_len = stack.len();
-                                    self.run_actions(stack, &values, &merge_prog, true)?;
-                                    let result = stack.pop().unwrap();
-                                    stack.truncate(old_len);
-                                    result
-                                }
-                            };
-                            if merged != old_value {
-                                let args = &stack[new_len..];
-                                let function = self.functions.get_mut(f).unwrap();
-                                function.insert(args, merged, self.timestamp);
-                            }
-                            // re-borrow
-                            let function = self.functions.get_mut(f).unwrap();
-                            if let Some(prog) = function.merge.on_merge.clone() {
-                                let values = [old_value, new_value];
-                                // XXX: we get an error if we pass the current
-                                // stack and then truncate it to the old length.
-                                // Why?
-                                self.run_actions(&mut Vec::new(), &values, &prog, true)?;
-                            }
-                        }
-                    } else {
-                        function.insert(args, new_value, self.timestamp);
-                    }
+                    self.perform_set(*f, &args, new_value, stack)?;
                     stack.truncate(new_len)
                 }
                 Instruction::Union(arity) => {

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -365,6 +365,19 @@ impl TypeInfo {
                     });
                     assert_bound(var, let_bound);
                 }
+                NormAction::Replace(
+                    NormExpr::Call(_old_constructor, old_args),
+                    NormExpr::Call(_new_constructor, new_args),
+                    new_value,
+                ) => {
+                    old_args.iter().for_each(|bvar| {
+                        assert_bound(bvar, let_bound);
+                    });
+                    new_args.iter().for_each(|bvar| {
+                        assert_bound(bvar, let_bound);
+                    });
+                    assert_bound(new_value, let_bound);
+                }
                 NormAction::Extract(var, variants) => {
                     assert_bound(var, let_bound);
                     assert_bound(variants, let_bound);
@@ -425,6 +438,14 @@ impl TypeInfo {
                 let other_type = self.lookup(ctx, *other)?;
                 if func_type.name() != other_type.name() {
                     return Err(TypeError::TypeMismatch(func_type, other_type));
+                }
+            }
+            NormAction::Replace(expr1, expr2, new_value) => {
+                let func_type1 = self.typecheck_expr(ctx, expr1, true)?.output;
+                let func_type2 = self.typecheck_expr(ctx, expr2, true)?.output;
+                let new_value_type = self.lookup(ctx, *new_value)?;
+                if func_type2.name() != new_value_type.name() {
+                    return Err(TypeError::TypeMismatch(func_type1, new_value_type));
                 }
             }
             NormAction::Union(var1, var2) => {

--- a/tests/replace-basic.egg
+++ b/tests/replace-basic.egg
@@ -1,0 +1,26 @@
+
+
+(function Add (i64 i64) i64)
+
+
+(set (Add 1 1) 2)
+
+(replace (Add 1 1) (Add 1 1) 3)
+
+(fail (check (= (Add 1 1) 2)))
+
+(check (= (Add 1 1) 3))
+
+
+
+(function Sub (i64 i64) i64)
+
+(set (Add 2 2) 3)
+
+(set (Sub 2 2) 1)
+
+(replace (Add 2 2) (Sub 3 3) 4)
+
+(fail (check (= (Add 2 2) 3)))
+(check (= (Sub 2 2) 1))
+(check (= (Sub 3 3) 4))

--- a/tests/replace-saturates.egg
+++ b/tests/replace-saturates.egg
@@ -1,0 +1,14 @@
+
+
+(function Add (i64 i64) i64)
+
+
+(set (Add 1 1) 2)
+
+
+(rule ((Add a b))
+      ((replace (Add a b)
+       (Add a b) 2)))
+
+       
+(run-schedule (saturate (run)))


### PR DESCRIPTION
When writing rules where one row in a table subsumes another, it's often hard to write the rules. This PR adds a prototype for a `replace` action to solve this problem.

In particular, the only way to do it right now is to use `delete`. However, if the two rows are actually the same, the problem is that we never saturate.
Stupid example that runs forever:
[https://egraphs-good.github.io/egglog/?program=XQAAgACeAAAAAAAAAAAFYJzIYToE-74urWhpV-IA_[…]IY2FIeFaKKvnanDvE9ubGR2gphrxqDRu1WAeyBGxkXMQP_-wXIAA%253D](https://egraphs-good.github.io/egglog/?program=XQAAgACeAAAAAAAAAAAFYJzIYToE-74urWhpV-IA_FDhGu3fewDZx-wvrHQ77dBuxcNtTt8GO8U3aYj9B8GU5s5_6Xs03CIMEusIY2FIeFaKKvnanDvE9ubGR2gphrxqDRu1WAeyBGxkXMQP_-wXIAA%253D)

This PR fixes this problem by adding a `replace` action, allowing for one row to replace another (and does nothing when they are the same).