### PR TITLE
Extract egraph-serialize features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,21 @@ harness = false
 members = [".", "web-demo"]
 
 [[test]]
-harness = false
 name = "files"
+harness = false
+required-features = ["bin"]
+
+[[bin]]
+name = "egglog"
+path = "src/main.rs"
+required-features = ["bin"]
 
 [features]
 default = ["bin"]
 
-bin = ["dep:clap", "dep:env_logger", "egraph-serialize/serde", "dep:serde_json"]
+bin = ["serde", "graphviz", "dep:clap", "dep:env_logger", "dep:serde_json"]
+serde = ["egraph-serialize/serde"]
+graphviz = ["egraph-serialize/graphviz"]
 wasm-bindgen = ["instant/wasm-bindgen", "dep:getrandom"]
 nondeterministic = []
 
@@ -40,17 +48,14 @@ smallvec = "1.11"
 
 generic_symbolic_expressions = "5.0.4"
 
-egraph-serialize = { version = "0.2.0", features = [
-  "serde",
-  "graphviz",
-] }
-serde_json = { optional = true, version = "1.0.100", features = [
-  "preserve_order",
-] }
+egraph-serialize = { version = "0.2.0", default-features = false }
 
 # binary dependencies
 clap = { version = "4", features = ["derive"], optional = true }
 env_logger = { version = "0.10", optional = true }
+serde_json = { version = "1.0.100", optional = true, features = [
+  "preserve_order",
+] }
 
 ordered-float = { version = "3.7" }
 
@@ -59,7 +64,6 @@ getrandom = { version = "0.2.10", features = ["js"], optional = true }
 
 im-rc = "15.1.0"
 im = "15.1.0"
-
 
 [build-dependencies]
 chrono = { version = "0.4", default-features = false, features = ["now"] }

--- a/web-demo/Cargo.toml
+++ b/web-demo/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies.egglog]
 default-features = false
-features = ["wasm-bindgen"]
+features = ["serde", "graphviz", "wasm-bindgen"]
 path = ".."
 
 [dependencies]
@@ -20,7 +20,7 @@ serde_json = "1.0"
 console_error_panic_hook = "0.1.7"
 js-sys = "0.3"
 wasm-bindgen = "0.2"
-web-sys = {version = "0.3.64", features = [
+web-sys = { version = "0.3.64", features = [
   # "Blob",
   # "BlobPropertyBag",
   # "console",
@@ -33,4 +33,4 @@ web-sys = {version = "0.3.64", features = [
   # "Text",
   "Worker",
   "DedicatedWorkerGlobalScope",
-]}
+] }


### PR DESCRIPTION
`egraph-serialize`'s "serde" and "graphviz" features are not used in the library but are always enabled. Disable them by default and extract them into our own features that just delegate to `egraph-serialize` to preserve the functionality.

This is a breaking change for library users that disable default features.