### PR TITLE
Disable build script for library builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,14 @@ required-features = ["bin"]
 [features]
 default = ["bin"]
 
-bin = ["serde", "graphviz", "dep:clap", "dep:env_logger", "dep:serde_json"]
+bin = [
+  "serde",
+  "graphviz",
+  "dep:clap",
+  "dep:env_logger",
+  "dep:serde_json",
+  "dep:chrono",
+]
 serde = ["egraph-serialize/serde"]
 graphviz = ["egraph-serialize/graphviz"]
 wasm-bindgen = ["instant/wasm-bindgen", "dep:getrandom"]
@@ -66,7 +73,9 @@ im-rc = "15.1.0"
 im = "15.1.0"
 
 [build-dependencies]
-chrono = { version = "0.4", default-features = false, features = ["now"] }
+chrono = { version = "0.4", default-features = false, optional = true, features = [
+  "now",
+] }
 
 [dev-dependencies]
 codspeed-criterion-compat = "2.7.2"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,8 @@
-use std::{env, process::Command};
-
+#[cfg(feature = "bin")]
 #[allow(clippy::disallowed_macros)] // for println!
 fn main() {
+    use std::{env, process::Command};
+
     let git_hash = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
         .output()
@@ -16,3 +17,6 @@ fn main() {
     let full_version = format!("{}_{}{}", version, build_date, git_hash);
     println!("cargo:rustc-env=FULL_VERSION={}", full_version);
 }
+
+#[cfg(not(feature = "bin"))]
+fn main() {}


### PR DESCRIPTION
The build script is only used for emitting the `FULL_VERSION` environment variable, which is only used in the binary. Make it a noop if "bin" is not enabled.