### PR TITLE
SVG/dot output limits specified via command line arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1539,11 +1539,13 @@ impl EGraph {
     pub fn serialize_for_graphviz(
         &self,
         split_primitive_outputs: bool,
+        max_functions: usize,
+        max_calls_per_function: usize,
     ) -> egraph_serialize::EGraph {
         let config = SerializeConfig {
             split_primitive_outputs,
-            max_functions: Some(40),
-            max_calls_per_function: Some(40),
+            max_functions: Some(max_functions),
+            max_calls_per_function: Some(max_calls_per_function),
             ..Default::default()
         };
         let mut serialized = self.serialize(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,12 @@ struct Args {
     to_svg: bool,
     #[clap(long)]
     serialize_split_primitive_outputs: bool,
+    /// Maximum number of function nodes to render in dot/svg output
+    #[clap(long, default_value = "40")]
+    max_functions: usize,
+    /// Maximum number of calls per function to render in dot/svg output
+    #[clap(long, default_value = "40")]
+    max_calls_per_function: usize,
 }
 
 #[allow(clippy::disallowed_macros)]
@@ -175,7 +181,11 @@ fn main() {
         }
 
         if args.to_dot || args.to_svg {
-            let serialized = egraph.serialize_for_graphviz(args.serialize_split_primitive_outputs);
+            let serialized = egraph.serialize_for_graphviz(
+                args.serialize_split_primitive_outputs,
+                args.max_functions,
+                args.max_calls_per_function,
+            );
             if args.to_dot {
                 let dot_path = serialize_filename.with_extension("dot");
                 serialized.to_dot_file(dot_path).unwrap()

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -45,9 +45,9 @@ impl Run {
                         log::info!("  {}", msg);
                     }
                     // Test graphviz dot generation
-                    egraph.serialize_for_graphviz(false).to_dot();
+                    egraph.serialize_for_graphviz(false, 40, 40).to_dot();
                     // Also try splitting
-                    egraph.serialize_for_graphviz(true).to_dot();
+                    egraph.serialize_for_graphviz(true, 40, 40).to_dot();
                 }
             }
             Err(err) => {

--- a/web-demo/src/lib.rs
+++ b/web-demo/src/lib.rs
@@ -17,7 +17,7 @@ pub fn run_program(input: &str) -> Result {
     let mut egraph = egglog::EGraph::default();
     match egraph.parse_and_run_program(input) {
         Ok(outputs) => {
-            let serialized = egraph.serialize_for_graphviz(false);
+            let serialized = egraph.serialize_for_graphviz(false, 40, 40);
             Result {
                 text: outputs.join("<br>"),
                 dot: serialized.to_dot(),


### PR DESCRIPTION
Partially addresses #377 by allowing the number of functions/calls per function to be specified via the command line. Preserved current behaviour if user does not specify limits.

Very happy to consider alternative approaches that may be more widely applicable.