### PR TITLE
Update link to Python docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is repo for the `egglog` tool accompanying the paper
 If you use this work, please use [this citation](./CITATION.bib).
 
 See also the Python binding, which provides a bit more documentation:
-https://egg-smol-python.readthedocs.io/en/latest/
+https://egglog-python.readthedocs.io/en/latest/
 
 ## Chat
 


### PR DESCRIPTION
The Python docs have a new home, reflecting the updated Python package name. See https://github.com/egraphs-good/egglog-python/pull/92