### PR TITLE
Add integer equal boolean function

### DIFF
--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -53,7 +53,7 @@ impl Sort for I64Sort {
         add_primitives!(typeinfo, ">" = |a: i64, b: i64| -> Opt { (a > b).then(|| ()) });
         add_primitives!(typeinfo, "<=" = |a: i64, b: i64| -> Opt { (a <= b).then(|| ()) });
         add_primitives!(typeinfo, ">=" = |a: i64, b: i64| -> Opt { (a >= b).then(|| ()) });
-        
+
         add_primitives!(typeinfo, "bool-=" = |a: i64, b: i64| -> bool { a == b });
         add_primitives!(typeinfo, "bool-<" = |a: i64, b: i64| -> bool { a < b });
         add_primitives!(typeinfo, "bool->" = |a: i64, b: i64| -> bool { a > b });

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -53,7 +53,8 @@ impl Sort for I64Sort {
         add_primitives!(typeinfo, ">" = |a: i64, b: i64| -> Opt { (a > b).then(|| ()) });
         add_primitives!(typeinfo, "<=" = |a: i64, b: i64| -> Opt { (a <= b).then(|| ()) });
         add_primitives!(typeinfo, ">=" = |a: i64, b: i64| -> Opt { (a >= b).then(|| ()) });
-
+        
+        add_primitives!(typeinfo, "bool-=" = |a: i64, b: i64| -> bool { a == b });
         add_primitives!(typeinfo, "bool-<" = |a: i64, b: i64| -> bool { a < b });
         add_primitives!(typeinfo, "bool->" = |a: i64, b: i64| -> bool { a > b });
         add_primitives!(typeinfo, "bool-<=" = |a: i64, b: i64| -> bool { a <= b });

--- a/tests/bool.egg
+++ b/tests/bool.egg
@@ -4,6 +4,11 @@
 (check (= (or true false) true))
 (check (!= (or true false) false))
 
+(check (= (bool-= 1 1) true))
+(check (= (bool-= -5 -5) true))
+(check (= (bool-= 1 3) false))
+(check (= (bool-= 3 1) false))
+
 (check (= (bool-< 1 2) true))
 (check (= (bool-< 2 1) false))
 (check (= (bool-< 1 1) false))


### PR DESCRIPTION
This PR add `bool-=` function, which is similar to existing `bool-<` but missing. I found `bool-=` is needed in eggcc.