### PR TITLE
Display build info when running egglog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,21 +41,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,15 +161,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "cc"
-version = "1.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
-dependencies = [
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,12 +178,7 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
- "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -265,12 +236,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -531,29 +496,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "im-rc"
@@ -1128,12 +1070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,15 +1396,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.4",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +176,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +195,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "clap"
@@ -227,6 +265,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -303,6 +347,7 @@ checksum = "675e35c02a51bb4d4618cb4885b3839ce6d1787c97b664474d9208d074742e20"
 name = "egglog"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "clap",
  "egraph-serialize",
  "env_logger",
@@ -486,6 +531,29 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "im-rc"
@@ -1060,6 +1128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1460,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ im-rc = "15.1.0"
 
 [build-dependencies]
 lalrpop = "0.20"
+chrono = "0.4"
 
 [dev-dependencies]
 glob = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ im-rc = "15.1.0"
 
 [build-dependencies]
 lalrpop = "0.20"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["now"] }
 
 [dev-dependencies]
 glob = "0.3.1"

--- a/build.rs
+++ b/build.rs
@@ -3,13 +3,13 @@ use std::{env, process::Command};
 #[allow(clippy::disallowed_macros)] // for println!
 fn main() {
     lalrpop::process_root().unwrap();
-    let output = Command::new("git")
+    let git_hash = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
         .output()
-        .unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
+        .map(|output| String::from_utf8(output.stdout).unwrap_or_default())
+        .unwrap_or_default();
     let build_date = chrono::Utc::now().format("%Y-%m-%d");
     let version = env::var("CARGO_PKG_VERSION").unwrap();
-    let full_version = format!("{}_{}_{}", version, build_date, git_hash);
+    let full_version = format!("{}_{}{}", version, build_date, git_hash);
     println!("cargo:rustc-env=FULL_VERSION={}", full_version);
 }

--- a/build.rs
+++ b/build.rs
@@ -3,10 +3,14 @@ use std::{env, process::Command};
 #[allow(clippy::disallowed_macros)] // for println!
 fn main() {
     lalrpop::process_root().unwrap();
-    let git_hash = Command::new("git")
+    let git_hash = Command::new("git2")
         .args(["rev-parse", "--short", "HEAD"])
         .output()
-        .map(|output| String::from_utf8(output.stdout).unwrap_or_default())
+        .map(|output| {
+            String::from_utf8(output.stdout)
+                .map(|s| "_".to_owned() + &s)
+                .unwrap_or_default()
+        })
         .unwrap_or_default();
     let build_date = chrono::Utc::now().format("%Y-%m-%d");
     let version = env::var("CARGO_PKG_VERSION").unwrap();

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ fn main() {
         .output()
         .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
-    let build_date = chrono::Local::now().format("%Y-%m-%d");
+    let build_date = chrono::Utc::now().format("%Y-%m-%d");
     let version = env::var("CARGO_PKG_VERSION").unwrap();
     let full_version = format!("{}_{}_{}", version, build_date, git_hash);
     println!("cargo:rustc-env=FULL_VERSION={}", full_version);

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,10 @@
 use std::{env, process::Command};
 
+#[allow(clippy::disallowed_macros)] // for println!
 fn main() {
     lalrpop::process_root().unwrap();
     let output = Command::new("git")
-        .args(&["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short", "HEAD"])
         .output()
         .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,14 @@
+use std::{env, process::Command};
+
 fn main() {
     lalrpop::process_root().unwrap();
+    let output = Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+        .unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    let build_date = chrono::Local::now().format("%Y-%m-%d");
+    let version = env::var("CARGO_PKG_VERSION").unwrap();
+    let full_version = format!("{}_{}_{}", version, build_date, git_hash);
+    println!("cargo:rustc-env=FULL_VERSION={}", full_version);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
+#[command(version = env!("FULL_VERSION"), about = env!("CARGO_PKG_DESCRIPTION"))]
 struct Args {
     #[clap(short = 'F', long)]
     fact_directory: Option<PathBuf>,
@@ -126,7 +127,7 @@ fn main() {
 
     if args.inputs.is_empty() {
         let stdin = io::stdin();
-        log::info!("Welcome to Egglog!");
+        log::info!("Welcome to Egglog! (build: {})", env!("FULL_VERSION"));
         let mut egraph = mk_egraph();
 
         let mut cmd_buffer = String::new();


### PR DESCRIPTION
This is useful when you install egglog to the system via `cargo install --path .` and later want to find out what the exact version you installed is.

After this PR:
```
> cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/egglog`
[INFO ] Welcome to Egglog! (build: 0.2.0_2024-09-25_5bf9dee)
```

and

```
> cargo run -- --version
    Finished dev [unoptimized + debuginfo] target(s) in 0.22s
     Running `target/debug/egglog --version`
egglog 0.2.0_2024-09-25_5bf9dee
```