### PR TITLE
Delete desugar struct

### DIFF
--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -1,6 +1,9 @@
 use super::{Rewrite, Rule};
 use crate::*;
 
+/// Desugars a list of commands into the normalized form.
+/// Gets rid of a bunch of syntactic sugar, but also
+/// makes rules into a SSA-like format (see [`NormFact`]).
 pub(crate) fn desugar_program(
     program: Vec<Command>,
     symbol_gen: &mut SymbolGen,
@@ -12,175 +15,6 @@ pub(crate) fn desugar_program(
         res.extend(desugared);
     }
     Ok(res)
-}
-
-fn desugar_datatype(span: Span, name: Symbol, variants: Vec<Variant>) -> Vec<NCommand> {
-    vec![NCommand::Sort(span.clone(), name, None)]
-        .into_iter()
-        .chain(variants.into_iter().map(|variant| {
-            NCommand::Function(FunctionDecl {
-                name: variant.name,
-                schema: Schema {
-                    input: variant.types,
-                    output: name,
-                },
-                merge: None,
-                merge_action: Actions::default(),
-                default: None,
-                cost: variant.cost,
-                unextractable: false,
-                ignore_viz: false,
-                span: variant.span,
-            })
-        }))
-        .collect()
-}
-
-fn desugar_rewrite(
-    ruleset: Symbol,
-    name: Symbol,
-    rewrite: &Rewrite,
-    subsume: bool,
-) -> Vec<NCommand> {
-    let span = rewrite.span.clone();
-    let var = Symbol::from("rewrite_var__");
-    let mut head = Actions::singleton(Action::Union(
-        span.clone(),
-        Expr::Var(span.clone(), var),
-        rewrite.rhs.clone(),
-    ));
-    if subsume {
-        match &rewrite.lhs {
-            Expr::Call(_, f, args) => {
-                head.0.push(Action::Change(
-                    span.clone(),
-                    Change::Subsume,
-                    *f,
-                    args.to_vec(),
-                ));
-            }
-            _ => {
-                panic!("Subsumed rewrite must have a function call on the lhs");
-            }
-        }
-    }
-    // make two rules- one to insert the rhs, and one to union
-    // this way, the union rule can only be fired once,
-    // which helps proofs not add too much info
-    vec![NCommand::NormRule {
-        ruleset,
-        name,
-        rule: Rule {
-            span: span.clone(),
-            body: [Fact::Eq(
-                span.clone(),
-                vec![Expr::Var(span, var), rewrite.lhs.clone()],
-            )]
-            .into_iter()
-            .chain(rewrite.conditions.clone())
-            .collect(),
-            head,
-        },
-    }]
-}
-
-fn desugar_birewrite(ruleset: Symbol, name: Symbol, rewrite: &Rewrite) -> Vec<NCommand> {
-    let span = rewrite.span.clone();
-    let rw2 = Rewrite {
-        span,
-        lhs: rewrite.rhs.clone(),
-        rhs: rewrite.lhs.clone(),
-        conditions: rewrite.conditions.clone(),
-    };
-    desugar_rewrite(ruleset, format!("{}=>", name).into(), rewrite, false)
-        .into_iter()
-        .chain(desugar_rewrite(
-            ruleset,
-            format!("{}<=", name).into(),
-            &rw2,
-            false,
-        ))
-        .collect()
-}
-
-// TODO(yz): we can delete this code once we enforce that all rule bodies cannot read the database (except EqSort).
-fn add_semi_naive_rule(symbol_gen: &mut SymbolGen, rule: Rule) -> Option<Rule> {
-    let mut new_rule = rule;
-    // Whenever an Let(_, expr@Call(...)) or Set(_, expr@Call(...)) is present in action,
-    // an additional seminaive rule should be created.
-    // Moreover, for each such expr, expr and all variable definitions that it relies on should be moved to trigger.
-    let mut new_head_atoms = vec![];
-    let mut add_new_rule = false;
-
-    let mut var_set = HashSet::default();
-    for head_slice in new_rule.head.0.iter_mut().rev() {
-        match head_slice {
-            Action::Set(span, _, _, expr) => {
-                var_set.extend(expr.vars());
-                if let Expr::Call(..) = expr {
-                    add_new_rule = true;
-
-                    let fresh_symbol = symbol_gen.fresh(&"desugar_snrule".into());
-                    let fresh_var = Expr::Var(span.clone(), fresh_symbol);
-                    let expr = std::mem::replace(expr, fresh_var.clone());
-                    new_head_atoms.push(Fact::Eq(span.clone(), vec![fresh_var, expr]));
-                };
-            }
-            Action::Let(span, symbol, expr) if var_set.contains(symbol) => {
-                var_set.extend(expr.vars());
-                if let Expr::Call(..) = expr {
-                    add_new_rule = true;
-
-                    let var = Expr::Var(span.clone(), *symbol);
-                    new_head_atoms.push(Fact::Eq(span.clone(), vec![var, expr.clone()]));
-                }
-            }
-            _ => (),
-        }
-    }
-
-    if add_new_rule {
-        new_rule.body.extend(new_head_atoms.into_iter().rev());
-        // remove all let action
-        new_rule.head.0.retain_mut(
-            |action| !matches!(action, Action::Let(_ann, var, _) if var_set.contains(var)),
-        );
-        log::debug!("Added a semi-naive desugared rule:\n{}", new_rule);
-        Some(new_rule)
-    } else {
-        None
-    }
-}
-
-fn desugar_simplify(
-    expr: &Expr,
-    schedule: &Schedule,
-    span: Span,
-    symbol_gen: &mut SymbolGen,
-) -> Vec<NCommand> {
-    let mut res = vec![NCommand::Push(1)];
-    let lhs = symbol_gen.fresh(&"desugar_simplify".into());
-    res.push(NCommand::CoreAction(Action::Let(
-        span.clone(),
-        lhs,
-        expr.clone(),
-    )));
-    res.push(NCommand::RunSchedule(schedule.clone()));
-    res.extend(
-        desugar_command(
-            Command::QueryExtract {
-                span: span.clone(),
-                variants: 0,
-                expr: Expr::Var(span.clone(), lhs),
-            },
-            symbol_gen,
-            false,
-        )
-        .unwrap(),
-    );
-
-    res.push(NCommand::Pop(span, 1));
-    res
 }
 
 /// Desugars a single command into the normalized form.
@@ -352,4 +186,173 @@ pub(crate) fn desugar_command(
     };
 
     Ok(res)
+}
+
+fn desugar_datatype(span: Span, name: Symbol, variants: Vec<Variant>) -> Vec<NCommand> {
+    vec![NCommand::Sort(span.clone(), name, None)]
+        .into_iter()
+        .chain(variants.into_iter().map(|variant| {
+            NCommand::Function(FunctionDecl {
+                name: variant.name,
+                schema: Schema {
+                    input: variant.types,
+                    output: name,
+                },
+                merge: None,
+                merge_action: Actions::default(),
+                default: None,
+                cost: variant.cost,
+                unextractable: false,
+                ignore_viz: false,
+                span: variant.span,
+            })
+        }))
+        .collect()
+}
+
+fn desugar_rewrite(
+    ruleset: Symbol,
+    name: Symbol,
+    rewrite: &Rewrite,
+    subsume: bool,
+) -> Vec<NCommand> {
+    let span = rewrite.span.clone();
+    let var = Symbol::from("rewrite_var__");
+    let mut head = Actions::singleton(Action::Union(
+        span.clone(),
+        Expr::Var(span.clone(), var),
+        rewrite.rhs.clone(),
+    ));
+    if subsume {
+        match &rewrite.lhs {
+            Expr::Call(_, f, args) => {
+                head.0.push(Action::Change(
+                    span.clone(),
+                    Change::Subsume,
+                    *f,
+                    args.to_vec(),
+                ));
+            }
+            _ => {
+                panic!("Subsumed rewrite must have a function call on the lhs");
+            }
+        }
+    }
+    // make two rules- one to insert the rhs, and one to union
+    // this way, the union rule can only be fired once,
+    // which helps proofs not add too much info
+    vec![NCommand::NormRule {
+        ruleset,
+        name,
+        rule: Rule {
+            span: span.clone(),
+            body: [Fact::Eq(
+                span.clone(),
+                vec![Expr::Var(span, var), rewrite.lhs.clone()],
+            )]
+            .into_iter()
+            .chain(rewrite.conditions.clone())
+            .collect(),
+            head,
+        },
+    }]
+}
+
+fn desugar_birewrite(ruleset: Symbol, name: Symbol, rewrite: &Rewrite) -> Vec<NCommand> {
+    let span = rewrite.span.clone();
+    let rw2 = Rewrite {
+        span,
+        lhs: rewrite.rhs.clone(),
+        rhs: rewrite.lhs.clone(),
+        conditions: rewrite.conditions.clone(),
+    };
+    desugar_rewrite(ruleset, format!("{}=>", name).into(), rewrite, false)
+        .into_iter()
+        .chain(desugar_rewrite(
+            ruleset,
+            format!("{}<=", name).into(),
+            &rw2,
+            false,
+        ))
+        .collect()
+}
+
+// TODO(yz): we can delete this code once we enforce that all rule bodies cannot read the database (except EqSort).
+fn add_semi_naive_rule(symbol_gen: &mut SymbolGen, rule: Rule) -> Option<Rule> {
+    let mut new_rule = rule;
+    // Whenever an Let(_, expr@Call(...)) or Set(_, expr@Call(...)) is present in action,
+    // an additional seminaive rule should be created.
+    // Moreover, for each such expr, expr and all variable definitions that it relies on should be moved to trigger.
+    let mut new_head_atoms = vec![];
+    let mut add_new_rule = false;
+
+    let mut var_set = HashSet::default();
+    for head_slice in new_rule.head.0.iter_mut().rev() {
+        match head_slice {
+            Action::Set(span, _, _, expr) => {
+                var_set.extend(expr.vars());
+                if let Expr::Call(..) = expr {
+                    add_new_rule = true;
+
+                    let fresh_symbol = symbol_gen.fresh(&"desugar_snrule".into());
+                    let fresh_var = Expr::Var(span.clone(), fresh_symbol);
+                    let expr = std::mem::replace(expr, fresh_var.clone());
+                    new_head_atoms.push(Fact::Eq(span.clone(), vec![fresh_var, expr]));
+                };
+            }
+            Action::Let(span, symbol, expr) if var_set.contains(symbol) => {
+                var_set.extend(expr.vars());
+                if let Expr::Call(..) = expr {
+                    add_new_rule = true;
+
+                    let var = Expr::Var(span.clone(), *symbol);
+                    new_head_atoms.push(Fact::Eq(span.clone(), vec![var, expr.clone()]));
+                }
+            }
+            _ => (),
+        }
+    }
+
+    if add_new_rule {
+        new_rule.body.extend(new_head_atoms.into_iter().rev());
+        // remove all let action
+        new_rule.head.0.retain_mut(
+            |action| !matches!(action, Action::Let(_ann, var, _) if var_set.contains(var)),
+        );
+        log::debug!("Added a semi-naive desugared rule:\n{}", new_rule);
+        Some(new_rule)
+    } else {
+        None
+    }
+}
+
+fn desugar_simplify(
+    expr: &Expr,
+    schedule: &Schedule,
+    span: Span,
+    symbol_gen: &mut SymbolGen,
+) -> Vec<NCommand> {
+    let mut res = vec![NCommand::Push(1)];
+    let lhs = symbol_gen.fresh(&"desugar_simplify".into());
+    res.push(NCommand::CoreAction(Action::Let(
+        span.clone(),
+        lhs,
+        expr.clone(),
+    )));
+    res.push(NCommand::RunSchedule(schedule.clone()));
+    res.extend(
+        desugar_command(
+            Command::QueryExtract {
+                span: span.clone(),
+                variants: 0,
+                expr: Expr::Var(span.clone(), lhs),
+            },
+            symbol_gen,
+            false,
+        )
+        .unwrap(),
+    );
+
+    res.push(NCommand::Pop(span, 1));
+    res
 }


### PR DESCRIPTION
This PR cleans up `ast/desugar.rs`, now that we've moved both the parser and the symbol generation out of the `Desguar` struct.
More specifically, this PR:

1. Deletes the `Desugar` struct. (We also discussed doing something like `struct Desugar(&mut SymbolGen)`, but I don't want to do this unless we have at least two things inside the struct.)
2. Deletes the `desugar::get_fresh` function, as I think that we should instead give name hints to `SymbolGen` that indicate where the variable was generated from.
3. Deletes `desugar_commands`, as without the `Desugar` struct this is exactly the same as `desugar_program` (which I've moved to the top of the file as the entry point).