### PR TITLE
FIx bool's tag symbol

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -70,7 +70,7 @@ impl From<Symbol> for Value {
 impl From<bool> for Value {
     fn from(b: bool) -> Self {
         Self {
-            tag: Symbol::from("Bool"),
+            tag: Symbol::from("bool"),
             bits: b as u64,
         }
     }

--- a/tests/bool.egg
+++ b/tests/bool.egg
@@ -20,4 +20,15 @@
 (check (= (bool->= 2 1) true))
 (check (= (bool->= 1 1) true))
 
+; Test bool's tag
+(relation R (i64))
+(function F (i64) bool)
 
+(rule
+    ((R i))
+    ((set (F i) true))
+)
+
+(R 0)
+
+(run 3)


### PR DESCRIPTION
```
; Test bool's tag
(relation R (i64))
(function F (i64) bool)

(rule
    ((R i))
    ((set (F i) true))
)

(R 0)

(run 3)
```

fails
```
thread 'main' panicked at /home/hatoo/.cargo/git/checkouts/egglog-0aabc6dbd51d8ac4/a4559d2/src/function/mod.rs:183:17:
assertion `left == right` failed
  left: "bool"
 right: "Bool"
```

I guess this is because of a typo for bool's tag.