### PR TITLE
Step through by block for slideshow mode

### DIFF
--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -209,10 +209,12 @@
                 let start = currentIndex;
                 // find next open parenthesis which isn't inside a comment
                 let inComment = false;
+                let newlines = 0;
                 while (currentIndex < content.length) {
                     if (content[currentIndex] == ";") {
                         inComment = true;
                     } else if (content[currentIndex] == "\n") {
+                        if (!inComment) newlines++;
                         inComment = false;
                     } else if (content[currentIndex] == "(" && !inComment) {
                         break;
@@ -233,7 +235,11 @@
 
                 let sexp = content.substring(start, currentIndex + 1);
 
-                contentBySexp.push(sexp);
+                if (newlines > 1 || contentBySexp.length == 0) {
+                    contentBySexp.push(sexp);
+                } else {
+                    contentBySexp[contentBySexp.length - 1] += sexp;
+                }
                 currentIndex = currentIndex + 1;
             }
 

--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -107,7 +107,6 @@
     <script src="//unpkg.com/codemirror@5.65.2/mode/scheme/scheme.js"></script>
     <script src="//unpkg.com/codemirror@5.65.2/addon/edit/matchbrackets.js"></script>
     <script src="//unpkg.com/codemirror@5.65.2/addon/edit/closebrackets.js"></script>
-    <script src="//unpkg.com/codemirror@5.65.2/addon/scroll/scrollpastend.js"></script>
     <script src="https://unpkg.com/@hpcc-js/wasm@2.13.1/dist/graphviz.umd.js" type="javascript/worker"></script>
     <script src="https://cdn.jsdelivr.net/npm/d3@7.8.5"></script>
     <script src="./d3-graphviz.js"></script>
@@ -378,7 +377,6 @@
                 },
                 matchBrackets: true,
                 autoCloseBrackets: true,
-                scrollPastEnd: true
             });
             nextButton = document.getElementById("next");
             prevButton = document.getElementById("prev");

--- a/web-demo/static/index.html
+++ b/web-demo/static/index.html
@@ -107,6 +107,7 @@
     <script src="//unpkg.com/codemirror@5.65.2/mode/scheme/scheme.js"></script>
     <script src="//unpkg.com/codemirror@5.65.2/addon/edit/matchbrackets.js"></script>
     <script src="//unpkg.com/codemirror@5.65.2/addon/edit/closebrackets.js"></script>
+    <script src="//unpkg.com/codemirror@5.65.2/addon/scroll/scrollpastend.js"></script>
     <script src="https://unpkg.com/@hpcc-js/wasm@2.13.1/dist/graphviz.umd.js" type="javascript/worker"></script>
     <script src="https://cdn.jsdelivr.net/npm/d3@7.8.5"></script>
     <script src="./d3-graphviz.js"></script>
@@ -377,6 +378,7 @@
                 },
                 matchBrackets: true,
                 autoCloseBrackets: true,
+                scrollPastEnd: true
             });
             nextButton = document.getElementById("next");
             prevButton = document.getElementById("prev");


### PR DESCRIPTION
Right now the step-throughs in the slideshow mode go command by command, which gets tedious if several commands should be introduced together (e.g., a set of algebraic rules)