### PR TITLE
SrcFile's debug should not print the whole content

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -78,10 +78,16 @@ pub(crate) enum Ruleset {
 pub const DEFAULT_FILENAME: &str = "<unnamed.egg>";
 pub const DUMMY_FILENAME: &str = "<internal.egg>";
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct SrcFile {
     pub name: String,
     pub contents: Option<String>,
+}
+
+impl Debug for SrcFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SrcFile({}, contents=...)", self.name)
+    }
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Fixes #447 

Before:
```bash
> RUST_LOG=debug cargo run --release tests/python_array_optimize.egg 2>&1 >/dev/null | wc 
   26609 14906607 220858043
```

After:
```bash
> RUST_LOG=debug cargo run --release tests/python_array_optimize.egg 2>&1 >/dev/null | wc
   26610  788211 10508203
```