### PR TITLE
Fix build on stable

### DIFF
--- a/src/terms.rs
+++ b/src/terms.rs
@@ -1,4 +1,12 @@
-use crate::*;
+use crate::{
+    ast::{
+        desugar::Desugar, Action, Command, CommandId, Expr, Fact, NCommand, NormAction,
+        NormCommand, NormExpr, NormFact, NormFunctionDecl, NormRule, NormSchedule, Rule, RunConfig,
+        Schedule,
+    },
+    util::ListDisplay,
+    ArcSort, EGraph, Error, Symbol, TypeInfo,
+};
 
 /// The state of the term encoding is simply a current context
 /// so that it can look up type information.


### PR DESCRIPTION
fix #311 

There are 2 `Rule`s are defined in `crate::*`. Which are `crate::ast::Rule` and `crate::Rule`. And rustc is confused about it.

We should specify it clearly and I think it's good to remove `use crate::*;` and specify each `use`s