### PR TITLE
Add combined rulesets to egglog

### DIFF
--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -274,8 +274,10 @@ pub(crate) fn desugar_command(
             result
         }
         Command::Sort(sort, option) => vec![NCommand::Sort(sort, option)],
-        // TODO ignoring cost for now
         Command::AddRuleset(name) => vec![NCommand::AddRuleset(name)],
+        Command::CombinedRuleset(name, subrulesets) => {
+            vec![NCommand::CombinedRuleset(name, subrulesets)]
+        }
         Command::Action(action) => vec![NCommand::CoreAction(action)],
         Command::Simplify { expr, schedule } => desugar_simplify(desugar, &expr, &schedule),
         Command::Calc(idents, exprs) => desugar_calc(desugar, idents, exprs, seminaive_transform)?,

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -275,8 +275,8 @@ pub(crate) fn desugar_command(
         }
         Command::Sort(sort, option) => vec![NCommand::Sort(sort, option)],
         Command::AddRuleset(name) => vec![NCommand::AddRuleset(name)],
-        Command::CombinedRuleset(name, subrulesets) => {
-            vec![NCommand::CombinedRuleset(name, subrulesets)]
+        Command::UnstableCombinedRuleset(name, subrulesets) => {
+            vec![NCommand::UnstableCombinedRuleset(name, subrulesets)]
         }
         Command::Action(action) => vec![NCommand::CoreAction(action)],
         Command::Simplify { expr, schedule } => desugar_simplify(desugar, &expr, &schedule),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -44,9 +44,10 @@ impl Display for Id {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Ruleset {
-    Rules(Symbol, HashMap<Symbol, Rule>),
+#[derive(Clone, Debug)]
+/// The egglog internal representation of already compiled rules
+pub(crate) enum Ruleset {
+    Rules(Symbol, HashMap<Symbol, CompiledRule>),
     Combined(Symbol, Vec<Symbol>),
 }
 
@@ -1458,6 +1459,12 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_sexp())
     }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CompiledRule {
+    pub(crate) query: CompiledQuery,
+    pub(crate) program: Program,
 }
 
 pub type Rule = GenericRule<Symbol, Symbol, ()>;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -717,7 +717,7 @@ where
             } => list!("relation", constructor, list!(++ inputs)),
             GenericCommand::AddRuleset(name) => list!("ruleset", name),
             GenericCommand::CombinedRuleset(name, others) => {
-                list!("combined-ruleset", name, ++ others)
+                list!("unstable-combined-ruleset", name, ++ others)
             }
             GenericCommand::Rule {
                 name,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -85,7 +85,7 @@ where
     ),
     Function(GenericFunctionDecl<Head, Leaf, Ann>),
     AddRuleset(Symbol),
-    CombinedRuleset(Symbol, Vec<Symbol>),
+    UnstableCombinedRuleset(Symbol, Vec<Symbol>),
     NormRule {
         name: Symbol,
         ruleset: Symbol,
@@ -125,8 +125,8 @@ where
             GenericNCommand::Sort(name, params) => GenericCommand::Sort(*name, params.clone()),
             GenericNCommand::Function(f) => GenericCommand::Function(f.clone()),
             GenericNCommand::AddRuleset(name) => GenericCommand::AddRuleset(*name),
-            GenericNCommand::CombinedRuleset(name, others) => {
-                GenericCommand::CombinedRuleset(*name, others.clone())
+            GenericNCommand::UnstableCombinedRuleset(name, others) => {
+                GenericCommand::UnstableCombinedRuleset(*name, others.clone())
             }
             GenericNCommand::NormRule {
                 name,
@@ -170,8 +170,8 @@ where
             GenericNCommand::Sort(name, params) => GenericNCommand::Sort(name, params),
             GenericNCommand::Function(func) => GenericNCommand::Function(func.visit_exprs(f)),
             GenericNCommand::AddRuleset(name) => GenericNCommand::AddRuleset(name),
-            GenericNCommand::CombinedRuleset(name, rulesets) => {
-                GenericNCommand::CombinedRuleset(name, rulesets)
+            GenericNCommand::UnstableCombinedRuleset(name, rulesets) => {
+                GenericNCommand::UnstableCombinedRuleset(name, rulesets)
             }
             GenericNCommand::NormRule {
                 name,
@@ -492,7 +492,7 @@ where
     ///       ((path x z))
     ///       :ruleset myrules2)
     /// (combined-ruleset myrules-combined myrules1 myrules2)
-    CombinedRuleset(Symbol, Vec<Symbol>),
+    UnstableCombinedRuleset(Symbol, Vec<Symbol>),
     /// ```text
     /// (rule <body:List<Fact>> <head:List<Action>>)
     /// ```
@@ -716,7 +716,7 @@ where
                 inputs,
             } => list!("relation", constructor, list!(++ inputs)),
             GenericCommand::AddRuleset(name) => list!("ruleset", name),
-            GenericCommand::CombinedRuleset(name, others) => {
+            GenericCommand::UnstableCombinedRuleset(name, others) => {
                 list!("unstable-combined-ruleset", name, ++ others)
             }
             GenericCommand::Rule {

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -59,7 +59,7 @@ Command: Command = {
     LParen "declare" <name:Ident> <sort:Ident> RParen => Command::Declare{name, sort},
     LParen "relation" <constructor:Ident> <inputs:List<Type>> RParen => Command::Relation{constructor, inputs},
     LParen "ruleset" <name:Ident> RParen => Command::AddRuleset(name),
-    LParen "combined-ruleset" <name:Ident> <subrulesets:Ident*> RParen => Command::CombinedRuleset(name, subrulesets),
+    LParen "unstable-combined-ruleset" <name:Ident> <subrulesets:Ident*> RParen => Command::CombinedRuleset(name, subrulesets),
     LParen "rule" <body:List<Fact>> <head:List<Action>> <ruleset:(":ruleset" <Ident>)?> <name:(":name" <String>)?> RParen => Command::Rule{ruleset: ruleset.unwrap_or("".into()), name: name.unwrap_or("".to_string()).into(), rule: Rule { head: Actions::new(head), body }},
     LParen "rewrite" <lhs:Expr> <rhs:Expr>
         <subsume:(":subsume")?>

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -59,7 +59,7 @@ Command: Command = {
     LParen "declare" <name:Ident> <sort:Ident> RParen => Command::Declare{name, sort},
     LParen "relation" <constructor:Ident> <inputs:List<Type>> RParen => Command::Relation{constructor, inputs},
     LParen "ruleset" <name:Ident> RParen => Command::AddRuleset(name),
-    LParen "unstable-combined-ruleset" <name:Ident> <subrulesets:Ident*> RParen => Command::CombinedRuleset(name, subrulesets),
+    LParen "unstable-combined-ruleset" <name:Ident> <subrulesets:Ident*> RParen => Command::UnstableCombinedRuleset(name, subrulesets),
     LParen "rule" <body:List<Fact>> <head:List<Action>> <ruleset:(":ruleset" <Ident>)?> <name:(":name" <String>)?> RParen => Command::Rule{ruleset: ruleset.unwrap_or("".into()), name: name.unwrap_or("".to_string()).into(), rule: Rule { head: Actions::new(head), body }},
     LParen "rewrite" <lhs:Expr> <rhs:Expr>
         <subsume:(":subsume")?>

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -59,7 +59,7 @@ Command: Command = {
     LParen "declare" <name:Ident> <sort:Ident> RParen => Command::Declare{name, sort},
     LParen "relation" <constructor:Ident> <inputs:List<Type>> RParen => Command::Relation{constructor, inputs},
     LParen "ruleset" <name:Ident> RParen => Command::AddRuleset(name),
-    LParen "combined-ruleset" <name:Ident> <subrulesets:List<Ident>> RParen => Command::CombinedRuleset(name, subrulesets),
+    LParen "combined-ruleset" <name:Ident> <subrulesets:Ident*> RParen => Command::CombinedRuleset(name, subrulesets),
     LParen "rule" <body:List<Fact>> <head:List<Action>> <ruleset:(":ruleset" <Ident>)?> <name:(":name" <String>)?> RParen => Command::Rule{ruleset: ruleset.unwrap_or("".into()), name: name.unwrap_or("".to_string()).into(), rule: Rule { head: Actions::new(head), body }},
     LParen "rewrite" <lhs:Expr> <rhs:Expr>
         <subsume:(":subsume")?>

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -59,6 +59,7 @@ Command: Command = {
     LParen "declare" <name:Ident> <sort:Ident> RParen => Command::Declare{name, sort},
     LParen "relation" <constructor:Ident> <inputs:List<Type>> RParen => Command::Relation{constructor, inputs},
     LParen "ruleset" <name:Ident> RParen => Command::AddRuleset(name),
+    LParen "combined-ruleset" <name:Ident> <subrulesets:List<Ident>> RParen => Command::CombinedRuleset(name, subrulesets),
     LParen "rule" <body:List<Fact>> <head:List<Action>> <ruleset:(":ruleset" <Ident>)?> <name:(":name" <String>)?> RParen => Command::Rule{ruleset: ruleset.unwrap_or("".into()), name: name.unwrap_or("".to_string()).into(), rule: Rule { head: Actions::new(head), body }},
     LParen "rewrite" <lhs:Expr> <rhs:Expr>
         <subsume:(":subsume")?>

--- a/src/gj.rs
+++ b/src/gj.rs
@@ -717,10 +717,7 @@ impl EGraph {
             let duration = start.elapsed();
             log::debug!("Matched {} times (took {:?})", ctx.matches, duration,);
             if duration.as_millis() > 1000 {
-                log::warn!(
-                    "Query took a long time: {:?}",
-                    duration
-                );
+                log::warn!("Query took a long time: {:?}", duration);
             }
         }
     }

--- a/src/gj.rs
+++ b/src/gj.rs
@@ -716,13 +716,9 @@ impl EGraph {
             }
             let duration = start.elapsed();
             log::debug!("Matched {} times (took {:?})", ctx.matches, duration,);
-            let iteration = self
-                .ruleset_iteration
-                .get::<Symbol>(&"".into())
-                .unwrap_or(&0);
             if duration.as_millis() > 1000 {
                 log::warn!(
-                    "Query took a long time at iter {iteration} : {:?}",
+                    "Query took a long time: {:?}",
                     duration
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1262,7 +1262,7 @@ impl EGraph {
                 self.add_ruleset(name);
                 log::info!("Declared ruleset {name}.");
             }
-            ResolvedNCommand::CombinedRuleset(name, others) => {
+            ResolvedNCommand::UnstableCombinedRuleset(name, others) => {
                 self.add_combined_ruleset(name, others);
                 log::info!("Declared ruleset {name}.");
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1098,13 +1098,13 @@ impl EGraph {
                         Entry::Occupied(_) => panic!("Rule '{name}' was already present"),
                         Entry::Vacant(e) => e.insert(compiled_rule),
                     };
+                    Ok(name)
                 }
-                _ => panic!("Attempted to add a rule to combined ruleset {ruleset}. Combined rulesets may only depend on other rulesets."),
+                Ruleset::Combined(_, _) => Err(Error::CombinedRulesetError(ruleset)),
             }
         } else {
-            panic!("No such ruleset {ruleset}");
+            Err(Error::NoSuchRuleset(ruleset))
         }
-        Ok(name)
     }
 
     pub(crate) fn add_rule(
@@ -1581,6 +1581,10 @@ pub enum Error {
     TypeErrors(Vec<TypeError>),
     #[error("Check failed: \n{}", ListDisplay(.0, "\n"))]
     CheckError(Vec<Fact>),
+    #[error("No such ruleset: {0}")]
+    NoSuchRuleset(Symbol),
+    #[error("Attempted to add a rule to combined ruleset {0}. Combined rulesets may only depend on other rulesets.")]
+    CombinedRulesetError(Symbol),
     #[error("Evaluating primitive {0:?} failed. ({0:?} {:?})", ListDebug(.1, " "))]
     PrimitiveError(Primitive, Vec<Value>),
     #[error("Illegal merge attempted for function {0}, {1:?} != {2:?}")]

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -204,8 +204,8 @@ impl TypeInfo {
                 ResolvedNCommand::SetOption { name: *name, value }
             }
             NCommand::AddRuleset(ruleset) => ResolvedNCommand::AddRuleset(*ruleset),
-            NCommand::CombinedRuleset(name, sub_rulesets) => {
-                ResolvedNCommand::CombinedRuleset(*name, sub_rulesets.clone())
+            NCommand::UnstableCombinedRuleset(name, sub_rulesets) => {
+                ResolvedNCommand::UnstableCombinedRuleset(*name, sub_rulesets.clone())
             }
             NCommand::PrintOverallStatistics => ResolvedNCommand::PrintOverallStatistics,
             NCommand::CheckProof => ResolvedNCommand::CheckProof,

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -204,6 +204,9 @@ impl TypeInfo {
                 ResolvedNCommand::SetOption { name: *name, value }
             }
             NCommand::AddRuleset(ruleset) => ResolvedNCommand::AddRuleset(*ruleset),
+            NCommand::CombinedRuleset(name, sub_rulesets) => {
+                ResolvedNCommand::CombinedRuleset(*name, sub_rulesets.clone())
+            }
             NCommand::PrintOverallStatistics => ResolvedNCommand::PrintOverallStatistics,
             NCommand::CheckProof => ResolvedNCommand::CheckProof,
             NCommand::PrintTable(table, size) => ResolvedNCommand::PrintTable(*table, *size),

--- a/tests/combined-nested.egg
+++ b/tests/combined-nested.egg
@@ -10,7 +10,7 @@
       ((number 2))
       :ruleset myrules2)
 
-(combined-ruleset rules1and2
+(unstable-combined-ruleset rules1and2
     myrules1 myrules2)
 
 ;; allowed to add to myrules2 and the change is reflected
@@ -35,7 +35,7 @@
       ((number 5))
       :ruleset myrules5)
 
-(combined-ruleset rules1and2and5
+(unstable-combined-ruleset rules1and2and5
      rules1and2 myrules5)
 
 (run-schedule

--- a/tests/combined-nested.egg
+++ b/tests/combined-nested.egg
@@ -1,0 +1,48 @@
+(relation number (i64))
+
+
+(ruleset myrules1)
+(rule ()
+      ((number 1))
+      :ruleset myrules1)
+(ruleset myrules2)
+(rule ()
+      ((number 2))
+      :ruleset myrules2)
+
+(combined-ruleset rules1and2
+    myrules1 myrules2)
+
+;; allowed to add to myrules2 and the change is reflected
+(rule ()
+      ((number 3))
+      :ruleset myrules2)
+
+;; not allowed to add to combined ruleset
+(fail
+ (rule ()
+    ((number 4))
+    :ruleset myrules1and2))
+
+
+(fail
+  (rule ()
+    ((number 4))
+    :ruleset unboundruleset))
+
+(ruleset myrules5)
+(rule ()
+      ((number 5))
+      :ruleset myrules5)
+
+(combined-ruleset rules1and2and5
+     rules1and2 myrules5)
+
+(run-schedule
+  rules1and2and5)
+
+(check (number 1))
+(check (number 2))
+(check (number 3))
+(check (number 5))
+(fail (check (number 4)))

--- a/tests/test-combined-steps.egg
+++ b/tests/test-combined-steps.egg
@@ -21,7 +21,7 @@
       ((middle x))
       :ruleset step-middle)
 
-(combined-ruleset
+(unstable-combined-ruleset
   my-combination 
   step-left step-right 
   step-middle)

--- a/tests/test-combined-steps.egg
+++ b/tests/test-combined-steps.egg
@@ -1,0 +1,53 @@
+; Step with alternating feet, left before right
+(relation left (i64))
+(relation right (i64))
+(relation middle (i64))
+
+(left 0)
+(right 0)
+
+(ruleset step-left)
+(rule ((left x) (right x))
+      ((left (+ x 1)))
+      :ruleset step-left)
+
+(ruleset step-right)
+(rule ((left x) (right y) (= x (+ y 1)))
+      ((right x))
+      :ruleset step-right)
+
+(ruleset step-middle)
+(rule ((left x))
+      ((middle x))
+      :ruleset step-middle)
+
+(combined-ruleset
+  my-combination 
+  step-left step-right 
+  step-middle)
+
+(run-schedule (repeat 1 my-combination))
+
+(check (left 1))
+(check (right 0))
+;; middle didn't observe anything except original step
+(check (middle 0))
+(fail (check (left 2)))
+(fail (check (right 1)))
+(fail (check (middle 1)))
+(fail (check (middle 2)))
+
+
+(run-schedule
+      (repeat 9
+            (saturate step-right)
+            my-combination
+            (saturate step-right)))
+
+(check (left 10))
+(check (right 10))
+;; middle didn't get a chance to observe (left 10)
+(check (middle 9))
+(fail (check (middle 10)))
+(fail (check (left 11)))
+(fail (check (right 11)))

--- a/tests/test-combined.egg
+++ b/tests/test-combined.egg
@@ -1,0 +1,33 @@
+(relation edge (i64 i64))
+(relation path (i64 i64))
+
+
+(ruleset myrules1)
+(rule ((edge x y))
+      ((path x y))
+      :ruleset myrules1)
+(ruleset myrules2)
+(rule ((path x y) (edge y z))
+      ((path x z))
+      :ruleset myrules2)
+
+(combined-ruleset myrules-combined
+    myrules1 myrules2)
+
+
+(edge 0 1)
+(edge 1 2)
+(edge 2 3)
+(edge 2 4)
+
+(run-schedule
+  (repeat 3 myrules-combined))
+
+
+(check (path 0 1))
+(check (path 0 2))
+(check (path 0 3))
+(check (path 0 4))
+(check (path 1 2))
+(check (path 1 3))
+(check (path 1 4))

--- a/tests/test-combined.egg
+++ b/tests/test-combined.egg
@@ -11,7 +11,7 @@
       ((path x z))
       :ruleset myrules2)
 
-(combined-ruleset myrules-combined
+(unstable-combined-ruleset myrules-combined
     myrules1 myrules2)
 
 


### PR DESCRIPTION
This PR adds combined rulesets to egglog, allowing rulesets to be collected and run together.
We plan to use this feature in eggcc, since we declare a ruleset per optimization. We want all our optimizations to run together each iteration.

The PR also cleans up the main loop of egglog, breaking it into functions.
Finally, it deletes the backoff scheduler functionality, which nobody uses as far as I can tell.