### PR TITLE
Remove HIGH_COST

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,8 +292,6 @@ impl RunReport {
     }
 }
 
-pub const HIGH_COST: usize = i64::MAX as usize;
-
 #[derive(Clone)]
 pub struct Primitive(Arc<dyn PrimitiveLike>);
 impl Primitive {


### PR DESCRIPTION
This PR removes `HIGH_COST` for a few reasons:

1. It's unused.
2. It's buggy. On 32-bit systems (such as WASM?) `i64::MAX` will overflow.
3. It's undocumented, so I don't believe it's used outside of this crate. If it is used outside of this crate, I'll edit the PR to use `isize` instead of `i64` to fix the bug, and add documentation.