### PR TITLE
Make s-expression conversion public

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -149,7 +149,10 @@ impl Expr {
         }
     }
 
-    pub(crate) fn to_sexp(&self) -> Sexp {
+    /// Converts this expression into a
+    /// s-expression (symbolic expression).
+    /// Example: `(Add (Add 2 3) 4)`
+    pub fn to_sexp(&self) -> Sexp {
         let res = match self {
             Expr::Lit(lit) => Sexp::Symbol(lit.to_string()),
             Expr::Var(v) => Sexp::Symbol(v.to_string()),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1475,7 +1475,8 @@ impl Display for NormRule {
 }
 
 impl Rule {
-    pub(crate) fn to_sexp(&self, ruleset: Symbol, name: Symbol) -> Sexp {
+    /// Converts this rule into an s-expression.
+    pub fn to_sexp(&self, ruleset: Symbol, name: Symbol) -> Sexp {
         let mut res = vec![
             Sexp::Symbol("rule".into()),
             Sexp::List(self.body.iter().map(|f| f.to_sexp()).collect()),
@@ -1557,7 +1558,8 @@ pub struct Rewrite {
 }
 
 impl Rewrite {
-    pub(crate) fn to_sexp(&self, ruleset: Symbol, is_bidirectional: bool) -> Sexp {
+    /// Converts the rewrite into an s-expression.
+    pub fn to_sexp(&self, ruleset: Symbol, is_bidirectional: bool) -> Sexp {
         let mut res = vec![
             Sexp::Symbol(if is_bidirectional {
                 "birewrite".into()


### PR DESCRIPTION
This PR makes s-expression conversion public for convenience. This also allows users to pretty-print their s-expressions, which we need in the eggcc project.