### PR TITLE
Add error message for ruleset that DNE.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,7 +938,10 @@ impl EGraph {
         run_report: &mut RunReport,
         search_results: &mut HashMap<Symbol, SearchResult>,
     ) {
-        let rules = self.rulesets.get(&ruleset).unwrap();
+        let rules = self
+            .rulesets
+            .get(&ruleset)
+            .unwrap_or_else(|| panic!("ruleset does not exist: {}", &ruleset));
         match rules {
             Ruleset::Rules(_ruleset_name, rule_names) => {
                 let copy_rules = rule_names.clone();


### PR DESCRIPTION
This PR adds an error message when the ruleset does not exist.

```
// Before
called `Option::unwrap()` on a `None` value 

// After
test panicked: ruleset does not exist: wrongnameruleset
```