### PR TITLE
Fix `extract_variants` by comparing against leader `Value`

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -84,7 +84,7 @@ impl EGraph {
 
                 func.nodes
                     .iter(false)
-                    .filter(|&(_, output)| (output.value == output_value))
+                    .filter(|&(_, output)| (self.find(output.value) == output_value))
                     .map(|(inputs, _output)| {
                         let node = Node { sym, inputs };
                         ext.expr_from_node(&node, termdag).expect(


### PR DESCRIPTION
The missing call to `find` meant that this code wasn't always figuring out when two Values were in the same eclass.