### PR TITLE
Static parser

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -14,6 +14,21 @@ lalrpop_mod!(
     "/ast/parse.rs"
 );
 
+lazy_static! {
+    static ref PARSER: parse::ProgramParser = Default::default();
+}
+
+pub fn parse_program(filename: Option<String>, input: &str) -> Result<Vec<Command>, Error> {
+    let filename = filename.unwrap_or_else(|| DEFAULT_FILENAME.to_string());
+    let srcfile = Arc::new(SrcFile {
+        name: filename,
+        contents: Some(input.to_string()),
+    });
+    Ok(PARSER
+        .parse(&srcfile, input)
+        .map_err(|e| e.map_token(|tok| tok.to_string()))?)
+}
+
 use crate::{
     core::{GenericAtom, GenericAtomTerm, HeadOrEq, Query, ResolvedCall},
     *,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -14,10 +14,13 @@ lalrpop_mod!(
     "/ast/parse.rs"
 );
 
+// For some reason the parser is slow to construct so
+// we make it static and only construct it once.
 lazy_static! {
     static ref PARSER: parse::ProgramParser = Default::default();
 }
 
+/// Parse a file into a program.
 pub fn parse_program(filename: Option<String>, input: &str) -> Result<Vec<Command>, Error> {
     let filename = filename.unwrap_or_else(|| DEFAULT_FILENAME.to_string());
     let srcfile = Arc::new(SrcFile {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1458,14 +1458,6 @@ impl EGraph {
         Ok(self.flush_msgs())
     }
 
-    pub fn parse_program(
-        &self,
-        filename: Option<String>,
-        input: &str,
-    ) -> Result<Vec<Command>, Error> {
-        self.desugar.parse_program(filename, input)
-    }
-
     /// Takes a source program `input`, parses it, runs it, and returns a list of messages.
     ///
     /// `filename` is an optional argument to indicate the source of
@@ -1476,7 +1468,7 @@ impl EGraph {
         filename: Option<String>,
         input: &str,
     ) -> Result<Vec<String>, Error> {
-        let parsed = self.desugar.parse_program(filename, input)?;
+        let parsed = parse_program(filename, input)?;
         self.run_program(parsed)
     }
 


### PR DESCRIPTION
This PR moves the `ProgramParser` struct out of `Desugar` and into a `lazy_static` block. This has a couple of benefits.

1. Separation of concerns
2. We won't clone the parser (which is apparently slow) when we `push`