### PR TITLE
src/typechecking.rs: fix compilation failure with rustc 1.75.0

### DIFF
--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -1,4 +1,5 @@
 use crate::{core::CoreRule, *};
+use ast::Rule;
 
 #[derive(Clone, Debug)]
 pub struct FuncType {


### PR DESCRIPTION
This one-line fix resolves the following compilation error I was getting on both `aarch64-darwin` and `x86_64-linux`:

```console
% cargo build -j 24 --target aarch64-apple-darwin --frozen --profile release
   Compiling egglog v0.1.0 (/Users/connorbaker/Packages/egglog)
error[E0308]: mismatched types
   --> src/typechecking.rs:169:43
    |
169 |                 rule: self.typecheck_rule(rule)?,
    |                            -------------- ^^^^ expected `&Rule`, found `&GenericRule<GlobalSymbol, GlobalSymbol, ()>`
    |                            |
    |                            arguments to this method are incorrect
    |
    = note: expected reference `&Rule`
               found reference `&ast::GenericRule<GlobalSymbol, GlobalSymbol, ()>`
note: method defined here
   --> src/typechecking.rs:319:8
    |
319 |     fn typecheck_rule(&self, rule: &Rule) -> Result<ResolvedRule, TypeError> {
    |        ^^^^^^^^^^^^^^        -----------

error[E0609]: no field `body` on type `&Rule`
   --> src/typechecking.rs:320:63
    |
320 |         let body: Vec<GenericFact<Symbol, Symbol, ()>> = rule.body;
    |                                                               ^^^^ unknown field
    |
    = note: available fields are: `query`, `program`, `matches`, `times_banned`, `banned_until`, `todo_timestamp`

error[E0609]: no field `head` on type `&Rule`
   --> src/typechecking.rs:321:65
    |
321 |         let head: Vec<GenericAction<Symbol, Symbol, ()>> = rule.head;
    |                                                                 ^^^^ unknown field
    |
    = note: available fields are: `query`, `program`, `matches`, `times_banned`, `banned_until`, `todo_timestamp`

Some errors have detailed explanations: E0308, E0609.
For more information about an error, try `rustc --explain E0308`.
error: could not compile `egglog` (lib) due to 3 previous errors
```

To be upfront, I don't know Rust and I don't quite understand why this fixes the error. From the diagnostics I was getting from the Rust Analyzer (namely that `head` and `body` weren't fields `Rule` had), I guess there was some sort of shadowing with another type/struct of the same name.

Any explanation (or suggestions for a better way to fix this) are greatly appreciated!

CC @yihozhang since you just finished your large rewrite (congratulations by the way!) and this might still be fresh.