### PR TITLE
Add multiset-sum primitive

### DIFF
--- a/tests/multiset.egg
+++ b/tests/multiset.egg
@@ -56,3 +56,15 @@
     (multiset-of (Num 1) (Num 4) (Num 9))
     squared-xs
 ))
+
+;; sum
+(check (=
+    (multiset-sum (multiset-of (Num 1) (Num 2) (Num 3)) (multiset-of (Num 1) (Num 2) (Num 4)))
+    (multiset-of (Num 1) (Num 4) (Num 2) (Num 3) (Num 2) (Num 1))
+))
+
+;; verify that sum computes length
+(check (=
+    (multiset-length (multiset-sum (multiset-of (Num 1) (Num 2) (Num 3)) (multiset-of (Num 1) (Num 2) (Num 4))))
+    6
+))


### PR DESCRIPTION
`multiset-sum` combines values from both multisets together, allowing for rules such as
```
(rewrite (Add (Sum  xs) (Sum ys)) (Add (Sum (multiset-sum xs ys))))
```
In my understanding, this primitive is crucial for modelling associative + commutative operations with multisets, but I might be missing something.