### PR TITLE
Clarify that merge should be monotonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ If you define a `:merge` expression, you can update specific values in the funct
 (extract (KeepMax 1)) ; this is 2
 ```
 
+Note that the `:merge` expression must be monotonic, meaning that if you merge any number of values, the ordering in which the merges are applied should not affect the final result.
+
 
 ### `declare` command
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If you define a `:merge` expression, you can update specific values in the funct
 (extract (KeepMax 1)) ; this is 2
 ```
 
-Note that the `:merge` expression must be monotonic, meaning that if you merge any number of values, the ordering in which the merges are applied should not affect the final result.
+Note that the `:merge` expression must be monotonic, meaning that if you merge any number of values, the ordering in which the merges are applied should not affect the final result, and similarily if you apply the same merge multiple times it should be consistant. If the merge expression is not monotonic, the behavior is undefined, it might be applied more than once during an application.
 
 
 ### `declare` command


### PR DESCRIPTION
Resolves the question in #229 by stating that merge functions must be monotonic, otherwise there is undefined behavior.