### PR TITLE
Move splitting primitives to serialize library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ _scratch.egg
 
 # racket
 scripts/compiled
+tests/*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,8 +333,7 @@ dependencies = [
 [[package]]
 name = "egraph-serialize"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41150f383849cfc16ae6230f592112b3c0a2c0e3ec43eb0b09db037bfcce703"
+source = "git+https://github.com/saulshanabrook/egraph-serialize?rev=1c205fcc6d3426800b828e9264dbadbd4a5ef6e9#1c205fcc6d3426800b828e9264dbadbd4a5ef6e9"
 dependencies = [
  "graphviz-rust",
  "indexmap",
@@ -374,9 +379,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys",
@@ -384,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fixedbitset"
@@ -643,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -774,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.7.8"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -785,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.8"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -795,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.8"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
 dependencies = [
  "pest",
  "pest_meta",
@@ -808,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.8"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
 dependencies = [
  "once_cell",
  "pest",
@@ -844,9 +849,12 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -970,9 +978,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -1126,12 +1134,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
+ "once_cell",
  "rustix",
  "windows-sys",
 ]
@@ -1507,6 +1516,7 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,7 @@ dependencies = [
 [[package]]
 name = "egraph-serialize"
 version = "0.1.0"
-source = "git+https://github.com/saulshanabrook/egraph-serialize?rev=1c205fcc6d3426800b828e9264dbadbd4a5ef6e9#1c205fcc6d3426800b828e9264dbadbd4a5ef6e9"
+source = "git+https://github.com/egraphs-good/egraph-serialize?rev=9ce281291635b0e1e7685b488de67bb5a3fee3db#9ce281291635b0e1e7685b488de67bb5a3fee3db"
 dependencies = [
  "graphviz-rust",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,10 @@ smallvec = "1.11"
 
 generic_symbolic_expressions = "5.0.4"
 
-egraph-serialize = { git = "https://github.com/saulshanabrook/egraph-serialize", rev = "1c205fcc6d3426800b828e9264dbadbd4a5ef6e9", features = ["serde", "graphviz"] }
+egraph-serialize = { git = "https://github.com/egraphs-good/egraph-serialize", rev = "9ce281291635b0e1e7685b488de67bb5a3fee3db", features = [
+  "serde",
+  "graphviz",
+] }
 serde_json = { optional = true, version = "1.0.100", features = [
   "preserve_order",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ smallvec = "1.11"
 
 generic_symbolic_expressions = "5.0.4"
 
-egraph-serialize = { version = "0.1.0", features = ["serde", "graphviz"] }
+egraph-serialize = { git = "https://github.com/saulshanabrook/egraph-serialize", rev = "1c205fcc6d3426800b828e9264dbadbd4a5ef6e9", features = ["serde", "graphviz"] }
 serde_json = { optional = true, version = "1.0.100", features = [
   "preserve_order",
 ] }

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,13 @@ ${DIST_WASM}: ${RUST_SRC}
 
 graphs: $(patsubst %.egg,%.svg,$(filter-out $(wildcard tests/repro-*.egg),$(wildcard tests/*.egg)))
 
+json: $(patsubst %.egg,%.json,$(filter-out $(wildcard tests/repro-*.egg),$(wildcard tests/*.egg)))
+
 %.svg: %.egg
 	cargo run --release -- --to-dot --to-svg  $^
+
+%.json: %.egg
+	cargo run --release -- --to-json $^
 
 rm-graphs:
 	rm -f tests/*.dot tests/*.svg

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ use hashbrown::hash_map::Entry;
 use index::ColumnIndex;
 use instant::{Duration, Instant};
 pub use serialize::SerializeConfig;
+pub use serialize::SerializedNode;
 use sort::*;
 pub use termdag::{Term, TermDag, TermId};
 use thiserror::Error;
@@ -1550,24 +1551,6 @@ impl EGraph {
     /// Gets the overall run report and returns it.
     pub fn get_overall_run_report(&self) -> &RunReport {
         &self.overall_run_report
-    }
-
-    /// Serializes the egraph for export to graphviz.
-    ///
-    /// This will limit the total number of nodes so that visualization does not blow up.
-    pub fn serialize_for_graphviz(
-        &self,
-        split_primitive_outputs: bool,
-        max_functions: usize,
-        max_calls_per_function: usize,
-    ) -> egraph_serialize::EGraph {
-        let config = SerializeConfig {
-            split_primitive_outputs,
-            max_functions: Some(max_functions),
-            max_calls_per_function: Some(max_calls_per_function),
-            ..Default::default()
-        };
-        self.serialize(config)
     }
 
     pub(crate) fn print_msg(&mut self, msg: String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ fn main() {
         if args.to_json || args.to_dot || args.to_svg {
             let mut serialized = egraph.serialize(SerializeConfig::default());
             if args.serialize_split_primitive_outputs {
-                serialized.split_e_classes(|id, _| egraph.from_node_id(id).is_primitive())
+                serialized.split_classes(|id, _| egraph.from_node_id(id).is_primitive())
             }
             for _ in 0..args.serialize_n_inline_leaves {
                 serialized.inline_leaves();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use egglog::{EGraph, Error, RunMode, SerializeConfig, SerializedNode};
+use egglog::{EGraph, Error, RunMode, SerializeConfig};
 use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use egglog::{EGraph, Error, RunMode, SerializeConfig};
+use egglog::{EGraph, Error, RunMode, SerializeConfig, SerializedNode};
 use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 
@@ -43,6 +43,9 @@ struct Args {
     /// Maximum number of calls per function to render in dot/svg output
     #[clap(long, default_value = "40")]
     max_calls_per_function: usize,
+    /// Number of times to inline leaves
+    #[clap(long, default_value = "0")]
+    serialize_n_inline_leaves: usize,
 }
 
 // test if the current command should be evaluated
@@ -209,31 +212,25 @@ fn main() {
                 std::process::exit(1)
             }
         }
-        // if we are splitting primitive outputs, add `-split` to the end of the file name
-        let serialize_filename = if args.serialize_split_primitive_outputs {
-            input.with_file_name(format!(
-                "{}-split",
-                input.file_stem().unwrap().to_str().unwrap()
-            ))
-        } else {
-            input.clone()
-        };
-        if args.to_json {
-            let json_path = serialize_filename.with_extension("json");
-            let config = SerializeConfig {
-                split_primitive_outputs: args.serialize_split_primitive_outputs,
-                ..SerializeConfig::default()
-            };
-            let serialized = egraph.serialize(config);
-            serialized.to_json_file(json_path).unwrap();
-        }
 
-        if args.to_dot || args.to_svg {
-            let serialized = egraph.serialize_for_graphviz(
-                args.serialize_split_primitive_outputs,
-                args.max_functions,
-                args.max_calls_per_function,
-            );
+        if args.to_json || args.to_dot || args.to_svg {
+            let mut serialized = egraph.serialize(SerializeConfig::default());
+            if args.serialize_split_primitive_outputs {
+                serialized.split_e_classes(|id, _| egraph.from_node_id(id).is_primitive())
+            }
+            for _ in 0..args.serialize_n_inline_leaves {
+                serialized.inline_leaves();
+            }
+
+            // if we are splitting primitive outputs, add `-split` to the end of the file name
+            let serialize_filename = if args.serialize_split_primitive_outputs {
+                input.with_file_name(format!(
+                    "{}-split",
+                    input.file_stem().unwrap().to_str().unwrap()
+                ))
+            } else {
+                input.clone()
+            };
             if args.to_dot {
                 let dot_path = serialize_filename.with_extension("dot");
                 serialized.to_dot_file(dot_path).unwrap()
@@ -241,6 +238,10 @@ fn main() {
             if args.to_svg {
                 let svg_path = serialize_filename.with_extension("svg");
                 serialized.to_svg_file(svg_path).unwrap()
+            }
+            if args.to_json {
+                let json_path = serialize_filename.with_extension("json");
+                serialized.to_json_file(json_path).unwrap();
             }
         }
         // no need to drop the egraph if we are going to exit
@@ -259,12 +260,12 @@ mod tests {
         #[rustfmt::skip]
         let test_cases = vec![
             vec![
-                "(extract", 
-                "\"1", 
-                ")", 
-                "(", 
-                ")))", 
-                "\"", 
+                "(extract",
+                "\"1",
+                ")",
+                "(",
+                ")))",
+                "\"",
                 ";; )",
                 ")"
             ],

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,9 +1,8 @@
 use ordered_float::NotNan;
 use std::collections::VecDeque;
+use symbol_table::GlobalSymbol;
 
-use crate::{
-    ast::ResolvedFunctionDecl, function::table::hash_values, util::HashMap, EGraph, Value,
-};
+use crate::{ast::ResolvedFunctionDecl, util::HashMap, EGraph, Value};
 
 pub struct SerializeConfig {
     // Maximumum number of functions to include in the serialized graph, any after this will be discarded
@@ -12,8 +11,6 @@ pub struct SerializeConfig {
     pub max_calls_per_function: Option<usize>,
     // Whether to include temporary functions in the serialized graph
     pub include_temporary_functions: bool,
-    // Whether to split primitive output values into their own e-classes with the function
-    pub split_primitive_outputs: bool,
     // Root eclasses to include in the output
     pub root_eclasses: Vec<Value>,
 }
@@ -25,8 +22,37 @@ impl Default for SerializeConfig {
             max_functions: None,
             max_calls_per_function: None,
             include_temporary_functions: false,
-            split_primitive_outputs: false,
             root_eclasses: vec![],
+        }
+    }
+}
+
+/// A node in the serialized egraph.
+#[derive(PartialEq, Debug, Clone)]
+pub enum SerializedNode {
+    /// A user defined function call.
+    Function {
+        /// The name of the function.
+        name: GlobalSymbol,
+        /// The offset of the index in the table.
+        /// This can be resolved to the output and input values with table.get_index(offset, true).
+        offset: usize,
+    },
+    /// A primitive value.
+    Primitive(Value),
+    /// A dummy node used to represent omitted nodes.
+    Dummy(Value),
+    /// A node that was split into multiple e-classes.
+    Split(Box<SerializedNode>),
+}
+
+impl SerializedNode {
+    /// Returns true if the node is a primitive value.
+    pub fn is_primitive(&self) -> bool {
+        match self {
+            SerializedNode::Primitive(_) => true,
+            SerializedNode::Split(node) => node.is_primitive(),
+            _ => false,
         }
     }
 }
@@ -46,11 +72,9 @@ impl EGraph {
     /// - Functions: Function name + hash of input values
     /// - Args which are eq sorts: Choose one ID from the e-class, distribute roughly evenly.
     /// - Args and outputs values which are primitives: Sort name + hash of value
-    ///   Notes: If `split_primitive_returns` is true, then each output value will be the function node id + `-output`
     ///
-    /// For e-classes:
-    /// - Eq sorts: Use the canonical ID of the e-class
-    /// - Primitives: Use the node ID
+    /// For e-classes IDs:
+    /// - tag and value of canonicalized value
     ///
     /// This is to achieve the following properties:
     /// - Equivalent primitive values will show up once in the e-graph.
@@ -64,22 +88,27 @@ impl EGraph {
             &ResolvedFunctionDecl,
             &[Value],
             &Value,
+            egraph_serialize::ClassId,
             egraph_serialize::NodeId,
         )> = self
             .functions
-            .values()
-            .filter(|function| !function.decl.ignore_viz)
-            .map(|function| {
+            .iter()
+            .filter(|(_, function)| !function.decl.ignore_viz)
+            .map(|(name, function)| {
                 function
                     .nodes
-                    .iter(true)
+                    .iter_range(0..function.nodes.num_offsets(), true)
                     .take(config.max_calls_per_function.unwrap_or(usize::MAX))
-                    .map(|(input, output)| {
+                    .map(|(offset, input, output)| {
                         (
                             &function.decl,
                             input,
                             &output.value,
-                            format!("{}-{}", function.decl.name, hash_values(input)).into(),
+                            self.value_to_class_id(&output.value),
+                            self.to_node_id(SerializedNode::Function {
+                                name: *name,
+                                offset,
+                            }),
                         )
                     })
                     .collect::<Vec<_>>()
@@ -94,34 +123,21 @@ impl EGraph {
         // Note that this is only for e-classes, primitives have e-classes equal to their node ID
         // This is for when we need to find what node ID to use for an edge to an e-class, we can rotate them evenly
         // amoung all possible options.
-        let mut node_ids: NodeIDs = all_calls
-            .iter()
-            .filter_map(|(_decl, _input, output, node_id)| {
+        let mut node_ids: NodeIDs = all_calls.iter().fold(
+            HashMap::default(),
+            |mut acc, (_decl, _input, output, class_id, node_id)| {
                 if self.get_sort_from_value(output).unwrap().is_eq_sort() {
-                    Some((self.value_to_class_id(output), node_id))
-                } else {
-                    None
+                    acc.entry(class_id.clone())
+                        .or_insert_with(VecDeque::new)
+                        .push_back(node_id.clone());
                 }
-            })
-            .fold(HashMap::default(), |mut acc, (canonical_id, node_id)| {
-                acc.entry(canonical_id)
-                    .or_insert_with(VecDeque::new)
-                    .push_back(node_id.clone());
                 acc
-            });
+            },
+        );
 
         let mut egraph = egraph_serialize::EGraph::default();
-        for (decl, input, output, node_id) in all_calls {
-            // If we are splitting primitive outputs, then we will use the function node ID as the e-class for the output, so
-            // that even if two functions have the same primitive output, they will be in different e-classes.
-            let eclass = if config.split_primitive_outputs
-                && !self.get_sort_from_value(output).unwrap().is_eq_sort()
-            {
-                format!("{}-value", node_id.clone()).into()
-            } else {
-                self.value_to_class_id(output)
-            };
-            self.serialize_value(&mut egraph, &mut node_ids, output, &eclass);
+        for (decl, input, output, class_id, node_id) in all_calls {
+            self.serialize_value(&mut egraph, &mut node_ids, output, &class_id);
             let children: Vec<_> = input
                 .iter()
                 .map(|v| {
@@ -132,7 +148,7 @@ impl EGraph {
                 node_id,
                 egraph_serialize::Node {
                     op: decl.name.to_string(),
-                    eclass,
+                    eclass: class_id.clone(),
                     cost: NotNan::new(decl.cost.unwrap_or(1) as f64).unwrap(),
                     children,
                 },
@@ -171,6 +187,51 @@ impl EGraph {
         }
     }
 
+    /// Gets the serialized node ID for the primitive, omitted, or function value.
+    pub fn to_node_id(&self, node: SerializedNode) -> egraph_serialize::NodeId {
+        match node {
+            SerializedNode::Function { name, offset } => {
+                format!("function-{}-{}", offset, name).into()
+            }
+            SerializedNode::Primitive(value) => {
+                format!("primitive-{}", self.value_to_class_id(&value)).into()
+            }
+            SerializedNode::Dummy(value) => {
+                format!("dummy-{}", self.value_to_class_id(&value)).into()
+            }
+            SerializedNode::Split(node) => format!("split-{}", self.to_node_id(*node)).into(),
+        }
+    }
+
+    /// Gets the serialized node for the node ID.
+    pub fn from_node_id(&self, node_id: &egraph_serialize::NodeId) -> SerializedNode {
+        let node_id = node_id.to_string();
+        let (tag, rest) = node_id.split_once('-').unwrap();
+        match tag {
+            "function" => {
+                let (offset, name) = rest.split_once('-').unwrap();
+                SerializedNode::Function {
+                    name: name.into(),
+                    offset: offset.parse().unwrap(),
+                }
+            }
+            "primitive" => {
+                let class_id: egraph_serialize::ClassId = rest.into();
+                SerializedNode::Primitive(self.class_id_to_value(&class_id))
+            }
+            "dummy" => {
+                let class_id: egraph_serialize::ClassId = rest.into();
+                SerializedNode::Dummy(self.class_id_to_value(&class_id))
+            }
+            "split" => {
+                let (_offset, rest) = rest.split_once('-').unwrap();
+                let node_id: egraph_serialize::NodeId = rest.into();
+                SerializedNode::Split(Box::new(self.from_node_id(&node_id)))
+            }
+            _ => std::panic::panic_any(format!("Unknown node ID: {}-{}", tag, rest)),
+        }
+    }
+
     /// Serialize the value and return the eclass and node ID
     /// If this is a primitive value, we will add the node to the data, but if it is an eclass, we will not
     /// When this is called on the output of a node, we only use the e-class to know which e-class its a part of
@@ -187,7 +248,7 @@ impl EGraph {
             let node_ids = node_ids.entry(class_id.clone()).or_insert_with(|| {
                 // If we don't find node IDs for this class, it means that all nodes for it were omitted due to size constraints
                 // In this case, add a dummy node in this class to represent the missing nodes
-                let node_id = egraph_serialize::NodeId::from(format!("{}-dummy", class_id));
+                let node_id = self.to_node_id(SerializedNode::Dummy(*value));
                 egraph.nodes.insert(
                     node_id.clone(),
                     egraph_serialize::Node {
@@ -202,7 +263,7 @@ impl EGraph {
             node_ids.rotate_left(1);
             node_ids.front().unwrap().clone()
         } else {
-            let node_id: egraph_serialize::NodeId = class_id.to_string().into();
+            let node_id = self.to_node_id(SerializedNode::Primitive(*value));
             // Add node for value
             {
                 // Children will be empty unless this is a container sort

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -194,7 +194,6 @@ impl Sort for SetSort {
     fn serialized_name(&self, _value: &Value) -> Symbol {
         "set-of".into()
     }
-
 }
 
 impl IntoSort for ValueSet {

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -190,6 +190,11 @@ impl Sort for SetSort {
         }
         Some((cost, expr))
     }
+
+    fn serialized_name(&self, _value: &Value) -> Symbol {
+        "set-of".into()
+    }
+
 }
 
 impl IntoSort for ValueSet {

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -197,6 +197,10 @@ impl Sort for VecSort {
             Some((cost, Expr::call_no_span("vec-of", elems)))
         }
     }
+
+    fn serialized_name(&self, _value: &Value) -> Symbol {
+        "vec-of".into()
+    }
 }
 
 impl IntoSort for ValueVec {

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -53,9 +53,16 @@ impl Run {
                         log::info!("  {}", msg);
                     }
                     // Test graphviz dot generation
-                    egraph.serialize_for_graphviz(false, 40, 40).to_dot();
-                    // Also try splitting
-                    egraph.serialize_for_graphviz(true, 40, 40).to_dot();
+                    let mut serialized = egraph.serialize(SerializeConfig {
+                        max_functions: Some(40),
+                        max_calls_per_function: Some(40),
+                        ..Default::default()
+                    });
+                    serialized.to_dot();
+                    // Also try splitting and inlining
+                    serialized.split_e_classes(|id, _| egraph.from_node_id(id).is_primitive());
+                    serialized.inline_leaves();
+                    serialized.to_dot();
                 }
             }
             Err(err) => {

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -60,7 +60,7 @@ impl Run {
                     });
                     serialized.to_dot();
                     // Also try splitting and inlining
-                    serialized.split_e_classes(|id, _| egraph.from_node_id(id).is_primitive());
+                    serialized.split_classes(|id, _| egraph.from_node_id(id).is_primitive());
                     serialized.inline_leaves();
                     serialized.to_dot();
                 }

--- a/web-demo/src/lib.rs
+++ b/web-demo/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unused_unit)] // weird clippy bug with wasm-bindgen
+use egglog::SerializeConfig;
 use log::{Level, Log, Metadata, Record};
 use wasm_bindgen::prelude::*;
 use web_sys::console;
@@ -17,7 +18,11 @@ pub fn run_program(input: &str) -> Result {
     let mut egraph = egglog::EGraph::default();
     match egraph.parse_and_run_program(Some("web-demo.egg".into()), input) {
         Ok(outputs) => {
-            let serialized = egraph.serialize_for_graphviz(false, 40, 40);
+            let serialized = egraph.serialize(SerializeConfig {
+                max_functions: Some(40),
+                max_calls_per_function: Some(40),
+                ..Default::default()
+            });
             Result {
                 text: outputs.join("<br>"),
                 dot: serialized.to_dot(),


### PR DESCRIPTION
This PR moves the ability to split primitive nodes into the serialize library from this library and also extends it to support splitting arbitrary nodes. See https://github.com/egraphs-good/egraph-serialize/pull/14 for the upstream PR that corresponds to this one, which includes an example using this new behavior.

By default, this should result in the same behavior as before, but just with the ability to split more e-classes besides just primitive nodes if desired.

In order to move the splitting logic upstream, I exposed a way to check if a serialized node ID is a primitive. In a way, this extends https://github.com/egraphs-good/egglog/pull/396 by also now supporting public deserialization/serialization for serialized node IDs as well as class IDs. This should also be useful if you do extraction externally and then want to convert back to egglog values.