### PR TITLE
Speed up local `make test` runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
     - uses: actions/checkout@v3
     - uses: taiki-e/install-action@v2
       with:
@@ -15,12 +16,14 @@ jobs:
   nits:
     runs-on: ubuntu-latest
     steps:
+    - run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
     - run: make nits
   benchmark:
     runs-on: ubuntu-latest
     steps:
+      - run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Disable Incremental Build
+      run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+
     - uses: actions/checkout@v3
 
     - name: Install wasm-pack

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,6 @@ chrono = { version = "0.4", default-features = false, features = ["now"] }
 codspeed-criterion-compat = "2.7.2"
 glob = "0.3.1"
 libtest-mimic = "0.6.1"
+
+[profile.release]
+incremental = true


### PR DESCRIPTION
This PR enables incremental builds for release mode to speed up hot runs of `make test`. It also turns off incremental builds in CI, following the advice of [this blog post](https://fasterthanli.me/articles/why-is-my-rust-build-so-slow#:~:text=Generally%20I%20would%20advise%20setting%20incremental%20%3D%20true%20in%20profile.release%2C%20and%20just%20disabling%20it%20in%20CI%20by%20setting%20the%20environment%20variable%20CARGO_INCREMENTAL%20to%200.).