### PR TITLE
Remove unused 'serde-1' attribute

### DIFF
--- a/src/function/index.rs
+++ b/src/function/index.rs
@@ -62,7 +62,7 @@ impl ColumnIndex {
     pub(crate) fn to_canonicalize<'a>(
         &'a self,
         uf: &'a UnionFind,
-    ) -> impl Iterator<Item = usize> + '_ {
+    ) -> impl Iterator<Item = usize> + 'a {
         uf.dirty_ids(self.sort).flat_map(|x| {
             self.get_indexes_for_bits(x)
                 .unwrap_or(&[])

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -12,7 +12,6 @@ use std::mem;
 pub type Id = u64;
 
 #[derive(Debug, Clone, Default)]
-#[cfg_attr(feature = "serde-1", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnionFind {
     parents: Vec<Cell<Id>>,
     n_unions: usize,


### PR DESCRIPTION
The feature "serde-1" doesn't exist.