### PR TITLE
Desugar global variables away

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -8,7 +8,6 @@ use typechecking::TypeError;
 use crate::{ast::Literal, core::ResolvedCall, ExtractReport, Value};
 
 struct ActionCompiler<'a> {
-    egraph: &'a EGraph,
     types: &'a IndexMap<Symbol, ArcSort>,
     locals: IndexSet<ResolvedVar>,
     instructions: Vec<Instruction>,
@@ -60,10 +59,6 @@ impl<'a> ActionCompiler<'a> {
         }
     }
 
-    fn egraph(&self) -> &'a EGraph {
-        self.egraph
-    }
-
     fn do_call(&mut self, f: &ResolvedCall, args: &[ResolvedAtomTerm]) {
         for arg in args {
             self.do_atom_term(arg);
@@ -87,13 +82,8 @@ impl<'a> ActionCompiler<'a> {
             ResolvedAtomTerm::Literal(lit) => {
                 self.instructions.push(Instruction::Literal(lit.clone()));
             }
-            ResolvedAtomTerm::Global(var) => {
-                assert!(
-                    self.egraph().global_bindings.contains_key(&var.name),
-                    "Global {} not found",
-                    var.name
-                );
-                self.instructions.push(Instruction::Global(var.name));
+            ResolvedAtomTerm::Global(_var) => {
+                panic!("Global variables should have been desugared");
             }
         }
     }
@@ -126,8 +116,6 @@ enum Instruction {
     Literal(Literal),
     /// Push a value from the stack or the substitution onto the stack.
     Load(Load),
-    /// Push a global bound value onto the stack.
-    Global(Symbol),
     /// Pop function arguments off the stack, calls the function,
     /// and push the result onto the stack. The bool indicates
     /// whether to make defaults.
@@ -171,7 +159,6 @@ impl EGraph {
             types.insert(var.name, var.sort.clone());
         }
         let mut compiler = ActionCompiler {
-            egraph: self,
             types: &types,
             locals: IndexSet::default(),
             instructions: Vec::new(),
@@ -200,7 +187,6 @@ impl EGraph {
             types.insert(var.name, var.sort.clone());
         }
         let mut compiler = ActionCompiler {
-            egraph: self,
             types: &types,
             locals: IndexSet::default(),
             instructions: Vec::new(),
@@ -274,10 +260,6 @@ impl EGraph {
     ) -> Result<(), Error> {
         for instr in &program.0 {
             match instr {
-                Instruction::Global(sym) => {
-                    let (_ty, value, _ts) = self.global_bindings.get(sym).unwrap();
-                    stack.push(*value);
-                }
                 Instruction::Load(load) => match load {
                     Load::Stack(idx) => stack.push(stack[*idx]),
                     Load::Subst(idx) => stack.push(subst[*idx]),

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -88,7 +88,11 @@ impl<'a> ActionCompiler<'a> {
                 self.instructions.push(Instruction::Literal(lit.clone()));
             }
             ResolvedAtomTerm::Global(var) => {
-                assert!(self.egraph().global_bindings.contains_key(&var.name));
+                assert!(
+                    self.egraph().global_bindings.contains_key(&var.name),
+                    "Global {} not found",
+                    var.name
+                );
                 self.instructions.push(Instruction::Global(var.name));
             }
         }

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -355,13 +355,6 @@ impl Clone for Desugar {
 }
 
 impl Desugar {
-    pub fn merge_ruleset_name(&self) -> Symbol {
-        Symbol::from(format!(
-            "merge_ruleset{}",
-            "_".repeat(self.number_underscores)
-        ))
-    }
-
     pub fn get_fresh(&mut self) -> Symbol {
         self.next_fresh += 1;
         format!(

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -16,6 +16,7 @@ fn desugar_datatype(name: Symbol, variants: Vec<Variant>) -> Vec<NCommand> {
                 default: None,
                 cost: variant.cost,
                 unextractable: false,
+                is_global: false,
             })
         }))
         .collect()
@@ -382,6 +383,7 @@ impl Desugar {
             .map_err(|e| e.map_token(|tok| tok.to_string()))?)
     }
 
+    // TODO declare by creating a new global function. See issue #334
     pub fn declare(&mut self, name: Symbol, sort: Symbol) -> Vec<NCommand> {
         let fresh = self.get_fresh();
         vec![
@@ -396,6 +398,7 @@ impl Desugar {
                 merge_action: Actions::default(),
                 cost: None,
                 unextractable: false,
+                is_global: false,
             }),
             NCommand::CoreAction(Action::Let((), name, Expr::Call((), fresh, vec![]))),
         ]
@@ -410,6 +413,7 @@ impl Desugar {
             merge_action: fdecl.merge_action.clone(),
             cost: fdecl.cost,
             unextractable: fdecl.unextractable,
+            is_global: fdecl.is_global,
         })]
     }
 

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -16,7 +16,7 @@ fn desugar_datatype(name: Symbol, variants: Vec<Variant>) -> Vec<NCommand> {
                 default: None,
                 cost: variant.cost,
                 unextractable: false,
-                is_global: false,
+                ignore_viz: false,
             })
         }))
         .collect()
@@ -420,7 +420,7 @@ impl Desugar {
                 merge_action: Actions::default(),
                 cost: None,
                 unextractable: false,
-                is_global: false,
+                ignore_viz: false,
             }),
             NCommand::CoreAction(Action::Let((), name, Expr::Call((), fresh, vec![]))),
         ]
@@ -435,7 +435,7 @@ impl Desugar {
             merge_action: fdecl.merge_action.clone(),
             cost: fdecl.cost,
             unextractable: fdecl.unextractable,
-            is_global: fdecl.is_global,
+            ignore_viz: fdecl.ignore_viz,
         })]
     }
 

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -64,6 +64,11 @@ pub struct ResolvedVar {
     pub sort: ArcSort,
     /// Is this a reference to a global variable?
     /// After the `remove_globals` pass, this should be `false`.
+    ///
+    /// NB: we distinguish between a global reference and a global binding.
+    /// The current implementation of `Eq` and `Hash` does not take this field
+    /// into consideration.
+    /// Overall, the definition of equality between two ResolvedVars is dicey.
     pub is_global_ref: bool,
 }
 

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -192,14 +192,9 @@ impl<Head: Clone + Display, Leaf: Hash + Clone + Display + Eq, Ann: Clone>
         self,
         f: &mut impl FnMut(Leaf) -> Leaf2,
     ) -> GenericExpr<Head, Leaf2, Ann> {
-        match self {
-            GenericExpr::Var(ann, v) => GenericExpr::Var(ann, f(v)),
-            GenericExpr::Lit(ann, lit) => GenericExpr::Lit(ann, lit),
-            GenericExpr::Call(ann, op, children) => {
-                let children = children.into_iter().map(|c| c.map_leafs(f)).collect();
-                GenericExpr::Call(ann, op, children)
-            }
-        }
+        self.subst(&mut |v| GenericExpr::Var((), f(v.clone())), &mut |x| {
+            x.clone()
+        })
     }
 
     // TODO: Currently, subst_leaf takes a leaf but not an annotation over the leaf,

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -62,6 +62,9 @@ impl Display for Literal {
 pub struct ResolvedVar {
     pub name: Symbol,
     pub sort: ArcSort,
+    /// Is this a reference to a global variable?
+    /// After the `remove_globals` pass, this should be `false`.
+    pub is_global_ref: bool,
 }
 
 impl PartialEq for ResolvedVar {
@@ -172,13 +175,13 @@ impl<Head: Clone + Display, Leaf: Hash + Clone + Display + Eq, Ann: Clone>
         f(self, ts)
     }
 
-    pub fn map(&self, f: &mut impl FnMut(&Self) -> Self) -> Self {
+    pub fn map(self, f: &mut impl FnMut(Self) -> Self) -> Self {
         match self {
             GenericExpr::Lit(..) => f(self),
             GenericExpr::Var(..) => f(self),
             GenericExpr::Call(ann, op, children) => {
                 let children = children.iter().map(|c| c.map(f)).collect();
-                f(&GenericExpr::Call(ann.clone(), op.clone(), children))
+                f(GenericExpr::Call(ann.clone(), op.clone(), children))
             }
         }
     }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -128,6 +128,13 @@ impl ResolvedExpr {
             ResolvedExpr::Call(_, resolved_call, _) => resolved_call.output().clone(),
         }
     }
+
+    pub(crate) fn get_global_var(&self) -> Option<ResolvedVar> {
+        match self {
+            ResolvedExpr::Var(_, v) if v.is_global_ref => Some(v.clone()),
+            _ => None,
+        }
+    }
 }
 
 impl Expr {
@@ -143,6 +150,14 @@ impl Expr {
 impl<Head: Clone + Display, Leaf: Hash + Clone + Display + Eq, Ann: Clone>
     GenericExpr<Head, Leaf, Ann>
 {
+    pub fn ann(&self) -> Ann {
+        match self {
+            GenericExpr::Lit(ann, _) => ann.clone(),
+            GenericExpr::Var(ann, _) => ann.clone(),
+            GenericExpr::Call(ann, _, _) => ann.clone(),
+        }
+    }
+
     pub fn is_var(&self) -> bool {
         matches!(self, GenericExpr::Var(_, _))
     }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -188,6 +188,34 @@ impl<Head: Clone + Display, Leaf: Hash + Clone + Display + Eq, Ann: Clone>
         }
     }
 
+    pub fn map_leafs<Leaf2>(
+        self,
+        f: &mut impl FnMut(Leaf) -> Leaf2,
+    ) -> GenericExpr<Head, Leaf2, Ann> {
+        match self {
+            GenericExpr::Var(ann, v) => GenericExpr::Var(ann, f(v)),
+            GenericExpr::Lit(ann, lit) => GenericExpr::Lit(ann, lit),
+            GenericExpr::Call(ann, op, children) => {
+                let children = children.into_iter().map(|c| c.map_leafs(f)).collect();
+                GenericExpr::Call(ann, op, children)
+            }
+        }
+    }
+
+    pub fn map_heads<Head2>(
+        self,
+        f: &mut impl FnMut(Head) -> Head2,
+    ) -> GenericExpr<Head2, Leaf, Ann> {
+        match self {
+            GenericExpr::Var(ann, v) => GenericExpr::Var(ann, v),
+            GenericExpr::Lit(ann, lit) => GenericExpr::Lit(ann, lit),
+            GenericExpr::Call(ann, op, children) => {
+                let children = children.into_iter().map(|c| c.map_heads(f)).collect();
+                GenericExpr::Call(ann, f(op), children)
+            }
+        }
+    }
+
     // TODO: Currently, subst_leaf takes a leaf but not an annotation over the leaf,
     // so it has to "make up" annotations for the returned GenericExpr. A better
     // approach is for subst_leaf to also take the annotation, which we should

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -175,6 +175,8 @@ impl<Head: Clone + Display, Leaf: Hash + Clone + Display + Eq, Ann: Clone>
         f(self, ts)
     }
 
+    /// Applys `f` to all sub-expressions (including `self`)
+    /// bottom-up, collecting the results.
     pub fn map(self, f: &mut impl FnMut(Self) -> Self) -> Self {
         match self {
             GenericExpr::Lit(..) => f(self),

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -188,15 +188,6 @@ impl<Head: Clone + Display, Leaf: Hash + Clone + Display + Eq, Ann: Clone>
         }
     }
 
-    pub fn map_leafs<Leaf2>(
-        self,
-        f: &mut impl FnMut(Leaf) -> Leaf2,
-    ) -> GenericExpr<Head, Leaf2, Ann> {
-        self.subst(&mut |v| GenericExpr::Var((), f(v.clone())), &mut |x| {
-            x.clone()
-        })
-    }
-
     // TODO: Currently, subst_leaf takes a leaf but not an annotation over the leaf,
     // so it has to "make up" annotations for the returned GenericExpr. A better
     // approach is for subst_leaf to also take the annotation, which we should

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 mod expr;
 pub use expr::*;
 pub mod desugar;
+mod remove_globals;
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Id(usize);

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1266,11 +1266,11 @@ where
     }
 }
 
-impl<Head: Display + ToSexp, Leaf: Display + ToSexp, Ann> ToSexp for GenericAction<Head, Leaf, Ann>
+impl<Head, Leaf, Ann> ToSexp for GenericAction<Head, Leaf, Ann>
 where
     Ann: Clone + Default,
-    Head: Clone + Display,
-    Leaf: Clone + PartialEq + Eq + Display + Hash,
+    Head: Clone + Display + ToSexp,
+    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
 {
     fn to_sexp(&self) -> Sexp {
         match self {
@@ -1346,6 +1346,7 @@ where
             }
             // TODO should we refactor `Set` so that we can map over Expr::Call(lhs, args)?
             // This seems more natural to oflatt
+            // Currently, visit_exprs does not apply f to the first argument of Set.
             GenericAction::Set(ann, lhs, args, rhs) => {
                 let args = args.into_iter().map(|e| e.visit_exprs(f)).collect();
                 GenericAction::Set(ann.clone(), lhs.clone(), args, rhs.visit_exprs(f))
@@ -1414,11 +1415,11 @@ where
     }
 }
 
-impl<Head: Display + ToSexp, Leaf: Display + ToSexp, Ann> Display for GenericAction<Head, Leaf, Ann>
+impl<Head, Leaf, Ann> Display for GenericAction<Head, Leaf, Ann>
 where
     Ann: Clone + Default,
-    Head: Clone + Display,
-    Leaf: Clone + PartialEq + Eq + Display + Hash,
+    Head: Clone + Display + ToSexp,
+    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_sexp())
@@ -1460,11 +1461,11 @@ where
     }
 }
 
-impl<Head: Display + ToSexp, Leaf: Display + ToSexp, Ann> GenericRule<Head, Leaf, Ann>
+impl<Head, Leaf, Ann> GenericRule<Head, Leaf, Ann>
 where
     Ann: Clone + Default,
-    Head: Clone + Display,
-    Leaf: Clone + PartialEq + Eq + Display + Hash,
+    Head: Clone + Display + ToSexp,
+    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
 {
     pub(crate) fn fmt_with_ruleset(
         &self,
@@ -1510,11 +1511,11 @@ where
     }
 }
 
-impl<Head: Display + ToSexp, Leaf: Display + ToSexp, Ann> GenericRule<Head, Leaf, Ann>
+impl<Head, Leaf, Ann> GenericRule<Head, Leaf, Ann>
 where
     Ann: Clone + Default,
-    Head: Clone + Display,
-    Leaf: Clone + PartialEq + Eq + Display + Hash,
+    Head: Clone + Display + ToSexp,
+    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
 {
     /// Converts this rule into an s-expression.
     pub fn to_sexp(&self, ruleset: Symbol, name: Symbol) -> Sexp {
@@ -1535,11 +1536,11 @@ where
     }
 }
 
-impl<Head: Display + ToSexp, Leaf: Display + ToSexp, Ann> Display for GenericRule<Head, Leaf, Ann>
+impl<Head, Leaf, Ann> Display for GenericRule<Head, Leaf, Ann>
 where
     Ann: Clone + Default,
-    Head: Clone + Display,
-    Leaf: Clone + PartialEq + Eq + Display + Hash,
+    Head: Clone + Display + ToSexp,
+    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.fmt_with_ruleset(f, "".into(), "".into())

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -809,6 +809,9 @@ where
     pub merge_action: GenericActions<Head, Leaf, Ann>,
     pub cost: Option<usize>,
     pub unextractable: bool,
+    /// Globals are desugared to functions, with this flag set to true.
+    /// This is used by visualization to handle globals differently.
+    pub is_global: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -863,6 +866,7 @@ impl FunctionDecl {
             default: Some(Expr::Lit((), Literal::Unit)),
             cost: None,
             unextractable: false,
+            is_global: false,
         }
     }
 }
@@ -885,6 +889,7 @@ where
             merge_action: self.merge_action.visit_exprs(f),
             cost: self.cost,
             unextractable: self.unextractable,
+            is_global: self.is_global,
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -659,7 +659,7 @@ where
     Include(String),
 }
 
-impl<Head: Display, Leaf: Display> ToSexp for GenericCommand<Head, Leaf>
+impl<Head, Leaf> ToSexp for GenericCommand<Head, Leaf>
 where
     Head: Clone + Display + ToSexp,
     Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
@@ -722,10 +722,10 @@ where
     }
 }
 
-impl<Head: Display + ToSexp, Leaf: Display + ToSexp> Display for GenericCommand<Head, Leaf>
+impl<Head, Leaf> Display for GenericCommand<Head, Leaf>
 where
-    Head: Clone + Display,
-    Leaf: Clone + PartialEq + Eq + Display + Hash,
+    Head: Clone + Display + ToSexp,
+    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -828,7 +828,7 @@ where
     pub unextractable: bool,
     /// Globals are desugared to functions, with this flag set to true.
     /// This is used by visualization to handle globals differently.
-    pub is_global: bool,
+    pub ignore_viz: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -883,7 +883,7 @@ impl FunctionDecl {
             default: Some(Expr::Lit((), Literal::Unit)),
             cost: None,
             unextractable: false,
-            is_global: false,
+            ignore_viz: false,
         }
     }
 }
@@ -906,7 +906,7 @@ where
             merge_action: self.merge_action.visit_exprs(f),
             cost: self.cost,
             unextractable: self.unextractable,
-            is_global: self.is_global,
+            ignore_viz: self.ignore_viz,
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1206,28 +1206,26 @@ where
     ) -> Self {
         match self {
             GenericAction::Let(ann, lhs, rhs) => {
-                GenericAction::Let(ann.clone(), lhs.clone(), f(rhs))
+                GenericAction::Let(ann.clone(), lhs.clone(), rhs.map(f))
             }
+            // TODO should we refactor `Set` so that we can map over Expr::Call(lhs, args)?
+            // This seems more natural to oflatt
             GenericAction::Set(ann, lhs, args, rhs) => {
-                let right = f(rhs);
-                GenericAction::Set(
-                    ann.clone(),
-                    lhs.clone(),
-                    args.into_iter().map(f).collect(),
-                    right,
-                )
+                let args = args.into_iter().map(|e| e.map(f)).collect();
+                GenericAction::Set(ann.clone(), lhs.clone(), args, rhs.map(f))
             }
             GenericAction::Delete(ann, lhs, args) => {
-                GenericAction::Delete(ann.clone(), lhs.clone(), args.into_iter().map(f).collect())
+                let args = args.into_iter().map(|e| e.map(f)).collect();
+                GenericAction::Delete(ann.clone(), lhs.clone(), args)
             }
             GenericAction::Union(ann, lhs, rhs) => {
-                GenericAction::Union(ann.clone(), f(lhs), f(rhs))
+                GenericAction::Union(ann.clone(), lhs.map(f), rhs.map(f))
             }
             GenericAction::Extract(ann, expr, variants) => {
-                GenericAction::Extract(ann.clone(), f(expr), f(variants))
+                GenericAction::Extract(ann.clone(), expr.map(f), variants.map(f))
             }
             GenericAction::Panic(ann, msg) => GenericAction::Panic(ann.clone(), msg.clone()),
-            GenericAction::Expr(ann, e) => GenericAction::Expr(ann.clone(), f(e)),
+            GenericAction::Expr(ann, e) => GenericAction::Expr(ann.clone(), e.map(f)),
         }
     }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1010,7 +1010,7 @@ where
     Leaf: Clone + PartialEq + Eq + Display + Hash,
     Head: Clone + Display,
 {
-    pub(crate) fn to_unresolved(self) -> Fact
+    pub(crate) fn make_unresolved(self) -> Fact
     where
         Leaf: SymbolLike,
         Head: SymbolLike,

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -54,7 +54,7 @@ Command: Command = {
         <unextractable:(":unextractable")?>
         <merge_action:(":on_merge" <List<Action>>)?>
         <merge:(":merge" <Expr>)?> <default:(":default" <Expr>)?> RParen => {
-        Command::Function(FunctionDecl { name, schema, merge, merge_action: Actions::new(merge_action.unwrap_or_default()), default, cost, unextractable: unextractable.is_some(), is_global: false })
+        Command::Function(FunctionDecl { name, schema, merge, merge_action: Actions::new(merge_action.unwrap_or_default()), default, cost, unextractable: unextractable.is_some(), ignore_viz: false })
     },
     LParen "declare" <name:Ident> <sort:Ident> RParen => Command::Declare{name, sort},
     LParen "relation" <constructor:Ident> <inputs:List<Type>> RParen => Command::Relation{constructor, inputs},

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -54,7 +54,7 @@ Command: Command = {
         <unextractable:(":unextractable")?>
         <merge_action:(":on_merge" <List<Action>>)?>
         <merge:(":merge" <Expr>)?> <default:(":default" <Expr>)?> RParen => {
-        Command::Function(FunctionDecl { name, schema, merge, merge_action: Actions::new(merge_action.unwrap_or_default()), default, cost, unextractable: unextractable.is_some() })
+        Command::Function(FunctionDecl { name, schema, merge, merge_action: Actions::new(merge_action.unwrap_or_default()), default, cost, unextractable: unextractable.is_some(), is_global: false })
     },
     LParen "declare" <name:Ident> <sort:Ident> RParen => Command::Declare{name, sort},
     LParen "relation" <constructor:Ident> <inputs:List<Type>> RParen => Command::Relation{constructor, inputs},

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -34,6 +34,10 @@ pub(crate) fn remove_globals(
         .collect()
 }
 
+/// TODO (yz) it would be better to implement replace_global_var
+/// as a function from ResolvedVar to ResolvedExpr
+/// and use it as an argument to `subst` instead of `visit_expr`,
+/// but we have not implemented `subst` for command.
 fn replace_global_var(expr: ResolvedExpr) -> ResolvedExpr {
     match expr {
         GenericExpr::Var(

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -92,6 +92,11 @@ fn remove_globals_cmd(type_info: &TypeInfo, cmd: ResolvedNCommand) -> Vec<Resolv
                             name: name.name,
                             input: vec![],
                             output: ty,
+                            // NB: Globals are desugared to non-datatype functions,
+                            // even when the output type is an EqSort.
+                            // This is nice because we don't need to touch the equivalence relation 
+                            // when setting it. 
+                            // The downside is that this is not consistent with `function_to_functype`
                             is_datatype: false,
                             has_default: false,
                         }),

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -59,11 +59,11 @@ fn replace_global_var(expr: ResolvedExpr) -> ResolvedExpr {
 }
 
 fn remove_globals_expr(expr: ResolvedExpr) -> ResolvedExpr {
-    expr.map(&mut replace_global_var)
+    expr.visit_exprs(&mut replace_global_var)
 }
 
 fn remove_globals_action(action: ResolvedAction) -> ResolvedAction {
-    action.map_exprs(&mut replace_global_var)
+    action.visit_exprs(&mut replace_global_var)
 }
 
 fn remove_globals_cmd(type_info: &TypeInfo, cmd: ResolvedNCommand) -> Vec<ResolvedNCommand> {
@@ -101,6 +101,6 @@ fn remove_globals_cmd(type_info: &TypeInfo, cmd: ResolvedNCommand) -> Vec<Resolv
             }
             _ => vec![GenericNCommand::CoreAction(remove_globals_action(action))],
         },
-        _ => vec![cmd.map_exprs(&mut remove_globals_expr)],
+        _ => vec![cmd.visit_exprs(&mut remove_globals_expr)],
     }
 }

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -4,8 +4,8 @@
 
 use crate::{
     core::ResolvedCall, typechecking::FuncType, GenericAction, GenericActions, GenericExpr,
-    GenericNCommand, ResolvedAction, ResolvedExpr, ResolvedFunctionDecl, ResolvedNCommand, Schema,
-    TypeInfo,
+    GenericNCommand, ResolvedAction, ResolvedExpr, ResolvedFunctionDecl, ResolvedNCommand,
+    ResolvedVar, Schema, TypeInfo,
 };
 
 /// Removes all globals from a program.
@@ -35,19 +35,25 @@ pub(crate) fn remove_globals(
 
 fn replace_global_var(expr: ResolvedExpr) -> ResolvedExpr {
     match expr {
-        GenericExpr::Lit(ann, lit) => GenericExpr::Lit(ann, lit),
-        GenericExpr::Var(ann, var) => GenericExpr::Call(
+        GenericExpr::Var(
+            ann,
+            ResolvedVar {
+                name,
+                sort,
+                is_global_ref: true,
+            },
+        ) => GenericExpr::Call(
             ann,
             ResolvedCall::Func(FuncType {
-                name: var.name,
+                name,
                 input: vec![],
-                output: var.sort.clone(),
+                output: sort,
                 is_datatype: false,
                 has_default: false,
             }),
             vec![],
         ),
-        GenericExpr::Call(ann, head, args) => GenericExpr::Call(ann, head, args),
+        _ => expr,
     }
 }
 

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -82,7 +82,7 @@ fn remove_globals_cmd(type_info: &TypeInfo, cmd: ResolvedNCommand) -> Vec<Resolv
                     merge_action: GenericActions(vec![]),
                     cost: None,
                     unextractable: true,
-                    is_global: true,
+                    ignore_viz: true,
                 };
                 vec![
                     GenericNCommand::Function(func_decl),
@@ -102,6 +102,6 @@ fn remove_globals_cmd(type_info: &TypeInfo, cmd: ResolvedNCommand) -> Vec<Resolv
             }
             _ => vec![GenericNCommand::CoreAction(remove_globals_action(action))],
         },
-        _ => vec![cmd.visit_exprs(&mut remove_globals_expr)],
+        _ => vec![cmd.visit_exprs(&mut replace_global_var)],
     }
 }

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -23,6 +23,7 @@ use crate::{
 /// ```ignore
 /// (function x () i64)
 /// (set (x) 3)
+/// (Add (x) (x))
 /// ```
 pub(crate) fn remove_globals(
     type_info: &TypeInfo,

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -82,6 +82,7 @@ fn remove_globals_cmd(type_info: &TypeInfo, cmd: ResolvedNCommand) -> Vec<Resolv
                     merge_action: GenericActions(vec![]),
                     cost: None,
                     unextractable: true,
+                    is_global: true,
                 };
                 vec![
                     GenericNCommand::Function(func_decl),

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -94,8 +94,8 @@ fn remove_globals_cmd(type_info: &TypeInfo, cmd: ResolvedNCommand) -> Vec<Resolv
                             output: ty,
                             // NB: Globals are desugared to non-datatype functions,
                             // even when the output type is an EqSort.
-                            // This is nice because we don't need to touch the equivalence relation 
-                            // when setting it. 
+                            // This is nice because we don't need to touch the equivalence relation
+                            // when setting it.
                             // The downside is that this is not consistent with `function_to_functype`
                             is_datatype: false,
                             has_default: false,

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -1,11 +1,14 @@
 //! Remove global variables from the program by translating
 //! them into functions with no arguments.
 //! This requires type information, so it is done after type checking.
+//! Primitives are translated into functions with a primitive output.
+//! When a globally-bound primitive value is used in the actions of a rule,
+//! we add a new variable to the query bound to the primitive value.
 
 use crate::{
-    core::ResolvedCall, typechecking::FuncType, GenericAction, GenericActions, GenericExpr,
-    GenericNCommand, HashMap, ResolvedAction, ResolvedExpr, ResolvedFunctionDecl, ResolvedNCommand,
-    ResolvedVar, Schema, Symbol, SymbolGen, TypeInfo,
+    core::ResolvedCall, typechecking::FuncType, FreshGen, GenericAction, GenericActions,
+    GenericExpr, GenericFact, GenericNCommand, GenericRule, HashMap, ResolvedAction, ResolvedExpr,
+    ResolvedFact, ResolvedFunctionDecl, ResolvedNCommand, ResolvedVar, Schema, SymbolGen, TypeInfo,
 };
 
 struct GlobalRemover {
@@ -30,9 +33,17 @@ struct GlobalRemover {
 /// (Add (x) (x))
 /// ```
 ///
-/// Primitives and containers need to be added to the query
-/// so they can be referenced in actions.
-/// Datatypes can be referenced directly from actions.
+/// If later, this global is referenced in a rule:
+/// ```ignore
+/// (rule ((Neg y))
+///       ((Add x x)))
+/// ```
+/// We instrument the query to make the value available:
+/// ```ignore
+/// (rule ((Neg y)
+///        (= fresh_var_for_x (x)))
+///       ((Add fresh_var_for_x fresh_var_for_x)))
+/// ```
 pub(crate) fn remove_globals(
     type_info: &TypeInfo,
     prog: Vec<ResolvedNCommand>,
@@ -45,40 +56,39 @@ pub(crate) fn remove_globals(
         .collect()
 }
 
+fn resolved_var_to_call(var: &ResolvedVar) -> ResolvedCall {
+    assert!(
+        var.is_global_ref,
+        "resolved_var_to_call called on non-global var"
+    );
+    ResolvedCall::Func(FuncType {
+        name: var.name,
+        input: vec![],
+        output: var.sort.clone(),
+        is_datatype: var.sort.is_eq_sort(),
+        has_default: false,
+    })
+}
+
 /// TODO (yz) it would be better to implement replace_global_var
 /// as a function from ResolvedVar to ResolvedExpr
 /// and use it as an argument to `subst` instead of `visit_expr`,
 /// but we have not implemented `subst` for command.
-fn replace_global_var(expr: ResolvedExpr) -> ResolvedExpr {
-    match expr {
-        GenericExpr::Var(
-            ann,
-            ResolvedVar {
-                name,
-                sort,
-                is_global_ref: true,
-            },
-        ) => GenericExpr::Call(
-            ann,
-            ResolvedCall::Func(FuncType {
-                name,
-                input: vec![],
-                output: sort,
-                is_datatype: false,
-                has_default: false,
-            }),
-            vec![],
-        ),
-        _ => expr,
+fn replace_global_vars(expr: ResolvedExpr) -> ResolvedExpr {
+    match expr.get_global_var() {
+        Some(resolved_var) => {
+            GenericExpr::Call(expr.ann(), resolved_var_to_call(&resolved_var), vec![])
+        }
+        None => expr,
     }
 }
 
 fn remove_globals_expr(expr: ResolvedExpr) -> ResolvedExpr {
-    expr.visit_exprs(&mut replace_global_var)
+    expr.visit_exprs(&mut replace_global_vars)
 }
 
 fn remove_globals_action(action: ResolvedAction) -> ResolvedAction {
-    action.visit_exprs(&mut replace_global_var)
+    action.visit_exprs(&mut replace_global_vars)
 }
 
 impl GlobalRemover {
@@ -91,87 +101,107 @@ impl GlobalRemover {
             GenericNCommand::CoreAction(action) => match action {
                 GenericAction::Let(ann, name, expr) => {
                     let ty = expr.output_type(type_info);
-                    if ty.is_eq_sort() {
+
+                    let func_decl = ResolvedFunctionDecl {
+                        name: name.name,
+                        schema: Schema {
+                            input: vec![],
+                            output: ty.name(),
+                        },
+                        default: None,
+                        merge: None,
+                        merge_action: GenericActions(vec![]),
+                        cost: None,
+                        unextractable: true,
+                        ignore_viz: true,
+                    };
+                    let resolved_call = ResolvedCall::Func(FuncType {
+                        name: name.name,
+                        input: vec![],
+                        is_datatype: ty.is_eq_sort(),
+                        output: ty.clone(),
+                        has_default: false,
+                    });
+                    vec![
+                        GenericNCommand::Function(func_decl),
                         // output is eq-able, so generate a union
-                        let func_decl = ResolvedFunctionDecl {
-                            name: name.name,
-                            schema: Schema {
-                                input: vec![],
-                                output: ty.name(),
-                            },
-                            default: None,
-                            merge: None,
-                            merge_action: GenericActions(vec![]),
-                            cost: None,
-                            unextractable: true,
-                            ignore_viz: true,
-                        };
-                        vec![
-                            GenericNCommand::Function(func_decl),
+                        if ty.is_eq_sort() {
                             GenericNCommand::CoreAction(GenericAction::Union(
                                 ann,
-                                GenericExpr::Call(
-                                    ann,
-                                    ResolvedCall::Func(FuncType {
-                                        name: name.name,
-                                        input: vec![],
-                                        output: ty,
-                                        is_datatype: true,
-                                        has_default: false,
-                                    }),
-                                    vec![],
-                                ),
+                                GenericExpr::Call(ann, resolved_call, vec![]),
                                 remove_globals_expr(expr),
-                            )),
-                        ]
-                    } else {
-                        let func_decl = ResolvedFunctionDecl {
-                            name: name.name,
-                            schema: Schema {
-                                input: vec![],
-                                output: ty.name(),
-                            },
-                            default: None,
-                            merge: None,
-                            merge_action: GenericActions(vec![]),
-                            cost: None,
-                            unextractable: true,
-                            ignore_viz: true,
-                        };
-
-                        vec![
-                            GenericNCommand::Function(func_decl),
+                            ))
+                        } else {
                             GenericNCommand::CoreAction(GenericAction::Set(
                                 ann,
-                                ResolvedCall::Func(FuncType {
-                                    name: name.name,
-                                    input: vec![],
-                                    output: ty,
-                                    is_datatype: false,
-                                    has_default: false,
-                                }),
+                                resolved_call,
                                 vec![],
                                 remove_globals_expr(expr),
-                            )),
-                        ]
-                    }
+                            ))
+                        },
+                    ]
                 }
                 _ => vec![GenericNCommand::CoreAction(remove_globals_action(action))],
             },
-            /*GenericNCommand::NormRule {
+            GenericNCommand::NormRule {
                 name,
                 ruleset,
                 rule,
             } => {
-                // rules handled specially because actions can't refer to
-                // global functions with primitive outputs
-                GenericNCommand::NormRule {
+                // A map from the global variables in actions to their new names
+                // in the query.
+                let mut globals = HashMap::default();
+                rule.head.clone().visit_exprs(&mut |expr| {
+                    if let Some(resolved_var) = expr.get_global_var() {
+                        let new_name = self.fresh.fresh(&resolved_var.name);
+                        globals.insert(
+                            resolved_var.clone(),
+                            GenericExpr::Var(
+                                (),
+                                ResolvedVar {
+                                    name: new_name,
+                                    sort: resolved_var.sort.clone(),
+                                    is_global_ref: false,
+                                },
+                            ),
+                        );
+                    }
+                    expr
+                });
+                let new_facts: Vec<ResolvedFact> = globals
+                    .iter()
+                    .map(|(old, new)| {
+                        GenericFact::Eq(vec![
+                            GenericExpr::Call((), resolved_var_to_call(old), vec![]),
+                            new.clone(),
+                        ])
+                    })
+                    .collect();
+
+                let new_rule = GenericRule {
+                    // instrument the old facts and add the new facts to the end
+                    body: rule
+                        .body
+                        .iter()
+                        .map(|fact| fact.clone().visit_exprs(&mut replace_global_vars))
+                        .chain(new_facts)
+                        .collect(),
+                    // replace references to globals with the newly bound names
+                    head: rule.head.clone().visit_exprs(&mut |expr| {
+                        if let Some(resolved_var) = expr.get_global_var() {
+                            globals.get(&resolved_var).unwrap().clone()
+                        } else {
+                            expr
+                        }
+                    }),
+                };
+                vec![GenericNCommand::NormRule {
                     name,
                     ruleset,
-                    rule: self.remove_globals_rule(rule),
-                }
-            }*/
-            _ => vec![cmd.visit_exprs(&mut replace_global_var)],
+                    rule: new_rule,
+                }]
+            }
+            _ => vec![cmd.visit_exprs(&mut replace_global_vars)],
         }
     }
 }

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -36,11 +36,19 @@ pub(crate) fn remove_globals(
 
 fn replace_global_var(type_info: &TypeInfo, expr: ResolvedExpr) -> ResolvedExpr {
     match expr {
-        GenericExpr::Lit(ann, lit) => expr,
-        GenericExpr::Var(ann, var) => {
-            todo!()
-        }
-        GenericExpr::Call(ann, head, args) => expr,
+        GenericExpr::Lit(ann, lit) => GenericExpr::Lit(ann, lit),
+        GenericExpr::Var(ann, var) => GenericExpr::Call(
+            (),
+            ResolvedCall::Func(FuncType {
+                name: var.name,
+                input: vec![],
+                output: var.sort.clone(),
+                is_datatype: false,
+                has_default: false,
+            }),
+            vec![],
+        ),
+        GenericExpr::Call(ann, head, args) => GenericExpr::Call(ann, head, args),
     }
 }
 
@@ -69,10 +77,10 @@ fn remove_globals_cmd(type_info: &TypeInfo, cmd: ResolvedNCommand) -> Vec<Resolv
                     cost: None,
                     unextractable: true,
                 };
-                let mut res = vec![
+                vec![
                     GenericNCommand::Function(func_decl),
                     GenericNCommand::CoreAction(GenericAction::Set(
-                        (),
+                        ann,
                         ResolvedCall::Func(FuncType {
                             name: name.name,
                             input: vec![],
@@ -83,9 +91,7 @@ fn remove_globals_cmd(type_info: &TypeInfo, cmd: ResolvedNCommand) -> Vec<Resolv
                         vec![],
                         remove_globals_expr(type_info, expr),
                     )),
-                ];
-
-                res
+                ]
             }
             _ => vec![GenericNCommand::CoreAction(remove_globals_action(
                 type_info, action,

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -1,0 +1,59 @@
+//! Remove global variables from the program by translating
+//! them into functions with no arguments.
+//! This requires type information, so it is done after type checking.
+
+use crate::{
+    desugar::Desugar, Action, GenericAction, GenericActions, GenericExpr, GenericFunctionDecl,
+    GenericNCommand, NCommand, ResolvedActions, ResolvedFunctionDecl, ResolvedNCommand, Schema,
+    Symbol, TypeInfo,
+};
+use hashbrown::HashSet;
+
+pub(crate) fn remove_globals(
+    type_info: &TypeInfo,
+    prog: &Vec<ResolvedNCommand>,
+) -> Vec<ResolvedNCommand> {
+    let mut res = Vec::new();
+    for cmd in prog {
+        res.extend(remove_globals_cmd(type_info, cmd));
+    }
+    res
+}
+
+/// Removes all globals from a command.
+/// Adds new functions for new globals
+/// and replaces references to globals with
+/// references to the new functions.
+/// Also adds the types for these functions to
+/// the type info struct.
+fn remove_globals_cmd(type_info: &TypeInfo, cmd: &ResolvedNCommand) -> Vec<ResolvedNCommand> {
+    match cmd {
+        GenericNCommand::CoreAction(action) => match action {
+            GenericAction::Let(ann, name, expr) => {
+                let ty = expr.output_type(type_info);
+                let func_decl = ResolvedFunctionDecl {
+                    name: name.name,
+                    schema: Schema {
+                        input: vec![],
+                        output: ty.name(),
+                    },
+                    default: None,
+                    merge: None,
+                    merge_action: GenericActions(vec![]),
+                    cost: None,
+                    unextractable: true,
+                };
+                let mut res = vec![
+                    GenericNCommand::Function(func_decl),
+                    GenericNCommand::CoreAction(GenericAction::Union(
+                        (),
+                        GenericExpr::Call((), ResolvedCall {}, vec![]),
+                        expr,
+                    )),
+                ];
+
+                res
+            }
+        },
+    }
+}

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -223,8 +223,8 @@ impl Assignment<AtomTerm, ArcSort> {
         match &expr {
             GenericExpr::Lit((), literal) => ResolvedExpr::Lit((), literal.clone()),
             GenericExpr::Var((), var) => {
-                let ty = typeinfo
-                    .lookup_global(var)
+                let global_ty = typeinfo.lookup_global(var);
+                let ty = global_ty
                     .or_else(|| self.get(&AtomTerm::Var(*var)).cloned())
                     .expect("All variables should be assigned before annotation");
                 ResolvedExpr::Var(
@@ -232,6 +232,7 @@ impl Assignment<AtomTerm, ArcSort> {
                     ResolvedVar {
                         name: *var,
                         sort: ty.clone(),
+                        is_global_ref: global_ty.is_some(),
                     },
                 )
             }
@@ -298,6 +299,7 @@ impl Assignment<AtomTerm, ArcSort> {
                     ResolvedVar {
                         name: *var,
                         sort: ty.clone(),
+                        is_global_ref: false,
                     },
                     self.annotate_expr(expr, typeinfo),
                 ))

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -9,7 +9,7 @@ use crate::{
     sort::I64Sort,
     typechecking::TypeError,
     util::{FreshGen, HashMap, HashSet, SymbolGen},
-    ArcSort, Symbol, TypeInfo,
+    ArcSort, CorrespondingVar, Symbol, TypeInfo,
 };
 use core::hash::Hash;
 use std::{fmt::Debug, iter::once, mem::swap};
@@ -217,7 +217,7 @@ where
 impl Assignment<AtomTerm, ArcSort> {
     pub(crate) fn annotate_expr(
         &self,
-        expr: &GenericExpr<(Symbol, Symbol), Symbol, ()>,
+        expr: &GenericExpr<CorrespondingVar<Symbol, Symbol>, Symbol, ()>,
         typeinfo: &TypeInfo,
     ) -> ResolvedExpr {
         match &expr {
@@ -236,7 +236,14 @@ impl Assignment<AtomTerm, ArcSort> {
                     },
                 )
             }
-            GenericExpr::Call((), (head, corresponding_var), args) => {
+            GenericExpr::Call(
+                (),
+                CorrespondingVar {
+                    head,
+                    to: corresponding_var,
+                },
+                args,
+            ) => {
                 // get the resolved call using resolve_rule
                 let args: Vec<_> = args
                     .iter()
@@ -259,7 +266,7 @@ impl Assignment<AtomTerm, ArcSort> {
 
     pub(crate) fn annotate_fact(
         &self,
-        facts: &GenericFact<(Symbol, Symbol), Symbol, ()>,
+        facts: &GenericFact<CorrespondingVar<Symbol, Symbol>, Symbol, ()>,
         typeinfo: &TypeInfo,
     ) -> ResolvedFact {
         match facts {
@@ -275,7 +282,7 @@ impl Assignment<AtomTerm, ArcSort> {
 
     pub(crate) fn annotate_facts(
         &self,
-        mapped_facts: &[GenericFact<(Symbol, Symbol), Symbol, ()>],
+        mapped_facts: &[GenericFact<CorrespondingVar<Symbol, Symbol>, Symbol, ()>],
         typeinfo: &TypeInfo,
     ) -> Vec<ResolvedFact> {
         mapped_facts
@@ -305,7 +312,15 @@ impl Assignment<AtomTerm, ArcSort> {
                 ))
             }
             // Note mapped_var for set is a dummy variable that does not mean anything
-            GenericAction::Set((), (head, _mapped_var), children, rhs) => {
+            GenericAction::Set(
+                (),
+                CorrespondingVar {
+                    head,
+                    to: _mapped_var,
+                },
+                children,
+                rhs,
+            ) => {
                 let children: Vec<_> = children
                     .iter()
                     .map(|child| self.annotate_expr(child, typeinfo))
@@ -323,7 +338,14 @@ impl Assignment<AtomTerm, ArcSort> {
                 Ok(ResolvedAction::Set((), resolved_call, children, rhs))
             }
             // Note mapped_var for delete is a dummy variable that does not mean anything
-            GenericAction::Delete((), (head, _mapped_var), children) => {
+            GenericAction::Delete(
+                (),
+                CorrespondingVar {
+                    head,
+                    to: _mapped_var,
+                },
+                children,
+            ) => {
                 let children: Vec<_> = children
                     .iter()
                     .map(|child| self.annotate_expr(child, typeinfo))
@@ -356,7 +378,7 @@ impl Assignment<AtomTerm, ArcSort> {
 
     pub(crate) fn annotate_actions(
         &self,
-        mapped_actions: &GenericActions<(Symbol, Symbol), Symbol, ()>,
+        mapped_actions: &GenericActions<CorrespondingVar<Symbol, Symbol>, Symbol, ()>,
         typeinfo: &TypeInfo,
     ) -> Result<ResolvedActions, TypeError> {
         let actions = mapped_actions

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -225,6 +225,7 @@ impl Assignment<AtomTerm, ArcSort> {
             GenericExpr::Var((), var) => {
                 let global_ty = typeinfo.lookup_global(var);
                 let ty = global_ty
+                    .clone()
                     .or_else(|| self.get(&AtomTerm::Var(*var)).cloned())
                     .expect("All variables should be assigned before annotation");
                 ResolvedExpr::Var(

--- a/src/core.rs
+++ b/src/core.rs
@@ -370,8 +370,8 @@ where
 #[allow(clippy::type_complexity)]
 impl<Head, Leaf> GenericActions<Head, Leaf, ()>
 where
-    Head: Clone,
-    Leaf: Clone + Hash + Eq + Clone,
+    Head: Clone + Display,
+    Leaf: Clone + PartialEq + Eq + Display + Hash,
 {
     pub(crate) fn to_core_actions<FG: FreshGen<Head, Leaf>>(
         &self,
@@ -389,7 +389,7 @@ where
         Leaf: SymbolLike,
     {
         let mut norm_actions = vec![];
-        let mut mapped_actions = vec![];
+        let mut mapped_actions: MappedActions<Head, Leaf, ()> = GenericActions(vec![]);
 
         // During the lowering, there are two important guaratees:
         //   Every used variable should be bound.
@@ -407,7 +407,9 @@ where
                         var.clone(),
                         mapped_expr.get_corresponding_var_or_lit(typeinfo),
                     ));
-                    mapped_actions.push(GenericAction::Let((), var.clone(), mapped_expr));
+                    mapped_actions
+                        .0
+                        .push(GenericAction::Let((), var.clone(), mapped_expr));
                     binding.insert(var.clone());
                 }
                 GenericAction::Set(_ann, head, args, expr) => {
@@ -430,9 +432,9 @@ where
                         mapped_expr.get_corresponding_var_or_lit(typeinfo),
                     ));
                     let v = fresh_gen.fresh(head);
-                    mapped_actions.push(GenericAction::Set(
+                    mapped_actions.0.push(GenericAction::Set(
                         (),
-                        (head.clone(), v),
+                        CorrespondingVar::new(head.clone(), v),
                         mapped_args,
                         mapped_expr,
                     ));
@@ -453,7 +455,11 @@ where
                             .collect(),
                     ));
                     let v = fresh_gen.fresh(head);
-                    mapped_actions.push(GenericAction::Delete((), (head.clone(), v), mapped_args));
+                    mapped_actions.0.push(GenericAction::Delete(
+                        (),
+                        CorrespondingVar::new(head.clone(), v),
+                        mapped_args,
+                    ));
                 }
                 GenericAction::Union(_ann, e1, e2) => {
                     let (actions1, mapped_e1) = e1.to_core_actions(typeinfo, binding, fresh_gen)?;
@@ -464,7 +470,9 @@ where
                         mapped_e1.get_corresponding_var_or_lit(typeinfo),
                         mapped_e2.get_corresponding_var_or_lit(typeinfo),
                     ));
-                    mapped_actions.push(GenericAction::Union((), mapped_e1, mapped_e2));
+                    mapped_actions
+                        .0
+                        .push(GenericAction::Union((), mapped_e1, mapped_e2));
                 }
                 GenericAction::Extract(_ann, e, n) => {
                     let (actions, mapped_e) = e.to_core_actions(typeinfo, binding, fresh_gen)?;
@@ -475,28 +483,34 @@ where
                         mapped_e.get_corresponding_var_or_lit(typeinfo),
                         mapped_n.get_corresponding_var_or_lit(typeinfo),
                     ));
-                    mapped_actions.push(GenericAction::Extract((), mapped_e, mapped_n));
+                    mapped_actions
+                        .0
+                        .push(GenericAction::Extract((), mapped_e, mapped_n));
                 }
                 GenericAction::Panic(_ann, string) => {
                     norm_actions.push(GenericCoreAction::Panic(string.clone()));
-                    mapped_actions.push(GenericAction::Panic((), string.clone()));
+                    mapped_actions
+                        .0
+                        .push(GenericAction::Panic((), string.clone()));
                 }
                 GenericAction::Expr(_ann, expr) => {
                     let (actions, mapped_expr) =
                         expr.to_core_actions(typeinfo, binding, fresh_gen)?;
                     norm_actions.extend(actions.0);
-                    mapped_actions.push(GenericAction::Expr((), mapped_expr));
+                    mapped_actions.0.push(GenericAction::Expr((), mapped_expr));
                 }
             }
         }
-        Ok((
-            GenericCoreActions::new(norm_actions),
-            GenericActions::new(mapped_actions),
-        ))
+        Ok((GenericCoreActions::new(norm_actions), mapped_actions))
     }
 }
 
-impl<Head: Clone, Leaf: Clone, Ann: Clone> GenericExpr<Head, Leaf, Ann> {
+impl<Head, Leaf, Ann> GenericExpr<Head, Leaf, Ann>
+where
+    Ann: Clone + Default,
+    Head: Clone + Display,
+    Leaf: Clone + PartialEq + Eq + Display + Hash,
+{
     pub(crate) fn to_query(
         &self,
         typeinfo: &TypeInfo,
@@ -533,7 +547,11 @@ impl<Head: Clone, Leaf: Clone, Ann: Clone> GenericExpr<Head, Leaf, Ann> {
                 });
                 (
                     atoms,
-                    GenericExpr::Call(ann.clone(), (f.clone(), fresh), child_exprs),
+                    GenericExpr::Call(
+                        ann.clone(),
+                        CorrespondingVar::new(f.clone(), fresh),
+                        child_exprs,
+                    ),
                 )
             }
         }
@@ -582,7 +600,7 @@ impl<Head: Clone, Leaf: Clone, Ann: Clone> GenericExpr<Head, Leaf, Ann> {
                 norm_actions.push(GenericCoreAction::Let(var.clone(), f.clone(), norm_args));
                 Ok((
                     GenericCoreActions::new(norm_actions),
-                    GenericExpr::Call((), (f.clone(), var), mapped_args),
+                    GenericExpr::Call((), CorrespondingVar::new(f.clone(), var), mapped_args),
                 ))
             }
         }
@@ -701,8 +719,8 @@ where
 
 impl<Head, Leaf> GenericRule<Head, Leaf, ()>
 where
-    Leaf: Clone + Eq + Hash + Debug,
-    Head: Clone,
+    Head: Clone + Display,
+    Leaf: Clone + PartialEq + Eq + Display + Hash + Debug,
 {
     pub(crate) fn to_core_rule(
         &self,

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -84,10 +84,12 @@ impl Function {
             ResolvedVar {
                 name: Symbol::from("old"),
                 sort: output.clone(),
+                is_global_ref: false,
             },
             ResolvedVar {
                 name: Symbol::from("new"),
                 sort: output.clone(),
+                is_global_ref: false,
             },
         ]);
 

--- a/src/gj.rs
+++ b/src/gj.rs
@@ -738,6 +738,7 @@ impl EGraph {
             for atom in cq.query.funcs() {
                 for arg in &atom.args {
                     if let AtomTerm::Global(g) = arg {
+                        panic!("found global var {}", g);
                         if self.global_bindings.get(g).unwrap().2 > timestamp {
                             global_updated = true;
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1214,7 +1214,7 @@ impl EGraph {
         if !matched {
             // TODO add useful info here
             Err(Error::CheckError(
-                facts.iter().map(|f| f.to_unresolved()).collect(),
+                facts.iter().map(|f| f.clone().to_unresolved()).collect(),
             ))
         } else {
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1436,7 +1436,7 @@ impl EGraph {
 
         let program = self.type_info_mut().typecheck_program(&program)?;
 
-        let program = remove_globals(&self.type_info, program);
+        //let program = remove_globals(&self.type_info, program);
 
         Ok(program)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1133,7 +1133,10 @@ impl EGraph {
         let fresh_name = self.desugar.get_fresh();
         let command = Command::Action(Action::Let((), fresh_name, expr.clone()));
         self.run_program(vec![command])?;
-        let (sort, value, _ts) = self.global_bindings.get(&fresh_name).unwrap().clone();
+        // find the table with the same name as the fresh name
+        let func = self.functions.get(&fresh_name).unwrap();
+        let value = func.nodes.get(&[]).unwrap().value;
+        let sort = func.schema.output.clone();
         Ok((sort, value))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod util;
 mod value;
 
 use ast::desugar::Desugar;
+use ast::remove_globals::remove_globals;
 use extract::Extractor;
 use hashbrown::hash_map::Entry;
 use index::ColumnIndex;
@@ -1434,6 +1435,8 @@ impl EGraph {
                 .desugar_program(vec![command], self.test_proofs, self.seminaive)?;
 
         let program = self.type_info_mut().typecheck_program(&program)?;
+
+        let program = remove_globals(&self.type_info, program);
 
         Ok(program)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1214,7 +1214,7 @@ impl EGraph {
         if !matched {
             // TODO add useful info here
             Err(Error::CheckError(
-                facts.iter().map(|f| f.clone().to_unresolved()).collect(),
+                facts.iter().map(|f| f.clone().make_unresolved()).collect(),
             ))
         } else {
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1436,7 +1436,7 @@ impl EGraph {
 
         let program = self.type_info_mut().typecheck_program(&program)?;
 
-        //let program = remove_globals(&self.type_info, program);
+        let program = remove_globals(&self.type_info, program);
 
         Ok(program)
     }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -70,7 +70,7 @@ impl EGraph {
         )> = self
             .functions
             .values()
-            .filter(|function| !function.decl.is_global)
+            .filter(|function| !function.decl.ignore_viz)
             .map(|function| {
                 function
                     .nodes

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -70,6 +70,7 @@ impl EGraph {
         )> = self
             .functions
             .values()
+            .filter(|function| !function.decl.is_global)
             .map(|function| {
                 function
                     .nodes

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -263,7 +263,7 @@ impl TypeInfo {
             merge_action: self.typecheck_actions(&fdecl.merge_action, &bound_vars)?,
             cost: fdecl.cost,
             unextractable: fdecl.unextractable,
-            is_global: fdecl.is_global,
+            ignore_viz: fdecl.ignore_viz,
         })
     }
 

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -184,6 +184,8 @@ impl TypeInfo {
                 let var = ResolvedVar {
                     name: *var,
                     sort: output_type,
+                    // not a global reference, but a global binding
+                    is_global_ref: false,
                 };
                 ResolvedNCommand::CoreAction(ResolvedAction::Let((), var, expr))
             }

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -263,6 +263,7 @@ impl TypeInfo {
             merge_action: self.typecheck_actions(&fdecl.merge_action, &bound_vars)?,
             cost: fdecl.cost,
             unextractable: fdecl.unextractable,
+            is_global: fdecl.is_global,
         })
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -107,6 +107,9 @@ impl FreshGen<ResolvedCall, ResolvedVar> for ResolvedGen {
         ResolvedVar {
             name: s.into(),
             sort,
+            // fresh variables are never global references, since globals
+            // are desugared away by `remove_globals`
+            is_global_ref: false,
         }
     }
 }


### PR DESCRIPTION
This PR adds a brand new, type-preserving pass that gets rid of all global variables by tuning them into functions.
This does not yet resolve the issue about declare: #334 
Example:
```
(let x 3)
(Add x x)
 ```

becomes

```
(function x () i64)
(set (x) 3)
(Add (x) (x))
```

Most of this PR is helpers, such as `map_exprs`, which allows us to map over all exprs in the whole egglog program.

Here are some questions we need to resolve before this is merged:
- [ ] While refactoring `map_exprs`, I had to add a lot of type constraints throughout the ast. It's a lot of boilerplate- is there a way to get rid of them?
- [x] How does this affect visualizations? Right now the function is unextractable, but probably still shows up in the viz which is incorrect
- [ ] Can we remove `AtomTerm::Global`? Seems like the typechecker uses core actions so maybe not? Right now we have several panics in the back end when we see a global.