### PR TITLE
Symbol generation fixes

### DIFF
--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -11,6 +11,7 @@ pub struct Desugar {
 impl Default for Desugar {
     fn default() -> Self {
         Self {
+            // the default reserved string in egglog is "_"
             fresh_gen: SymbolGen::new("_".repeat(2)),
             parser: ast::parse::ProgramParser::new(),
         }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -22,6 +22,7 @@ mod expr;
 pub use expr::*;
 pub mod desugar;
 pub(crate) mod remove_globals;
+pub(crate) mod term_encoding;
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Id(usize);

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -22,7 +22,6 @@ mod expr;
 pub use expr::*;
 pub mod desugar;
 pub(crate) mod remove_globals;
-pub(crate) mod term_encoding;
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Id(usize);

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -11,8 +11,8 @@ use crate::{
     ResolvedFact, ResolvedFunctionDecl, ResolvedNCommand, ResolvedVar, Schema, SymbolGen, TypeInfo,
 };
 
-struct GlobalRemover {
-    fresh: SymbolGen,
+struct GlobalRemover<'a> {
+    fresh: &'a mut SymbolGen,
 }
 
 /// Removes all globals from a program.
@@ -47,10 +47,9 @@ struct GlobalRemover {
 pub(crate) fn remove_globals(
     type_info: &TypeInfo,
     prog: Vec<ResolvedNCommand>,
+    fresh: &mut SymbolGen,
 ) -> Vec<ResolvedNCommand> {
-    let mut remover = GlobalRemover {
-        fresh: SymbolGen::new(),
-    };
+    let mut remover = GlobalRemover { fresh };
     prog.into_iter()
         .flat_map(|cmd| remover.remove_globals_cmd(type_info, cmd))
         .collect()
@@ -91,7 +90,7 @@ fn remove_globals_action(action: ResolvedAction) -> ResolvedAction {
     action.visit_exprs(&mut replace_global_vars)
 }
 
-impl GlobalRemover {
+impl<'a> GlobalRemover<'a> {
     fn remove_globals_cmd(
         &mut self,
         type_info: &TypeInfo,

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -191,7 +191,7 @@ pub struct Problem<Var, Value> {
 
 impl Default for Problem<AtomTerm, ArcSort> {
     fn default() -> Self {
-        Problem {
+        Self {
             constraints: vec![],
             range: HashSet::default(),
         }
@@ -444,7 +444,7 @@ impl Problem<AtomTerm, ArcSort> {
         actions: &GenericCoreActions<Symbol, Symbol>,
         typeinfo: &TypeInfo,
     ) -> Result<(), TypeError> {
-        let mut symbol_gen = SymbolGen::new();
+        let mut symbol_gen = SymbolGen::new("$".to_string());
         for action in actions.0.iter() {
             self.constraints
                 .extend(action.get_constraints(typeinfo, &mut symbol_gen)?);
@@ -511,7 +511,7 @@ impl CoreAction {
             CoreAction::Change(_change, head, args) => {
                 let mut args = args.clone();
                 // Add a dummy last output argument
-                let var = symbol_gen.fresh(&Symbol::from(format!("constraint${head}")));
+                let var = symbol_gen.fresh(head);
                 args.push(AtomTerm::Var(var));
 
                 Ok(get_literal_and_global_constraints(&args, typeinfo)

--- a/src/core.rs
+++ b/src/core.rs
@@ -762,12 +762,16 @@ impl ResolvedRule {
     ) -> Result<ResolvedCoreRule, TypeError> {
         let value_eq = &typeinfo.primitives.get(&Symbol::from("value-eq")).unwrap()[0];
         let unit = typeinfo.get_sort_nofail::<UnitSort>();
-        self.to_canonicalized_core_rule_impl(typeinfo, ResolvedGen::new(), |at1, at2| {
-            ResolvedCall::Primitive(SpecializedPrimitive {
-                primitive: value_eq.clone(),
-                input: vec![at1.output(typeinfo), at2.output(typeinfo)],
-                output: unit.clone(),
-            })
-        })
+        self.to_canonicalized_core_rule_impl(
+            typeinfo,
+            ResolvedGen::new("$".to_string()),
+            |at1, at2| {
+                ResolvedCall::Primitive(SpecializedPrimitive {
+                    primitive: value_eq.clone(),
+                    input: vec![at1.output(typeinfo), at2.output(typeinfo)],
+                    output: unit.clone(),
+                })
+            },
+        )
     }
 }

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -115,7 +115,7 @@ impl Function {
             let (actions, mapped_expr) = merge_expr.to_core_actions(
                 egraph.type_info(),
                 &mut binding.clone(),
-                &mut ResolvedGen::new(),
+                &mut ResolvedGen::new("$".to_string()),
             )?;
             let target = mapped_expr.get_corresponding_var_or_lit(egraph.type_info());
             let program = egraph
@@ -134,7 +134,7 @@ impl Function {
             let (merge_action, _) = decl.merge_action.to_core_actions(
                 egraph.type_info(),
                 &mut binding.clone(),
-                &mut ResolvedGen::new(),
+                &mut ResolvedGen::new("$".to_string()),
             )?;
             let program = egraph
                 .compile_actions(&binding, &merge_action)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1428,7 +1428,7 @@ impl EGraph {
 
         let program = self.type_info_mut().typecheck_program(&program)?;
 
-        let program = remove_globals(&self.type_info, program);
+        let program = remove_globals(&self.type_info, program, &mut self.desugar.fresh_gen);
 
         Ok(program)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,7 +410,6 @@ pub struct EGraph {
     interactive_mode: bool,
     timestamp: u32,
     pub run_mode: RunMode,
-    // pub(crate) term_header_added: bool,
     pub test_proofs: bool,
     pub match_limit: usize,
     pub node_limit: usize,
@@ -594,7 +593,15 @@ impl EGraph {
     pub fn find(&self, value: Value) -> Value {
         if self.terms_enabled {
             // HACK using value tag for parent table name
-            let parent_name = self.desugar.parent_name(value.tag);
+            let parent_name = self
+                .desugar
+                .lookup_parent_name(value.tag)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Term encoding should have created parent table for {}",
+                        value.tag
+                    )
+                });
             if let Some(func) = self.functions.get(&parent_name) {
                 func.get(&[value])
                     .unwrap_or_else(|| panic!("No value {:?} in {parent_name}.", value,))
@@ -1108,7 +1115,7 @@ impl EGraph {
         let (actions, _) = actions.to_core_actions(
             self.type_info(),
             &mut Default::default(),
-            &mut ResolvedGen::new(),
+            &mut ResolvedGen::new("$".to_string()),
         )?;
         let program = self
             .compile_actions(&Default::default(), &actions)
@@ -1139,7 +1146,7 @@ impl EGraph {
         let (actions, mapped_expr) = expr.to_core_actions(
             self.type_info(),
             &mut Default::default(),
-            &mut ResolvedGen::new(),
+            &mut ResolvedGen::new("$".to_string()),
         )?;
         let target = mapped_expr.get_corresponding_var_or_lit(self.type_info());
         let program = self
@@ -1406,8 +1413,12 @@ impl EGraph {
         }
     }
 
-    pub fn set_underscores_for_desugaring(&mut self, underscores: usize) {
-        self.desugar.number_underscores = underscores;
+    pub fn set_reserved_symbol(&mut self, sym: Symbol) {
+        assert!(
+            !self.desugar.fresh_gen.has_been_used(),
+            "Reserved symbol must be set before any symbols are generated"
+        );
+        self.desugar.fresh_gen = SymbolGen::new(sym.to_string());
     }
 
     fn process_command(&mut self, command: Command) -> Result<Vec<ResolvedNCommand>, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ struct Args {
     #[clap(long, default_value_t = RunMode::Normal)]
     show: RunMode,
     // TODO remove this evil hack
-    #[clap(long, default_value_t = 3)]
-    num_underscores: usize,
+    #[clap(long, default_value = "__")]
+    reserved_symbol: String,
     inputs: Vec<PathBuf>,
     #[clap(long)]
     to_json: bool,
@@ -50,7 +50,7 @@ fn main() {
 
     let mk_egraph = || {
         let mut egraph = EGraph::default();
-        egraph.set_underscores_for_desugaring(args.num_underscores);
+        egraph.set_reserved_symbol(args.reserved_symbol.clone().into());
         egraph.fact_directory = args.fact_directory.clone();
         egraph.seminaive = !args.naive;
         egraph.run_mode = args.show;

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -324,7 +324,7 @@ impl TypeInfo {
         let Rule { head, body } = rule;
         let mut constraints = vec![];
 
-        let mut fresh_gen = SymbolGen::new();
+        let mut fresh_gen = SymbolGen::new("$".to_string());
         let (query, mapped_query) = Facts(body.clone()).to_query(self, &mut fresh_gen);
         constraints.extend(query.get_constraints(self)?);
 
@@ -354,7 +354,7 @@ impl TypeInfo {
     }
 
     fn typecheck_facts(&self, facts: &[Fact]) -> Result<Vec<ResolvedFact>, TypeError> {
-        let mut fresh_gen = SymbolGen::new();
+        let mut fresh_gen = SymbolGen::new("$".to_string());
         let (query, mapped_facts) = Facts(facts.to_vec()).to_query(self, &mut fresh_gen);
         let mut problem = Problem::default();
         problem.add_query(&query, self)?;
@@ -371,7 +371,7 @@ impl TypeInfo {
         binding: &IndexMap<Symbol, ArcSort>,
     ) -> Result<ResolvedActions, TypeError> {
         let mut binding_set = binding.keys().cloned().collect::<IndexSet<_>>();
-        let mut fresh_gen = SymbolGen::new();
+        let mut fresh_gen = SymbolGen::new("$".to_string());
         let (actions, mapped_action) =
             actions.to_core_actions(self, &mut binding_set, &mut fresh_gen)?;
         let mut problem = Problem::default();

--- a/src/util.rs
+++ b/src/util.rs
@@ -66,39 +66,75 @@ where
 /// user's symbols because they use $.
 pub(crate) trait FreshGen<Head, Leaf> {
     fn fresh(&mut self, name_hint: &Head) -> Leaf;
+    fn has_been_used(&self) -> bool;
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SymbolGen {
     gen: usize,
+    reserved_string: String,
+    special_reserved: HashMap<Symbol, String>,
 }
 
 impl SymbolGen {
-    pub(crate) fn new() -> Self {
-        Self { gen: 0 }
+    pub(crate) fn new(reserved_string: String) -> Self {
+        Self {
+            gen: 0,
+            reserved_string,
+            special_reserved: HashMap::default(),
+        }
+    }
+
+    pub(crate) fn has_been_used(&self) -> bool {
+        self.gen > 0
+    }
+
+    pub(crate) fn generate_special(&mut self, sym: &Symbol) -> Symbol {
+        match self.special_reserved.get(sym) {
+            Some(res) => res.into(),
+            None => {
+                let res = format!("{}{}{}", self.reserved_string, sym, self.gen);
+                self.gen += 1;
+                self.special_reserved.insert(*sym, res.clone());
+                res.into()
+            }
+        }
+    }
+
+    pub(crate) fn lookup_special(&self, sym: &Symbol) -> Option<Symbol> {
+        self.special_reserved.get(sym).map(|s| s.into())
     }
 }
 
 impl FreshGen<Symbol, Symbol> for SymbolGen {
     fn fresh(&mut self, name_hint: &Symbol) -> Symbol {
-        let s = format!("__{}{}", name_hint, self.gen);
+        let s = format!("{}{}{}", self.reserved_string, name_hint, self.gen);
         self.gen += 1;
         Symbol::from(s)
+    }
+
+    fn has_been_used(&self) -> bool {
+        self.gen > 0
     }
 }
 
 pub(crate) struct ResolvedGen {
     gen: usize,
+    reserved_string: String,
 }
 
 impl ResolvedGen {
-    pub(crate) fn new() -> Self {
-        Self { gen: 0 }
+    pub(crate) fn new(reserved_string: String) -> Self {
+        Self {
+            gen: 0,
+            reserved_string,
+        }
     }
 }
 
 impl FreshGen<ResolvedCall, ResolvedVar> for ResolvedGen {
     fn fresh(&mut self, name_hint: &ResolvedCall) -> ResolvedVar {
-        let s = format!("__{}{}", name_hint, self.gen);
+        let s = format!("{}{}{}", self.reserved_string, name_hint, self.gen);
         self.gen += 1;
         let sort = match name_hint {
             ResolvedCall::Func(f) => f.output.clone(),
@@ -111,6 +147,10 @@ impl FreshGen<ResolvedCall, ResolvedVar> for ResolvedGen {
             // are desugared away by `remove_globals`
             is_global_ref: false,
         }
+    }
+
+    fn has_been_used(&self) -> bool {
+        self.gen > 0
     }
 }
 

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -20,7 +20,7 @@ impl Run {
         } else {
             let mut egraph = EGraph::default();
             egraph.run_mode = RunMode::ShowDesugaredEgglog;
-            egraph.set_underscores_for_desugaring(3);
+            egraph.set_reserved_symbol("__".into());
             let desugared_str = egraph.parse_and_run_program(&program).unwrap().join("\n");
 
             self.test_program(
@@ -32,7 +32,7 @@ impl Run {
 
     fn test_program(&self, program: &str, message: &str) {
         let mut egraph = EGraph::default();
-        egraph.set_underscores_for_desugaring(5);
+        egraph.set_reserved_symbol("___".into());
         match egraph.parse_and_run_program(program) {
             Ok(msgs) => {
                 if self.should_fail() {


### PR DESCRIPTION
This PR allows different code to set different reserved symbols for the symbol gen struct
This fixes all of our name conflicts. Desugaring using `__` by default and the middle of the compiler uses `$`