### PR TITLE
Remove code path for calling set on union merge fn

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -776,8 +776,7 @@ impl EGraph {
                         return Err(Error::MergeError(table, new_value, old_value));
                     }
                     MergeFn::Union => {
-                        self.unionfind
-                            .union_values(old_value, new_value, old_value.tag)
+                        panic!("Set should not be called on eqsat values without a merge function")
                     }
                     MergeFn::Expr(merge_prog) => {
                         let values = [old_value, new_value];


### PR DESCRIPTION
This PR removes an unused code path for calling set on eqsat types with a default merge function of union.

Follow up on https://github.com/egraphs-good/egglog/pull/223

See https://github.com/egraphs-good/egglog/issues/298#issuecomment-1828374259