### PR TITLE
Change graphviz output to not inline leaves

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1546,9 +1546,7 @@ impl EGraph {
             max_calls_per_function: Some(40),
             ..Default::default()
         };
-        let mut serialized = self.serialize(config);
-        serialized.inline_leaves();
-        serialized
+        self.serialize(config)
     }
 
     pub(crate) fn print_msg(&mut self, msg: String) {


### PR DESCRIPTION
Currently with the graphviz output, all leaves will be inlined. This makes the graph a bit more compact, but end up with a representation that is less true to the source, by adding function calls in single nodes with a `f(*args)` calling convention.

Without the inlining it would resolve this complaint from [a blog post](http://www.chriswarbo.net/blog/2024-02-25-sk_logic_in_egglog_1.html):

> Note: Yes, it’s annoying that the graphical output writes parentheses like E("C"), whilst the actual egglog language uses prefix-style (E "C"). That seems to be a quirk of the rendering; all of the actual code will always use the latter style!

---

Alternatively, we could add an option in the serialization for inling leaves but keeping the format as s-expressions. That could be useful to explore in the future and adding a way to expose in the graphviz rendering the ability to inline leaves (and how many times to inline the leaves). For the moment, having something consistent seems preferable over something succinct, to help with learning/teaching.