### PR TITLE
Add custom extraction cost functions

### DIFF
--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -101,9 +101,12 @@ Schedule: Schedule = {
     <ident:Ident> => Schedule::Run(RunConfig { ruleset: ident, until: None }),
 }
 
-Cost: Option<usize> = {
-    ":cost" <UNum> => Some(<>),
-    => None,
+Cost: CostFn = {
+    ":cost" <UNum> => CostFn::Constant(<>),
+    ":cost" <Ident> => CostFn::Table(false, <>),
+    // dont use this, it's only for round-tripping desugaring
+    ":_declared_cost" <Ident> => CostFn::Table(true, <>),
+    => CostFn::Constant(1),
 }
 
 NonLetAction: Action = {

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -183,6 +183,16 @@ impl Function {
         self.nodes.get(inputs).map(|output| output.value)
     }
 
+    pub fn get_cost(&self, egraph: &EGraph, inputs: &[Value]) -> Option<usize> {
+        match self.decl.cost {
+            CostFn::Constant(n) => Some(n),
+            CostFn::Table(_, symbol) => {
+                let f = egraph.functions.get(&symbol)?;
+                f.get(inputs).map(|output| output.bits as usize)
+            }
+        }
+    }
+
     pub fn insert(&mut self, inputs: &[Value], value: Value, timestamp: u32) -> Option<Value> {
         self.insert_internal(inputs, value, timestamp, true)
     }

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -259,7 +259,7 @@ impl TypeInfo {
                 .map(|default| self.typecheck_expr(default, &Default::default()))
                 .transpose()?,
             merge_action: self.typecheck_actions(&fdecl.merge_action, &bound_vars)?,
-            cost: fdecl.cost,
+            cost: fdecl.cost.clone(),
             unextractable: fdecl.unextractable,
         })
     }

--- a/tests/extract-costfn.egg
+++ b/tests/extract-costfn.egg
@@ -1,0 +1,14 @@
+
+(datatype E
+  (Foo String :cost FooCost))
+
+(union (Foo "x") (Foo "y"))
+(union (Foo "y") (Foo "z"))
+
+(set (FooCost "x") 17)
+(set (FooCost "y") 11)
+(set (FooCost "z") 15)
+
+(extract (Foo "y"))
+
+


### PR DESCRIPTION
This add support for custom cost function. You can write code like this now:

```

(datatype E
  (Foo String :cost FooCost))

(union (Foo "x") (Foo "y"))
(union (Foo "y") (Foo "z"))

(set (FooCost "x") 17)
(set (FooCost "y") 11)
(set (FooCost "z") 15)

(extract (Foo "y"))

```

I'm not 100% if what I did with typechecking is okay, but at least this simple example works.