### PR TITLE
Add `set-length` and `set-get`

### DIFF
--- a/tests/set.egg
+++ b/tests/set.egg
@@ -1,0 +1,40 @@
+(sort ISetBase (Set i64))
+
+; Test set-of
+(check (= (set-of 1 2) (set-insert (set-insert (set-empty) 1) 2)))
+(check (= (set-of 1 2) (set-insert (set-insert (set-empty) 2) 1)))
+
+; Test set-union
+(check (= (set-union (set-of 1 2) (set-of 3 4)) (set-of 1 2 3 4)))
+
+; Test set-length
+(check (= 0 (set-length (set-empty))))
+(check (= 1 (set-length (set-of 1 1 1))))
+(check (= 2 (set-length (set-of 1 -1 1 1))))
+
+; Test set-get
+(check (= 1 (set-get (set-of 1 -1 2 4 1) 0)))
+(check (= 2 (set-get (set-of 1 -1 2 4 1) 1)))
+(check (= 4 (set-get (set-of 1 -1 2 4 1) 2)))
+(check (= -1 (set-get (set-of 1 -1 2 4 1) 3)))
+
+; Test set-remove
+(check (= (set-remove (set-of 1 2 3) 3) (set-of 1 2)))
+
+; Reify set
+(sort ISet)
+(function IS (ISetBase) ISet)
+
+(function ISet-get (ISet i64) i64 :unextractable)
+(rule ((IS x) (> (set-length x) 0))
+    ((set (ISet-get (IS x) 0) (set-get x 0))))
+(rule ((ISet-get (IS x) j)
+     (= i (+ j 1)) (< i (set-length x)))
+    ((set (ISet-get (IS x) i) (set-get x i))))
+
+(let myset (IS (set-of 2 4 1 4 -1)))
+(run 100)
+(check (= 1 (ISet-get myset 0)))
+(check (= 2 (ISet-get myset 1)))
+(check (= 4 (ISet-get myset 2)))
+(check (= -1 (ISet-get myset 3)))


### PR DESCRIPTION
Without these, we can't walk over a set nor match its contents.

See [tests/set.egg](https://github.com/rtjoa/egglog/blob/set-length-and-get/tests/set.egg) for examples.