### PR TITLE
Infer types of functions values based on names

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -98,7 +98,7 @@ impl ResolvedCall {
 
         if let Some(primitives) = typeinfo.primitives.get(head) {
             for primitive in primitives {
-                if primitive.accept(types) {
+                if primitive.accept(types, typeinfo) {
                     let (out, inp) = types.split_last().unwrap();
                     resolved_call.push(ResolvedCall::Primitive(SpecializedPrimitive {
                         primitive: primitive.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ pub struct Primitive(Arc<dyn PrimitiveLike>);
 impl Primitive {
     // Takes the full signature of a primitive (including input and output types)
     // Returns whether the primitive is compatible with this signature
-    fn accept(&self, tys: &[Arc<dyn Sort>]) -> bool {
+    fn accept(&self, tys: &[Arc<dyn Sort>], typeinfo: &TypeInfo) -> bool {
         let mut constraints = vec![];
         let lits: Vec<_> = (0..tys.len())
             .map(|i| AtomTerm::Literal(DUMMY_SPAN.clone(), Literal::Int(i as i64)))
@@ -306,7 +306,7 @@ impl Primitive {
         for (lit, ty) in lits.iter().zip(tys.iter()) {
             constraints.push(Constraint::Assign(lit.clone(), ty.clone()))
         }
-        constraints.extend(self.get_type_constraints(&DUMMY_SPAN).get(&lits));
+        constraints.extend(self.get_type_constraints(&DUMMY_SPAN).get(&lits, typeinfo));
         let problem = Problem {
             constraints,
             range: HashSet::default(),

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -490,6 +490,8 @@ pub enum TypeError {
     PrimitiveAlreadyBound(Symbol),
     #[error("Type mismatch: expected {}, actual {}", .0.name(), .1.name())]
     TypeMismatch(ArcSort, ArcSort),
+    #[error("Function type mismatch: expected {} => {}, actual {} => {}", .1.iter().map(|s| s.name().to_string()).collect::<Vec<_>>().join(", "), .0.name(), .3.iter().map(|s| s.name().to_string()).collect::<Vec<_>>().join(", "), .2.name())]
+    FunctionTypeMismatch(ArcSort, Vec<ArcSort>, ArcSort, Vec<ArcSort>),
     #[error("Presort {0} not found.")]
     PresortNotFound(Symbol),
     #[error("Cannot type a variable as unit: {0}")]

--- a/tests/fail-typecheck/unstable-fn-wrong-args-type.egg
+++ b/tests/fail-typecheck/unstable-fn-wrong-args-type.egg
@@ -1,0 +1,8 @@
+;; test that you can't resolve a function with the wrong type of args
+
+(datatype Math
+    (Zero)
+    (Inc Math))
+
+(sort Fn (UnstableFn (i64) Math))
+(unstable-fn "Inc")

--- a/tests/fail-typecheck/unstable-fn-wrong-return-type.egg
+++ b/tests/fail-typecheck/unstable-fn-wrong-return-type.egg
@@ -1,0 +1,8 @@
+;; test that you can't resolve a function with the wrong return type
+
+(datatype Math
+    (Zero)
+    (Inc Math))
+
+(sort Fn (UnstableFn (Math) i64))
+(unstable-fn "Inc")

--- a/tests/unstable-fn.egg
+++ b/tests/unstable-fn.egg
@@ -66,3 +66,5 @@
 
 ;; Verify that function parsing works with a function with no args
 (sort TestNullaryFunction (UnstableFn () Math))
+;; Verify that we know the type of a function based on the string name
+(extract (unstable-fn "square"))


### PR DESCRIPTION
Previously, the type inference for creating function values with `(unstable-fn <name> [<partial arg>]*)` did not use the name. It would only use the context within which the function was created to infer the type of the function.

This works fine if you only have one function sort defined or if always can infer it based on its calling location. However, I was noticing in my usages of `unstable-fn` I would often be passing another function reference as a partial arg. This means it would be hard for the type checker to figure out what type to use for these, so it would just give up and fail.

In this PR, I extend the type inference for functions to use the string name. If it is a literal value that shows up during type checking and we can find it in the function table, we use this to help infer what the types are. We can then narrow down both the partial arg types and also make sure that the output and inputs to the function are the same as those of the `UnstableFn` sort. If not, then we know that this constructor won't match.


The main change I had to do to implement this was to pass the `TypeInfo` into the `accept` method of `TypeConstraint`s, so that we could lookup the function name.

I also had to add a new `ImpossibleConstraint` error for when a function is constructed with a string that doesn't match the function sort.