### PR TITLE
Add support for matching on rationals

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Rational numbers (fractions) with 64-bit precision for numerator and denominator
 + - * /         ; arithmetic
 min max neg abs floor ceil round
 rational        ; construct from a numerator and denominator
+numer denom     ; get numerator and denominator
 pow log sqrt
 < > <= >=       ; comparisons
 ```

--- a/src/sort/rational.rs
+++ b/src/sort/rational.rs
@@ -50,6 +50,9 @@ impl Sort for RationalSort {
         add_primitives!(eg, "ceil" = |a: R| -> R { a.ceil() });
         add_primitives!(eg, "round" = |a: R| -> R { a.round() });
         add_primitives!(eg, "rational" = |a: i64, b: i64| -> R { R::new(a, b) });
+        add_primitives!(eg, "numer" = |a: R| -> i64 { *a.numer() });
+        add_primitives!(eg, "denom" = |a: R| -> i64 { *a.denom() });
+
         add_primitives!(eg, "to-f64" = |a: R| -> f64 { a.to_f64().unwrap() });
 
         add_primitives!(eg, "pow" = |a: R, b: R| -> Option<R> {
@@ -101,10 +104,10 @@ impl Sort for RationalSort {
             }
         });
 
-        add_primitives!(eg, "<" = |a: R, b: R| -> Opt { if a < b {Some(())} else {None} }); 
-        add_primitives!(eg, ">" = |a: R, b: R| -> Opt { if a > b {Some(())} else {None} }); 
-        add_primitives!(eg, "<=" = |a: R, b: R| -> Opt { if a <= b {Some(())} else {None} }); 
-        add_primitives!(eg, ">=" = |a: R, b: R| -> Opt { if a >= b {Some(())} else {None} }); 
+        add_primitives!(eg, "<" = |a: R, b: R| -> Opt { if a < b {Some(())} else {None} });
+        add_primitives!(eg, ">" = |a: R, b: R| -> Opt { if a > b {Some(())} else {None} });
+        add_primitives!(eg, "<=" = |a: R, b: R| -> Opt { if a <= b {Some(())} else {None} });
+        add_primitives!(eg, ">=" = |a: R, b: R| -> Opt { if a >= b {Some(())} else {None} });
    }
     fn make_expr(&self, _egraph: &EGraph, value: Value) -> (Cost, Expr) {
         assert!(value.tag == self.name());

--- a/tests/rational.egg
+++ b/tests/rational.egg
@@ -1,0 +1,14 @@
+; Test that can run rule matching on rational
+
+(datatype Pretty
+    (pretty-str String)
+    (pretty-rational Rational))
+
+; This will fail with `Unbound variable x in primitive computation` currently:
+; (rewrite (pretty-rational (rational x y)) (pretty-str (+ (to-string x) "/" (to-string y))))
+
+(rewrite (pretty-rational r) (pretty-str (+ (to-string (numer r)) "/" (to-string (denom r)))))
+
+(let z (pretty-rational (rational 1 2)))
+(run 1)
+(check (= z (pretty-str "1/2")))


### PR DESCRIPTION
This PR adds `numer` and `denom` functions to deconstruct rationals.

Otherwise, I couldn't seem to match on the pieces of them in rules, so this lets you do that now.