### PR TITLE
In REPL, evaluates only when parens are closed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1494,6 +1494,8 @@ impl EGraph {
         self.desugar.parse_program(filename, input)
     }
 
+    /// Parse and run a program, returning a list of messages.
+    /// If filename is None, a default name will be provided
     pub fn parse_and_run_program(
         &mut self,
         filename: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,12 +63,12 @@ fn should_eval(curr_cmd: &str) -> bool {
             }
             ';' => {
                 // `any` moves the iterator forward until it finds a match
-                if indices.any(|ch| ch == '\n') {
+                if !indices.any(|ch| ch == '\n') {
                     return false;
                 }
             }
             '"' => {
-                if indices.any(|ch| ch == '"') {
+                if !indices.any(|ch| ch == '"') {
                     return false;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,7 +278,6 @@ mod tests {
             for (i, line) in test.iter().enumerate() {
                 cmd_buffer.push_str(line);
                 cmd_buffer.push('\n');
-                dbg!(i, &cmd_buffer, should_eval(&cmd_buffer));
                 assert_eq!(should_eval(&cmd_buffer), i == test.len() - 1);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ struct Args {
     max_calls_per_function: usize,
 }
 
-// Takes a multi-line string, processes the first command, and returns the rest of the string
+// test if the current command should be evaluated
 fn should_eval(curr_cmd: &str) -> bool {
     let mut count = 0;
     let mut indices = curr_cmd.chars();
@@ -246,6 +246,41 @@ fn main() {
         // no need to drop the egraph if we are going to exit
         if idx == args.inputs.len() - 1 {
             std::mem::forget(egraph)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_eval() {
+        #[rustfmt::skip]
+        let test_cases = vec![
+            vec![
+                "(extract", 
+                "\"1", 
+                ")", 
+                "(", 
+                ")))", 
+                "\"", 
+                ";; )",
+                ")"
+            ],
+            vec![
+                "(extract 1) (extract",
+                "2) (",
+                "extract 3) (extract 4) ;;;; ("
+            ]];
+        for test in test_cases {
+            let mut cmd_buffer = String::new();
+            for (i, line) in test.iter().enumerate() {
+                cmd_buffer.push_str(line);
+                cmd_buffer.push('\n');
+                dbg!(i, &cmd_buffer, should_eval(&cmd_buffer));
+                assert_eq!(should_eval(&cmd_buffer), i == test.len() - 1);
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,53 @@ struct Args {
     max_calls_per_function: usize,
 }
 
+// Takes a multi-line string, processes the first command, and returns the rest of the string
+fn should_eval(curr_cmd: &str) -> bool {
+    let mut count = 0;
+    let mut indices = curr_cmd.chars();
+    while let Some(ch) = indices.next() {
+        match ch {
+            '(' => count += 1,
+            ')' => {
+                count -= 1;
+                // if we have a negative count,
+                // this means excessive closing parenthesis
+                // which we would like to throw an error eagerly
+                if count < 0 {
+                    return true;
+                }
+            }
+            ';' => {
+                // `any` moves the iterator forward until it finds a match
+                if indices.any(|ch| ch == '\n') {
+                    return false;
+                }
+            }
+            '"' => {
+                if indices.any(|ch| ch == '"') {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+    }
+    count <= 0
+}
+
+#[allow(clippy::disallowed_macros)]
+fn run_command_in_scripting(egraph: &mut EGraph, command: &str) {
+    match egraph.parse_and_run_program(None, command) {
+        Ok(msgs) => {
+            for msg in msgs {
+                println!("{msg}");
+            }
+        }
+        Err(err) => {
+            log::error!("{err}");
+        }
+    }
+}
+
 #[allow(clippy::disallowed_macros)]
 fn main() {
     env_logger::Builder::new()
@@ -79,18 +126,19 @@ fn main() {
         log::info!("Welcome to Egglog!");
         let mut egraph = mk_egraph();
 
+        let mut cmd_buffer = String::new();
+
         for line in BufReader::new(stdin).lines() {
             match line {
-                Ok(line_str) => match egraph.parse_and_run_program(None, &line_str) {
-                    Ok(msgs) => {
-                        for msg in msgs {
-                            println!("{msg}");
-                        }
+                Ok(line_str) => {
+                    cmd_buffer.push_str(&line_str);
+                    cmd_buffer.push('\n');
+                    // handles multi-line commands
+                    if should_eval(&cmd_buffer) {
+                        run_command_in_scripting(&mut egraph, &cmd_buffer);
+                        cmd_buffer = String::new();
                     }
-                    Err(err) => {
-                        log::error!("{err}");
-                    }
-                },
+                }
                 Err(err) => {
                     log::error!("{err}");
                     std::process::exit(1)
@@ -102,7 +150,11 @@ fn main() {
             }
         }
 
-        std::process::exit(1)
+        if !cmd_buffer.is_empty() {
+            run_command_in_scripting(&mut egraph, &cmd_buffer)
+        }
+
+        std::process::exit(0)
     }
 
     for (idx, input) in args.inputs.iter().enumerate() {


### PR DESCRIPTION
Currently, the REPL mode evaluates programs line by line, which means `egglog < main.egg` almost certainly won't work because most expressions are multi-lines. Moreover, simply concatenating all lines in the source file (e.g., `tr -d "\n" < main.egg | egglog`) also does not work if the source file contains comments.

This PR fixes this by only evaluating a multi-line block when all the parentheses are closed. So that the program
```
(extract "1
2
3 
)
"
) (extract
";;;""))"
)

```
will only call `parse_and_run_program once` once at the end of the program