### PR TITLE
Remove useless type_info getters

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -362,7 +362,7 @@ impl EGraph {
                         let (cost, term) = self.extract(
                             values[0],
                             &mut termdag,
-                            self.type_info().sorts.get(&values[0].tag).unwrap(),
+                            self.type_info.sorts.get(&values[0].tag).unwrap(),
                         );
                         let extracted = termdag.to_string(&term);
                         log::info!("extracted with cost {cost}: {extracted}");

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -86,7 +86,7 @@ impl Function {
     pub(crate) fn new(egraph: &EGraph, decl: &ResolvedFunctionDecl) -> Result<Self, Error> {
         let mut input = Vec::with_capacity(decl.schema.input.len());
         for s in &decl.schema.input {
-            input.push(match egraph.type_info().sorts.get(s) {
+            input.push(match egraph.type_info.sorts.get(s) {
                 Some(sort) => sort.clone(),
                 None => {
                     return Err(Error::TypeError(TypeError::UndefinedSort(
@@ -97,7 +97,7 @@ impl Function {
             })
         }
 
-        let output = match egraph.type_info().sorts.get(&decl.schema.output) {
+        let output = match egraph.type_info.sorts.get(&decl.schema.output) {
             Some(sort) => sort.clone(),
             None => {
                 return Err(Error::TypeError(TypeError::UndefinedSort(
@@ -123,11 +123,11 @@ impl Function {
         // Invariant: the last element in the stack is the return value.
         let merge_vals = if let Some(merge_expr) = &decl.merge {
             let (actions, mapped_expr) = merge_expr.to_core_actions(
-                egraph.type_info(),
+                &egraph.type_info,
                 &mut binding.clone(),
                 &mut ResolvedGen::new("$".to_string()),
             )?;
-            let target = mapped_expr.get_corresponding_var_or_lit(egraph.type_info());
+            let target = mapped_expr.get_corresponding_var_or_lit(&egraph.type_info);
             let program = egraph
                 .compile_expr(&binding, &actions, &target)
                 .map_err(Error::TypeErrors)?;
@@ -142,7 +142,7 @@ impl Function {
             None
         } else {
             let (merge_action, _) = decl.merge_action.to_core_actions(
-                egraph.type_info(),
+                &egraph.type_info,
                 &mut binding.clone(),
                 &mut ResolvedGen::new("$".to_string()),
             )?;

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -389,7 +389,7 @@ impl PrimitiveLike for Apply {
 /// so that we can re-use the logic for primitive and regular functions.
 fn call_fn(egraph: &mut EGraph, name: &Symbol, types: Vec<ArcSort>, args: Vec<Value>) -> Value {
     // Make a call with temp vars as each of the args
-    let resolved_call = ResolvedCall::from_resolution(name, types.as_slice(), egraph.type_info());
+    let resolved_call = ResolvedCall::from_resolution(name, types.as_slice(), &egraph.type_info);
     let arg_vars: Vec<_> = types
         .into_iter()
         // Skip last sort which is the output sort
@@ -410,12 +410,12 @@ fn call_fn(egraph: &mut EGraph, name: &Symbol, types: Vec<ArcSort>, args: Vec<Va
     // Similar to how the merge function is created in `Function::new`
     let (actions, mapped_expr) = expr
         .to_core_actions(
-            egraph.type_info(),
+            &egraph.type_info,
             &mut binding.clone(),
             &mut ResolvedGen::new("$".to_string()),
         )
         .unwrap();
-    let target = mapped_expr.get_corresponding_var_or_lit(egraph.type_info());
+    let target = mapped_expr.get_corresponding_var_or_lit(&egraph.type_info);
     let program = egraph.compile_expr(&binding, &actions, &target).unwrap();
     // Similar to how the `MergeFn::Expr` case is handled in `Egraph::perform_set`
     // egraph.rebuild().unwrap();


### PR DESCRIPTION
This PR removes the `type_info` and `type_info_mut` from the `EGraph` struct, since having a mutable getter that doesn't do anything else doesn't make sense.

Happy to close this PR if there is a reason for these functions, but only if that reason is documented.