### PR TITLE
Update Fact accept CallExpr instead of Expr

### DIFF
--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -453,7 +453,7 @@ pub(crate) fn desugar_simplify(
         desugar_command(
             Command::Extract {
                 variants: 0,
-                fact: Fact::Fact(Expr::Var(lhs)),
+                expr: Expr::Var(lhs),
             },
             desugar,
             false,
@@ -592,16 +592,16 @@ pub(crate) fn desugar_command(
         Command::PrintOverallStatistics => {
             vec![NCommand::PrintOverallStatistics]
         }
-        Command::Extract { variants, fact } => {
+        Command::Extract { variants, expr } => {
             let fresh = desugar.get_fresh();
             let fresh_ruleset = desugar.get_fresh();
-            let desugaring = if let Fact::Fact(Expr::Var(v)) = fact {
+            let desugaring = if let Expr::Var(v) = expr {
                 format!("(extract {v} {variants})")
             } else {
                 format!(
-                    "(check {fact})
+                    "(check {expr})
                     (ruleset {fresh_ruleset})
-                    (rule ((= {fresh} {fact}))
+                    (rule ((= {fresh} {expr}))
                           ((extract {fresh} {variants}))
                           :ruleset {fresh_ruleset})
                     (run {fresh_ruleset} 1)"

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -381,7 +381,7 @@ pub enum Command {
     Calc(Vec<IdentSort>, Vec<Expr>),
     Extract {
         variants: usize,
-        fact: Fact,
+        expr: Expr,
     },
     // TODO: this could just become an empty query
     Check(Vec<Fact>),
@@ -428,8 +428,8 @@ impl ToSexp for Command {
             Command::RunSchedule(sched) => list!("run-schedule", sched),
             Command::PrintOverallStatistics => list!("print-stats"),
             Command::Calc(args, exprs) => list!("calc", list!(++ args), ++ exprs),
-            Command::Extract { variants, fact } => {
-                list!("query-extract", ":variants", variants, fact)
+            Command::Extract { variants, expr } => {
+                list!("query-extract", ":variants", variants, expr)
             }
             Command::Check(facts) => list!("check", ++ facts),
             Command::CheckProof => list!("check-proof"),

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -75,7 +75,7 @@ Command: Command = {
         => Command::Simplify { expr, schedule },
     LParen "add-ruleset" <name:Ident> RParen => Command::AddRuleset(name),
     LParen "calc" LParen <idents:IdentSort*> RParen <exprs:Expr+> RParen => Command::Calc(idents, exprs),
-    LParen "query-extract" <variants:(":variants" <UNum>)?> <fact:Fact> RParen => Command::Extract { fact, variants: variants.unwrap_or(0) },
+    LParen "query-extract" <variants:(":variants" <UNum>)?> <expr:Expr> RParen => Command::Extract { expr, variants: variants.unwrap_or(0) },
     LParen "check" <(Fact)*> RParen => Command::Check(<>),
     LParen "check-proof" RParen => Command::CheckProof,
     LParen "run-schedule" <Schedule*> RParen => Command::RunSchedule(Schedule::Sequence(<>)),
@@ -127,7 +127,7 @@ pub Fact: Fact = {
         es.push(e);
         Fact::Eq(es)
     },
-    <Expr> => Fact::Fact(<>),
+    <CallExpr> => Fact::Fact(<>),
 }
 
 Schema: Schema = {


### PR DESCRIPTION
Fix #243 

This PR

- Fix `Command::Extract` to contain `Expr` instead of `Fact` because inputting `Fact::Eq` into it leads to a runtime error
- Disallow variable and literal itself as a fact
  - Since `Expr::Call` doesn't have its own type yet, `Fact` still has an `Expr`.