### PR TITLE
SymbolGen cleanup

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -471,11 +471,11 @@ impl Problem<AtomTerm, ArcSort> {
         &mut self,
         actions: &GenericCoreActions<Symbol, Symbol>,
         typeinfo: &TypeInfo,
+        symbol_gen: &mut SymbolGen,
     ) -> Result<(), TypeError> {
-        let mut symbol_gen = SymbolGen::new("$".to_string());
         for action in actions.0.iter() {
             self.constraints
-                .extend(action.get_constraints(typeinfo, &mut symbol_gen)?);
+                .extend(action.get_constraints(typeinfo, symbol_gen)?);
 
             // bound vars are added to range
             match action {
@@ -495,6 +495,7 @@ impl Problem<AtomTerm, ArcSort> {
         &mut self,
         rule: &CoreRule,
         typeinfo: &TypeInfo,
+        symbol_gen: &mut SymbolGen,
     ) -> Result<(), TypeError> {
         let CoreRule {
             span: _,
@@ -502,7 +503,7 @@ impl Problem<AtomTerm, ArcSort> {
             body,
         } = rule;
         self.add_query(body, typeinfo)?;
-        self.add_actions(head, typeinfo)?;
+        self.add_actions(head, typeinfo, symbol_gen)?;
         Ok(())
     }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -796,7 +796,7 @@ where
     pub(crate) fn to_core_rule(
         &self,
         typeinfo: &TypeInfo,
-        mut fresh_gen: impl FreshGen<Head, Leaf>,
+        fresh_gen: &mut impl FreshGen<Head, Leaf>,
     ) -> Result<GenericCoreRule<HeadOrEq<Head>, Head, Leaf>, TypeError>
     where
         Leaf: SymbolLike,
@@ -807,10 +807,9 @@ where
             body,
         } = self;
 
-        let (body, _correspondence) = Facts(body.clone()).to_query(typeinfo, &mut fresh_gen);
+        let (body, _correspondence) = Facts(body.clone()).to_query(typeinfo, fresh_gen);
         let mut binding = body.get_vars();
-        let (head, _correspondence) =
-            head.to_core_actions(typeinfo, &mut binding, &mut fresh_gen)?;
+        let (head, _correspondence) = head.to_core_actions(typeinfo, &mut binding, fresh_gen)?;
         Ok(GenericCoreRule {
             span: self.span.clone(),
             body,
@@ -821,7 +820,7 @@ where
     fn to_canonicalized_core_rule_impl(
         &self,
         typeinfo: &TypeInfo,
-        fresh_gen: impl FreshGen<Head, Leaf>,
+        fresh_gen: &mut impl FreshGen<Head, Leaf>,
         value_eq: impl Fn(&GenericAtomTerm<Leaf>, &GenericAtomTerm<Leaf>) -> Head,
     ) -> Result<GenericCoreRule<Head, Head, Leaf>, TypeError>
     where
@@ -836,19 +835,16 @@ impl ResolvedRule {
     pub(crate) fn to_canonicalized_core_rule(
         &self,
         typeinfo: &TypeInfo,
+        fresh_gen: &mut SymbolGen,
     ) -> Result<ResolvedCoreRule, TypeError> {
         let value_eq = &typeinfo.primitives.get(&Symbol::from("value-eq")).unwrap()[0];
         let unit = typeinfo.get_sort_nofail::<UnitSort>();
-        self.to_canonicalized_core_rule_impl(
-            typeinfo,
-            SymbolGen::new("$".to_string()),
-            |at1, at2| {
-                ResolvedCall::Primitive(SpecializedPrimitive {
-                    primitive: value_eq.clone(),
-                    input: vec![at1.output(typeinfo), at2.output(typeinfo)],
-                    output: unit.clone(),
-                })
-            },
-        )
+        self.to_canonicalized_core_rule_impl(typeinfo, fresh_gen, |at1, at2| {
+            ResolvedCall::Primitive(SpecializedPrimitive {
+                primitive: value_eq.clone(),
+                input: vec![at1.output(typeinfo), at2.output(typeinfo)],
+                output: unit.clone(),
+            })
+        })
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -841,7 +841,7 @@ impl ResolvedRule {
         let unit = typeinfo.get_sort_nofail::<UnitSort>();
         self.to_canonicalized_core_rule_impl(
             typeinfo,
-            ResolvedGen::new("$".to_string()),
+            SymbolGen::new("$".to_string()),
             |at1, at2| {
                 ResolvedCall::Primitive(SpecializedPrimitive {
                     primitive: value_eq.clone(),

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -83,7 +83,7 @@ impl Debug for Function {
 pub(crate) type DeferredMerge = (ValueVec, Value, Value);
 
 impl Function {
-    pub(crate) fn new(egraph: &EGraph, decl: &ResolvedFunctionDecl) -> Result<Self, Error> {
+    pub(crate) fn new(egraph: &mut EGraph, decl: &ResolvedFunctionDecl) -> Result<Self, Error> {
         let mut input = Vec::with_capacity(decl.schema.input.len());
         for s in &decl.schema.input {
             input.push(match egraph.type_info.sorts.get(s) {
@@ -125,7 +125,7 @@ impl Function {
             let (actions, mapped_expr) = merge_expr.to_core_actions(
                 &egraph.type_info,
                 &mut binding.clone(),
-                &mut SymbolGen::new("$".to_string()),
+                &mut egraph.symbol_gen,
             )?;
             let target = mapped_expr.get_corresponding_var_or_lit(&egraph.type_info);
             let program = egraph
@@ -144,7 +144,7 @@ impl Function {
             let (merge_action, _) = decl.merge_action.to_core_actions(
                 &egraph.type_info,
                 &mut binding.clone(),
-                &mut SymbolGen::new("$".to_string()),
+                &mut egraph.symbol_gen,
             )?;
             let program = egraph
                 .compile_actions(&binding, &merge_action)

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -125,7 +125,7 @@ impl Function {
             let (actions, mapped_expr) = merge_expr.to_core_actions(
                 &egraph.type_info,
                 &mut binding.clone(),
-                &mut ResolvedGen::new("$".to_string()),
+                &mut SymbolGen::new("$".to_string()),
             )?;
             let target = mapped_expr.get_corresponding_var_or_lit(&egraph.type_info);
             let program = egraph
@@ -144,7 +144,7 @@ impl Function {
             let (merge_action, _) = decl.merge_action.to_core_actions(
                 &egraph.type_info,
                 &mut binding.clone(),
-                &mut ResolvedGen::new("$".to_string()),
+                &mut SymbolGen::new("$".to_string()),
             )?;
             let program = egraph
                 .compile_actions(&binding, &merge_action)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1083,7 +1083,7 @@ impl EGraph {
         let (actions, _) = actions.to_core_actions(
             &self.type_info,
             &mut Default::default(),
-            &mut ResolvedGen::new("$".to_string()),
+            &mut SymbolGen::new("$".to_string()),
         )?;
         let program = self
             .compile_actions(&Default::default(), &actions)
@@ -1110,7 +1110,7 @@ impl EGraph {
         let (actions, mapped_expr) = expr.to_core_actions(
             &self.type_info,
             &mut Default::default(),
-            &mut ResolvedGen::new("$".to_string()),
+            &mut SymbolGen::new("$".to_string()),
         )?;
         let target = mapped_expr.get_corresponding_var_or_lit(&self.type_info);
         let program = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,7 @@ impl FromStr for RunMode {
 
 #[derive(Clone)]
 pub struct EGraph {
+    symbol_gen: SymbolGen,
     egraphs: Vec<Self>,
     unionfind: UnionFind,
     pub(crate) desugar: Desugar,
@@ -447,6 +448,7 @@ pub struct EGraph {
 impl Default for EGraph {
     fn default() -> Self {
         let mut egraph = Self {
+            symbol_gen: SymbolGen::new("$".to_string()),
             egraphs: vec![],
             unionfind: Default::default(),
             functions: Default::default(),
@@ -1042,7 +1044,7 @@ impl EGraph {
         ruleset: Symbol,
     ) -> Result<Symbol, Error> {
         let name = Symbol::from(name);
-        let core_rule = rule.to_canonicalized_core_rule(&self.type_info)?;
+        let core_rule = rule.to_canonicalized_core_rule(&self.type_info, &mut self.symbol_gen)?;
         let (query, actions) = (core_rule.body, core_rule.head);
 
         let vars = query.get_vars();
@@ -1083,7 +1085,7 @@ impl EGraph {
         let (actions, _) = actions.to_core_actions(
             &self.type_info,
             &mut Default::default(),
-            &mut SymbolGen::new("$".to_string()),
+            &mut self.symbol_gen,
         )?;
         let program = self
             .compile_actions(&Default::default(), &actions)
@@ -1094,7 +1096,7 @@ impl EGraph {
     }
 
     pub fn eval_expr(&mut self, expr: &Expr) -> Result<(ArcSort, Value), Error> {
-        let fresh_name = self.desugar.get_fresh();
+        let fresh_name = self.desugar.get_fresh(&mut self.symbol_gen);
         let command = Command::Action(Action::Let(DUMMY_SPAN.clone(), fresh_name, expr.clone()));
         self.run_program(vec![command])?;
         // find the table with the same name as the fresh name
@@ -1110,7 +1112,7 @@ impl EGraph {
         let (actions, mapped_expr) = expr.to_core_actions(
             &self.type_info,
             &mut Default::default(),
-            &mut SymbolGen::new("$".to_string()),
+            &mut self.symbol_gen,
         )?;
         let target = mapped_expr.get_corresponding_var_or_lit(&self.type_info);
         let program = self
@@ -1154,7 +1156,7 @@ impl EGraph {
             head: ResolvedActions::default(),
             body: facts.to_vec(),
         };
-        let core_rule = rule.to_canonicalized_core_rule(&self.type_info)?;
+        let core_rule = rule.to_canonicalized_core_rule(&self.type_info, &mut self.symbol_gen)?;
         let query = core_rule.body;
         let ordering = &query.get_vars();
         let query = self.compile_gj_query(query, ordering);
@@ -1382,7 +1384,9 @@ impl EGraph {
             .into_iter()
             .map(NCommand::CoreAction)
             .collect::<Vec<_>>();
-        let commands: Vec<_> = self.type_info.typecheck_program(&commands)?;
+        let commands: Vec<_> = self
+            .type_info
+            .typecheck_program(&mut self.symbol_gen, &commands)?;
         for command in commands {
             self.run_command(command)?;
         }
@@ -1398,20 +1402,22 @@ impl EGraph {
 
     pub fn set_reserved_symbol(&mut self, sym: Symbol) {
         assert!(
-            !self.desugar.fresh_gen.has_been_used(),
+            !self.symbol_gen.has_been_used(),
             "Reserved symbol must be set before any symbols are generated"
         );
-        self.desugar.fresh_gen = SymbolGen::new(sym.to_string());
+        self.symbol_gen = SymbolGen::new(sym.to_string());
     }
 
     fn process_command(&mut self, command: Command) -> Result<Vec<ResolvedNCommand>, Error> {
+        let program =
+            self.desugar
+                .desugar_program(vec![command], &mut self.symbol_gen, self.seminaive)?;
+
         let program = self
-            .desugar
-            .desugar_program(vec![command], self.seminaive)?;
+            .type_info
+            .typecheck_program(&mut self.symbol_gen, &program)?;
 
-        let program = self.type_info.typecheck_program(&program)?;
-
-        let program = remove_globals(&self.type_info, program, &mut self.desugar.fresh_gen);
+        let program = remove_globals(&self.type_info, program, &mut self.symbol_gen);
 
         Ok(program)
     }

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -412,7 +412,7 @@ fn call_fn(egraph: &mut EGraph, name: &Symbol, types: Vec<ArcSort>, args: Vec<Va
         .to_core_actions(
             &egraph.type_info,
             &mut binding.clone(),
-            &mut ResolvedGen::new("$".to_string()),
+            &mut SymbolGen::new("$".to_string()),
         )
         .unwrap();
     let target = mapped_expr.get_corresponding_var_or_lit(&egraph.type_info);

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -412,7 +412,7 @@ fn call_fn(egraph: &mut EGraph, name: &Symbol, types: Vec<ArcSort>, args: Vec<Va
         .to_core_actions(
             &egraph.type_info,
             &mut binding.clone(),
-            &mut SymbolGen::new("$".to_string()),
+            &mut egraph.symbol_gen,
         )
         .unwrap();
     let target = mapped_expr.get_corresponding_var_or_lit(&egraph.type_info);

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -122,11 +122,12 @@ impl TypeInfo {
 
     pub(crate) fn typecheck_program(
         &mut self,
+        symbol_gen: &mut SymbolGen,
         program: &Vec<NCommand>,
     ) -> Result<Vec<ResolvedNCommand>, TypeError> {
         let mut result = vec![];
         for command in program {
-            result.push(self.typecheck_command(command)?);
+            result.push(self.typecheck_command(symbol_gen, command)?);
         }
 
         Ok(result)
@@ -163,90 +164,97 @@ impl TypeInfo {
         })
     }
 
-    fn typecheck_command(&mut self, command: &NCommand) -> Result<ResolvedNCommand, TypeError> {
-        let command: ResolvedNCommand = match command {
-            NCommand::Function(fdecl) => {
-                ResolvedNCommand::Function(self.typecheck_function(fdecl)?)
-            }
-            NCommand::NormRule {
-                rule,
-                ruleset,
-                name,
-            } => ResolvedNCommand::NormRule {
-                rule: self.typecheck_rule(rule)?,
-                ruleset: *ruleset,
-                name: *name,
-            },
-            NCommand::Sort(span, sort, presort_and_args) => {
-                // Note this is bad since typechecking should be pure and idempotent
-                // Otherwise typechecking the same program twice will fail
-                self.declare_sort(*sort, presort_and_args, span.clone())?;
-                ResolvedNCommand::Sort(span.clone(), *sort, presort_and_args.clone())
-            }
-            NCommand::CoreAction(Action::Let(span, var, expr)) => {
-                let expr = self.typecheck_expr(expr, &Default::default())?;
-                let output_type = expr.output_type(self);
-                self.global_types.insert(*var, output_type.clone());
-                let var = ResolvedVar {
-                    name: *var,
-                    sort: output_type,
-                    // not a global reference, but a global binding
-                    is_global_ref: false,
-                };
-                ResolvedNCommand::CoreAction(ResolvedAction::Let(span.clone(), var, expr))
-            }
-            NCommand::CoreAction(action) => {
-                ResolvedNCommand::CoreAction(self.typecheck_action(action, &Default::default())?)
-            }
-            NCommand::Check(span, facts) => {
-                ResolvedNCommand::Check(span.clone(), self.typecheck_facts(facts)?)
-            }
-            NCommand::Fail(span, cmd) => {
-                ResolvedNCommand::Fail(span.clone(), Box::new(self.typecheck_command(cmd)?))
-            }
-            NCommand::RunSchedule(schedule) => {
-                ResolvedNCommand::RunSchedule(self.typecheck_schedule(schedule)?)
-            }
-            NCommand::Pop(span, n) => ResolvedNCommand::Pop(span.clone(), *n),
-            NCommand::Push(n) => ResolvedNCommand::Push(*n),
-            NCommand::SetOption { name, value } => {
-                let value = self.typecheck_expr(value, &Default::default())?;
-                ResolvedNCommand::SetOption { name: *name, value }
-            }
-            NCommand::AddRuleset(ruleset) => ResolvedNCommand::AddRuleset(*ruleset),
-            NCommand::UnstableCombinedRuleset(name, sub_rulesets) => {
-                ResolvedNCommand::UnstableCombinedRuleset(*name, sub_rulesets.clone())
-            }
-            NCommand::PrintOverallStatistics => ResolvedNCommand::PrintOverallStatistics,
-            NCommand::PrintTable(span, table, size) => {
-                ResolvedNCommand::PrintTable(span.clone(), *table, *size)
-            }
-            NCommand::PrintSize(span, n) => {
-                // Should probably also resolve the function symbol here
-                ResolvedNCommand::PrintSize(span.clone(), *n)
-            }
-            NCommand::Output { span, file, exprs } => {
-                let exprs = exprs
-                    .iter()
-                    .map(|expr| self.typecheck_expr(expr, &Default::default()))
-                    .collect::<Result<Vec<_>, _>>()?;
-                ResolvedNCommand::Output {
-                    span: span.clone(),
-                    file: file.clone(),
-                    exprs,
+    fn typecheck_command(
+        &mut self,
+        symbol_gen: &mut SymbolGen,
+        command: &NCommand,
+    ) -> Result<ResolvedNCommand, TypeError> {
+        let command: ResolvedNCommand =
+            match command {
+                NCommand::Function(fdecl) => {
+                    ResolvedNCommand::Function(self.typecheck_function(symbol_gen, fdecl)?)
                 }
-            }
-            NCommand::Input { span, name, file } => ResolvedNCommand::Input {
-                span: span.clone(),
-                name: *name,
-                file: file.clone(),
-            },
-        };
+                NCommand::NormRule {
+                    rule,
+                    ruleset,
+                    name,
+                } => ResolvedNCommand::NormRule {
+                    rule: self.typecheck_rule(symbol_gen, rule)?,
+                    ruleset: *ruleset,
+                    name: *name,
+                },
+                NCommand::Sort(span, sort, presort_and_args) => {
+                    // Note this is bad since typechecking should be pure and idempotent
+                    // Otherwise typechecking the same program twice will fail
+                    self.declare_sort(*sort, presort_and_args, span.clone())?;
+                    ResolvedNCommand::Sort(span.clone(), *sort, presort_and_args.clone())
+                }
+                NCommand::CoreAction(Action::Let(span, var, expr)) => {
+                    let expr = self.typecheck_expr(symbol_gen, expr, &Default::default())?;
+                    let output_type = expr.output_type(self);
+                    self.global_types.insert(*var, output_type.clone());
+                    let var = ResolvedVar {
+                        name: *var,
+                        sort: output_type,
+                        // not a global reference, but a global binding
+                        is_global_ref: false,
+                    };
+                    ResolvedNCommand::CoreAction(ResolvedAction::Let(span.clone(), var, expr))
+                }
+                NCommand::CoreAction(action) => ResolvedNCommand::CoreAction(
+                    self.typecheck_action(symbol_gen, action, &Default::default())?,
+                ),
+                NCommand::Check(span, facts) => {
+                    ResolvedNCommand::Check(span.clone(), self.typecheck_facts(symbol_gen, facts)?)
+                }
+                NCommand::Fail(span, cmd) => ResolvedNCommand::Fail(
+                    span.clone(),
+                    Box::new(self.typecheck_command(symbol_gen, cmd)?),
+                ),
+                NCommand::RunSchedule(schedule) => {
+                    ResolvedNCommand::RunSchedule(self.typecheck_schedule(symbol_gen, schedule)?)
+                }
+                NCommand::Pop(span, n) => ResolvedNCommand::Pop(span.clone(), *n),
+                NCommand::Push(n) => ResolvedNCommand::Push(*n),
+                NCommand::SetOption { name, value } => {
+                    let value = self.typecheck_expr(symbol_gen, value, &Default::default())?;
+                    ResolvedNCommand::SetOption { name: *name, value }
+                }
+                NCommand::AddRuleset(ruleset) => ResolvedNCommand::AddRuleset(*ruleset),
+                NCommand::UnstableCombinedRuleset(name, sub_rulesets) => {
+                    ResolvedNCommand::UnstableCombinedRuleset(*name, sub_rulesets.clone())
+                }
+                NCommand::PrintOverallStatistics => ResolvedNCommand::PrintOverallStatistics,
+                NCommand::PrintTable(span, table, size) => {
+                    ResolvedNCommand::PrintTable(span.clone(), *table, *size)
+                }
+                NCommand::PrintSize(span, n) => {
+                    // Should probably also resolve the function symbol here
+                    ResolvedNCommand::PrintSize(span.clone(), *n)
+                }
+                NCommand::Output { span, file, exprs } => {
+                    let exprs = exprs
+                        .iter()
+                        .map(|expr| self.typecheck_expr(symbol_gen, expr, &Default::default()))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    ResolvedNCommand::Output {
+                        span: span.clone(),
+                        file: file.clone(),
+                        exprs,
+                    }
+                }
+                NCommand::Input { span, name, file } => ResolvedNCommand::Input {
+                    span: span.clone(),
+                    name: *name,
+                    file: file.clone(),
+                },
+            };
         Ok(command)
     }
 
     fn typecheck_function(
         &mut self,
+        symbol_gen: &mut SymbolGen,
         fdecl: &FunctionDecl,
     ) -> Result<ResolvedFunctionDecl, TypeError> {
         if self.sorts.contains_key(&fdecl.name) {
@@ -274,15 +282,15 @@ impl TypeInfo {
             name: fdecl.name,
             schema: fdecl.schema.clone(),
             merge: match &fdecl.merge {
-                Some(merge) => Some(self.typecheck_expr(merge, &bound_vars)?),
+                Some(merge) => Some(self.typecheck_expr(symbol_gen, merge, &bound_vars)?),
                 None => None,
             },
             default: fdecl
                 .default
                 .as_ref()
-                .map(|default| self.typecheck_expr(default, &Default::default()))
+                .map(|default| self.typecheck_expr(symbol_gen, default, &Default::default()))
                 .transpose()?,
-            merge_action: self.typecheck_actions(&fdecl.merge_action, &bound_vars)?,
+            merge_action: self.typecheck_actions(symbol_gen, &fdecl.merge_action, &bound_vars)?,
             cost: fdecl.cost,
             unextractable: fdecl.unextractable,
             ignore_viz: fdecl.ignore_viz,
@@ -290,28 +298,32 @@ impl TypeInfo {
         })
     }
 
-    fn typecheck_schedule(&self, schedule: &Schedule) -> Result<ResolvedSchedule, TypeError> {
+    fn typecheck_schedule(
+        &self,
+        symbol_gen: &mut SymbolGen,
+        schedule: &Schedule,
+    ) -> Result<ResolvedSchedule, TypeError> {
         let schedule = match schedule {
             Schedule::Repeat(span, times, schedule) => ResolvedSchedule::Repeat(
                 span.clone(),
                 *times,
-                Box::new(self.typecheck_schedule(schedule)?),
+                Box::new(self.typecheck_schedule(symbol_gen, schedule)?),
             ),
             Schedule::Sequence(span, schedules) => {
                 let schedules = schedules
                     .iter()
-                    .map(|schedule| self.typecheck_schedule(schedule))
+                    .map(|schedule| self.typecheck_schedule(symbol_gen, schedule))
                     .collect::<Result<Vec<_>, _>>()?;
                 ResolvedSchedule::Sequence(span.clone(), schedules)
             }
             Schedule::Saturate(span, schedule) => ResolvedSchedule::Saturate(
                 span.clone(),
-                Box::new(self.typecheck_schedule(schedule)?),
+                Box::new(self.typecheck_schedule(symbol_gen, schedule)?),
             ),
             Schedule::Run(span, RunConfig { ruleset, until }) => {
                 let until = until
                     .as_ref()
-                    .map(|facts| self.typecheck_facts(facts))
+                    .map(|facts| self.typecheck_facts(symbol_gen, facts))
                     .transpose()?;
                 ResolvedSchedule::Run(
                     span.clone(),
@@ -350,16 +362,19 @@ impl TypeInfo {
         self.add_arcsort(sort, span)
     }
 
-    fn typecheck_rule(&self, rule: &Rule) -> Result<ResolvedRule, TypeError> {
+    fn typecheck_rule(
+        &self,
+        symbol_gen: &mut SymbolGen,
+        rule: &Rule,
+    ) -> Result<ResolvedRule, TypeError> {
         let Rule { span, head, body } = rule;
         let mut constraints = vec![];
 
-        let mut fresh_gen = SymbolGen::new("$".to_string());
-        let (query, mapped_query) = Facts(body.clone()).to_query(self, &mut fresh_gen);
+        let (query, mapped_query) = Facts(body.clone()).to_query(self, symbol_gen);
         constraints.extend(query.get_constraints(self)?);
 
         let mut binding = query.get_vars();
-        let (actions, mapped_action) = head.to_core_actions(self, &mut binding, &mut fresh_gen)?;
+        let (actions, mapped_action) = head.to_core_actions(self, &mut binding, symbol_gen)?;
 
         let mut problem = Problem::default();
         problem.add_rule(
@@ -369,6 +384,7 @@ impl TypeInfo {
                 head: actions,
             },
             self,
+            symbol_gen,
         )?;
 
         let assignment = problem
@@ -385,9 +401,12 @@ impl TypeInfo {
         })
     }
 
-    fn typecheck_facts(&self, facts: &[Fact]) -> Result<Vec<ResolvedFact>, TypeError> {
-        let mut fresh_gen = SymbolGen::new("$".to_string());
-        let (query, mapped_facts) = Facts(facts.to_vec()).to_query(self, &mut fresh_gen);
+    fn typecheck_facts(
+        &self,
+        symbol_gen: &mut SymbolGen,
+        facts: &[Fact],
+    ) -> Result<Vec<ResolvedFact>, TypeError> {
+        let (query, mapped_facts) = Facts(facts.to_vec()).to_query(self, symbol_gen);
         let mut problem = Problem::default();
         problem.add_query(&query, self)?;
         let assignment = problem
@@ -399,17 +418,17 @@ impl TypeInfo {
 
     fn typecheck_actions(
         &self,
+        symbol_gen: &mut SymbolGen,
         actions: &Actions,
         binding: &IndexMap<Symbol, (Span, ArcSort)>,
     ) -> Result<ResolvedActions, TypeError> {
         let mut binding_set = binding.keys().cloned().collect::<IndexSet<_>>();
-        let mut fresh_gen = SymbolGen::new("$".to_string());
         let (actions, mapped_action) =
-            actions.to_core_actions(self, &mut binding_set, &mut fresh_gen)?;
+            actions.to_core_actions(self, &mut binding_set, symbol_gen)?;
         let mut problem = Problem::default();
 
         // add actions to problem
-        problem.add_actions(&actions, self)?;
+        problem.add_actions(&actions, self, symbol_gen)?;
 
         // add bindings from the context
         for (var, (span, sort)) in binding {
@@ -426,11 +445,12 @@ impl TypeInfo {
 
     fn typecheck_expr(
         &self,
+        symbol_gen: &mut SymbolGen,
         expr: &Expr,
         binding: &IndexMap<Symbol, (Span, ArcSort)>,
     ) -> Result<ResolvedExpr, TypeError> {
         let action = Action::Expr(DUMMY_SPAN.clone(), expr.clone());
-        let typechecked_action = self.typecheck_action(&action, binding)?;
+        let typechecked_action = self.typecheck_action(symbol_gen, &action, binding)?;
         match typechecked_action {
             ResolvedAction::Expr(_, expr) => Ok(expr),
             _ => unreachable!(),
@@ -439,10 +459,11 @@ impl TypeInfo {
 
     fn typecheck_action(
         &self,
+        symbol_gen: &mut SymbolGen,
         action: &Action,
         binding: &IndexMap<Symbol, (Span, ArcSort)>,
     ) -> Result<ResolvedAction, TypeError> {
-        self.typecheck_actions(&Actions::singleton(action.clone()), binding)
+        self.typecheck_actions(symbol_gen, &Actions::singleton(action.clone()), binding)
             .map(|mut v| {
                 assert_eq!(v.len(), 1);
                 v.0.pop().unwrap()

--- a/src/util.rs
+++ b/src/util.rs
@@ -65,14 +65,14 @@ where
 /// These are guaranteed not to collide with the
 /// user's symbols because they use $.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SymbolGen {
+pub struct SymbolGen {
     gen: usize,
     reserved_string: String,
     special_reserved: HashMap<Symbol, String>,
 }
 
 impl SymbolGen {
-    pub(crate) fn new(reserved_string: String) -> Self {
+    pub fn new(reserved_string: String) -> Self {
         Self {
             gen: 0,
             reserved_string,
@@ -80,13 +80,13 @@ impl SymbolGen {
         }
     }
 
-    pub(crate) fn has_been_used(&self) -> bool {
+    pub fn has_been_used(&self) -> bool {
         self.gen > 0
     }
 }
 
 /// This trait lets us statically dispatch between `fresh` methods for generic structs.
-pub(crate) trait FreshGen<Head, Leaf> {
+pub trait FreshGen<Head, Leaf> {
     fn fresh(&mut self, name_hint: &Head) -> Leaf;
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -68,7 +68,6 @@ where
 pub struct SymbolGen {
     gen: usize,
     reserved_string: String,
-    special_reserved: HashMap<Symbol, String>,
 }
 
 impl SymbolGen {
@@ -76,7 +75,6 @@ impl SymbolGen {
         Self {
             gen: 0,
             reserved_string,
-            special_reserved: HashMap::default(),
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -88,22 +88,6 @@ impl SymbolGen {
     pub(crate) fn has_been_used(&self) -> bool {
         self.gen > 0
     }
-
-    pub(crate) fn generate_special(&mut self, sym: &Symbol) -> Symbol {
-        match self.special_reserved.get(sym) {
-            Some(res) => res.into(),
-            None => {
-                let res = format!("{}{}{}", self.reserved_string, sym, self.gen);
-                self.gen += 1;
-                self.special_reserved.insert(*sym, res.clone());
-                res.into()
-            }
-        }
-    }
-
-    pub(crate) fn lookup_special(&self, sym: &Symbol) -> Option<Symbol> {
-        self.special_reserved.get(sym).map(|s| s.into())
-    }
 }
 
 impl FreshGen<Symbol, Symbol> for SymbolGen {


### PR DESCRIPTION
This PR:

1. Deletes the unused `_special` methods on `SymbolGen`.
2. Deletes the `ResolvedGen` struct and just `impl FreshGen for SymbolGen` twice.
3. Creates one `SymbolGen` in `EGraph` that is used everywhere, instead of constructing multiple `SymbolGen`s which is potentially buggy.