### PR TITLE
Switch default serialization to output all nodes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1523,12 +1523,16 @@ impl EGraph {
     }
 
     /// Serializes the egraph for export to graphviz.
+    ///
+    /// This will limit the total number of nodes so that visualization does not blow up.
     pub fn serialize_for_graphviz(
         &self,
         split_primitive_outputs: bool,
     ) -> egraph_serialize::EGraph {
         let config = SerializeConfig {
             split_primitive_outputs,
+            max_functions: Some(40),
+            max_calls_per_function: Some(40),
             ..Default::default()
         };
         let mut serialized = self.serialize(config);

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -21,12 +21,12 @@ pub struct SerializeConfig {
     pub root_eclasses: Vec<Value>,
 }
 
-/// Default is used for visualizations and limits number of functions and calls
+/// Default is used for exporting JSON and will output all nodes.
 impl Default for SerializeConfig {
     fn default() -> Self {
         SerializeConfig {
-            max_functions: Some(40),
-            max_calls_per_function: Some(40),
+            max_functions: None,
+            max_calls_per_function: None,
             include_temporary_functions: false,
             split_primitive_outputs: false,
             root_eclasses: vec![],


### PR DESCRIPTION
Still keeps visualization defaults to limit for testing and to make more readable graphviz files.

Partially addresses #345 