### PR TITLE
fix: use single import for `Rule`

### DIFF
--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use super::Rule;
 
 fn desugar_datatype(name: Symbol, variants: Vec<Variant>) -> Vec<NCommand> {
     vec![NCommand::Sort(name, None)]

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use super::Rule;
+use crate::*;
 
 fn desugar_datatype(name: Symbol, variants: Vec<Variant>) -> Vec<NCommand> {
     vec![NCommand::Sort(name, None)]


### PR DESCRIPTION
Hi, we have been troubleshooting a name resolution bug and discovered that ﻿`egglog` has a regression case. You can find more details at https://github.com/rust-lang/rust/pull/115269.

In this context, `﻿crate::ast::Rule` should be overshadowed by ﻿`crate::Rule` when `﻿crate::*` is used.