### PR TITLE
Make "declared function" printouts debug mode

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -66,7 +66,10 @@ impl EGraph {
                     }
                 }
 
-                panic!("No cost for {:?}", value)
+                panic!(
+                    "Failed to extract value {:?}. Did you use :unextractable constructors or the delete keyword?",
+                    value
+                )
             })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1197,19 +1197,19 @@ impl EGraph {
             }
             // Sorts are already declared during typechecking
             ResolvedNCommand::Sort(_span, name, _presort_and_args) => {
-                log::info!("Declared sort {}.", name)
+                log::debug!("Declared sort {}.", name)
             }
             ResolvedNCommand::Function(fdecl) => {
                 self.declare_function(&fdecl)?;
-                log::info!("Declared function {}.", fdecl.name)
+                log::debug!("Declared function {}.", fdecl.name)
             }
             ResolvedNCommand::AddRuleset(name) => {
                 self.add_ruleset(name);
-                log::info!("Declared ruleset {name}.");
+                log::debug!("Declared ruleset {name}.");
             }
             ResolvedNCommand::UnstableCombinedRuleset(name, others) => {
                 self.add_combined_ruleset(name, others);
-                log::info!("Declared ruleset {name}.");
+                log::debug!("Declared ruleset {name}.");
             }
             ResolvedNCommand::NormRule {
                 ruleset,
@@ -1217,7 +1217,7 @@ impl EGraph {
                 name,
             } => {
                 self.add_rule(rule, ruleset)?;
-                log::info!("Declared rule {name}.")
+                log::debug!("Declared rule {name}.")
             }
             ResolvedNCommand::RunSchedule(sched) => {
                 let report = self.run_schedule(&sched);


### PR DESCRIPTION
The eggcc project relies on info printing, and the declared function print outs are becoming super verbose (one per variable, which we generate tens of thousands of)
This PR makes these prints debug instead of info

It also slightly cleans up a confusing error message in the extractor