### PR TITLE
Expose interface to add primitives

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -123,7 +123,7 @@ impl<'a> Extractor<'a> {
     fn expr_from_node(&self, node: &Node, termdag: &mut TermDag) -> Option<Term> {
         let mut children = vec![];
         for value in node.inputs {
-            let arcsort = self.egraph.get_sort(value).unwrap();
+            let arcsort = self.egraph.get_sort_from_value(value).unwrap();
             children.push(self.find_best(*value, termdag, arcsort)?.1)
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1502,7 +1502,7 @@ impl EGraph {
 
     /// Returns a sort based on the type
     pub fn get_sort<S: Sort + Send + Sync>(&self) -> Option<Arc<S>> {
-        self.type_info().get_sort_by(|s| true)
+        self.type_info().get_sort_by(|_| true)
     }
 
     /// Add a user-defined sort
@@ -1592,8 +1592,8 @@ mod tests {
 
     use crate::{
         constraint::SimpleTypeConstraint,
-        sort::{FromSort, I64Sort, IntoSort, SetSort, Sort, VecSort},
-        EGraph, Primitive, PrimitiveLike, Value,
+        sort::{FromSort, I64Sort, IntoSort, Sort, VecSort},
+        EGraph, PrimitiveLike, Value,
     };
 
     struct InnerProduct {
@@ -1614,7 +1614,7 @@ mod tests {
             .into_box()
         }
 
-        fn apply(&self, values: &[crate::Value], egraph: &EGraph) -> Option<crate::Value> {
+        fn apply(&self, values: &[crate::Value], _egraph: &EGraph) -> Option<crate::Value> {
             let mut sum = 0;
             let vec1 = Vec::<Value>::load(&self.vec, &values[0]);
             let vec2 = Vec::<Value>::load(&self.vec, &values[1]);
@@ -1633,7 +1633,7 @@ mod tests {
         let mut egraph = EGraph::default();
         egraph
             .parse_and_run_program(
-                &"
+                "
                 (sort IntVec (Vec i64))
             ",
             )
@@ -1646,15 +1646,14 @@ mod tests {
             ele: i64_sort,
             vec: int_vec_sort,
         });
-        println!("{:?}", egraph
+        egraph
             .parse_and_run_program(
-                &"
+                "
                 (let a (vec-of 1 2 3 4 5 6))
                 (let b (vec-of 6 5 4 3 2 1))
-                ;; (extract (inner-product a b))
                 (check (= (inner-product a b) 56))
             ",
             )
-            .unwrap());
+            .unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1491,7 +1491,7 @@ impl EGraph {
         self.type_info().sorts.get(&value.tag)
     }
 
-    // Get a sort by its type
+    /// Get a sort by its type
     pub fn get_sort<S: Sort + Send + Sync>(&self) -> Option<Arc<S>> {
         self.type_info().get_sort()
     }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -94,7 +94,7 @@ impl EGraph {
         let mut node_ids: NodeIDs = all_calls
             .iter()
             .filter_map(|(_decl, _input, output, node_id)| {
-                if self.get_sort(output).unwrap().is_eq_sort() {
+                if self.get_sort_from_value(output).unwrap().is_eq_sort() {
                     let id = output.bits as usize;
                     let canonical: usize = self.unionfind.find(Id::from(id)).into();
                     let canonical_id: egraph_serialize::ClassId = canonical.to_string().into();
@@ -151,7 +151,7 @@ impl EGraph {
         // Set iff `split_primitive_outputs` is set and this is an output of a function.
         prim_node_id: Option<String>,
     ) -> (egraph_serialize::ClassId, Option<egraph_serialize::NodeId>) {
-        let sort = self.get_sort(value).unwrap();
+        let sort = self.get_sort_from_value(value).unwrap();
         let (class_id, node_id): (egraph_serialize::ClassId, Option<egraph_serialize::NodeId>) =
             if sort.is_eq_sort() {
                 let id: usize = value.bits as usize;

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -67,7 +67,7 @@ impl Sort for I64Sort {
         // Must be in the i64 sort register function because the string sort is registered before the i64 sort.
         typeinfo.add_primitive(CountMatches {
             name: "count-matches".into(),
-            string: typeinfo.get_sort(),
+            string: typeinfo.get_sort_nofail(),
             int: self.clone(),
         });
 

--- a/src/sort/macros.rs
+++ b/src/sort/macros.rs
@@ -61,8 +61,8 @@ macro_rules! add_primitives {
                 }
             }
             type_info.add_primitive($crate::Primitive::from(MyPrim {
-                $( $param: type_info.get_sort::<<$param_t as IntoSort>::Sort>(), )*
-                __out: type_info.get_sort::<<$ret as IntoSort>::Sort>(),
+                $( $param: type_info.get_sort_nofail::<<$param_t as IntoSort>::Sort>(), )*
+                __out: type_info.get_sort_nofail::<<$ret as IntoSort>::Sort>(),
             }))
         }
     }};

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -131,12 +131,12 @@ impl Sort for MapSort {
         typeinfo.add_primitive(NotContains {
             name: "map-not-contains".into(),
             map: self.clone(),
-            unit: typeinfo.get_sort(),
+            unit: typeinfo.get_sort_nofail(),
         });
         typeinfo.add_primitive(Contains {
             name: "map-contains".into(),
             map: self.clone(),
-            unit: typeinfo.get_sort(),
+            unit: typeinfo.get_sort_nofail(),
         });
         typeinfo.add_primitive(Remove {
             name: "map-remove".into(),

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -129,12 +129,12 @@ impl Sort for SetSort {
         typeinfo.add_primitive(NotContains {
             name: "set-not-contains".into(),
             set: self.clone(),
-            unit: typeinfo.get_sort(),
+            unit: typeinfo.get_sort_nofail(),
         });
         typeinfo.add_primitive(Contains {
             name: "set-contains".into(),
             set: self.clone(),
-            unit: typeinfo.get_sort(),
+            unit: typeinfo.get_sort_nofail(),
         });
         typeinfo.add_primitive(Remove {
             name: "set-remove".into(),

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -135,27 +135,27 @@ impl Sort for VecSort {
         typeinfo.add_primitive(NotContains {
             name: "vec-not-contains".into(),
             vec: self.clone(),
-            unit: typeinfo.get_sort(),
+            unit: typeinfo.get_sort_nofail(),
         });
         typeinfo.add_primitive(Contains {
             name: "vec-contains".into(),
             vec: self.clone(),
-            unit: typeinfo.get_sort(),
+            unit: typeinfo.get_sort_nofail(),
         });
         typeinfo.add_primitive(Length {
             name: "vec-length".into(),
             vec: self.clone(),
-            i64: typeinfo.get_sort(),
+            i64: typeinfo.get_sort_nofail(),
         });
         typeinfo.add_primitive(Get {
             name: "vec-get".into(),
             vec: self.clone(),
-            i64: typeinfo.get_sort(),
+            i64: typeinfo.get_sort_nofail(),
         });
         typeinfo.add_primitive(Set {
             name: "vec-set".into(),
             vec: self.clone(),
-            i64: typeinfo.get_sort(),
+            i64: typeinfo.get_sort_nofail(),
         })
     }
 

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -95,7 +95,10 @@ impl TypeInfo {
         }
     }
 
-    pub fn get_sort_by<S: Sort + Send + Sync>(&self, pred: impl Fn(&Arc<S>) -> bool) -> Option<Arc<S>> {
+    pub fn get_sort_by<S: Sort + Send + Sync>(
+        &self,
+        pred: impl Fn(&Arc<S>) -> bool,
+    ) -> Option<Arc<S>> {
         for sort in self.sorts.values() {
             let sort = sort.clone().as_arc_any();
             if let Ok(sort) = Arc::downcast(sort) {
@@ -108,7 +111,7 @@ impl TypeInfo {
     }
 
     pub fn get_sort_nofail<S: Sort + Send + Sync>(&self) -> Arc<S> {
-        match self.get_sort_by(|s| true) {
+        match self.get_sort_by(|_| true) {
             Some(sort) => sort,
             None => panic!("Failed to lookup sort: {}", std::any::type_name::<S>()),
         }

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -95,18 +95,20 @@ impl TypeInfo {
         }
     }
 
-    pub fn get_sort<S: Sort + Send + Sync>(&self) -> Option<Arc<S>> {
+    pub fn get_sort_by<S: Sort + Send + Sync>(&self, pred: impl Fn(&Arc<S>) -> bool) -> Option<Arc<S>> {
         for sort in self.sorts.values() {
             let sort = sort.clone().as_arc_any();
             if let Ok(sort) = Arc::downcast(sort) {
-                return Some(sort);
+                if pred(&sort) {
+                    return Some(sort);
+                }
             }
         }
         None
     }
 
     pub fn get_sort_nofail<S: Sort + Send + Sync>(&self) -> Arc<S> {
-        match self.get_sort() {
+        match self.get_sort_by(|s| true) {
             Some(sort) => sort,
             None => panic!("Failed to lookup sort: {}", std::any::type_name::<S>()),
         }


### PR DESCRIPTION
Right now it is impossible to register a primitive without registering a user-defined sort.

This PR allows users to 1) directly register primitives and 2) get a handle of registered sorts (for primitive definition).

This is a breaking change since it changes the signature of `get_sort` in `TypeInfo` (cc @saulshanabrook ).