### PR TITLE
Fix the missing `include_subsume` flag so that subsumed tuples does not show up for rules

### DIFF
--- a/src/gj.rs
+++ b/src/gj.rs
@@ -959,7 +959,7 @@ impl<'a> TrieAccess<'a> {
         if idxs.is_empty() {
             let rows = self
                 .function
-                .iter_timestamp_range(&self.timestamp_range, true);
+                .iter_timestamp_range(&self.timestamp_range, self.include_subsumed);
             if self.column < arity {
                 for (i, tup, out) in rows {
                     insert(i, tup, out, tup[self.column])


### PR DESCRIPTION
To see how this bug can cause failures, comment out the lines where `from_column_index` is used (which is hiding the bug) and use `LazyTrie::default` instead and run the tests again.