### PR TITLE
Fix `query-extract` for `vec`

### DIFF
--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -468,3 +468,35 @@ impl PrimitiveLike for Set {
         vec.store(&self.vec)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vec_make_expr() {
+        let mut egraph = EGraph::default();
+        let outputs = egraph
+            .parse_and_run_program(
+                r#"
+            (sort IVec (Vec i64))
+            (let v0 (vec-empty))
+            (let v1 (vec-of 1 2 3 4))
+            (extract v0)
+            (extract v1)
+            "#,
+            )
+            .unwrap();
+
+        // Check extracted expr is parsed as an original expr
+        egraph
+            .parse_and_run_program(&format!(
+                r#"
+                (check (= v0 {}))
+                (check (= v1 {}))
+                "#,
+                outputs[0], outputs[1],
+            ))
+            .unwrap();
+    }
+}


### PR DESCRIPTION
Currently, `query-extract` for `vec` prints the reverse order of the argument

```
(sort IVec (Vec i64))

(let e (vec-of 1 2 3 4))
(query-extract e) ; => (vec-push (vec-push (vec-push (vec-push (vec-empty) 4) 3) 2) 1)

(check (= e (vec-push (vec-push (vec-push (vec-push (vec-empty) 4) 3) 2) 1))) ; fail
```

This PR fixes it and prints by `vec-of`

```
(sort IVec (Vec i64))

(let e (vec-of 1 2 3 4))
(query-extract e) ; => (vec-of 1 2 3 4)
(query-extract (vec-empty)) ; => (vec-empty)

(check (= e (vec-of 1 2 3 4))) ; OK
```
