### PR TITLE
Subsume should succeed even when the tuple is not present in the database

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -419,7 +419,7 @@ impl EGraph {
                             if function.decl.merge.is_some() {
                                 return Err(Error::SubsumeMergeError(*f));
                             }
-                            function.subsume(args);
+                            function.subsume(args, self.timestamp);
                         }
                     }
                     stack.truncate(new_len);

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -236,8 +236,12 @@ impl Function {
     }
 
     /// Mark the given inputs as subsumed.
-    pub fn subsume(&mut self, inputs: &[Value]) {
-        self.nodes.get_mut(inputs).unwrap().subsumed = true;
+    /// This will succeed no matter the tuple is already present or not.
+    /// In case the tuple is absent, it will use a dummy value for the output instead.
+    pub fn subsume(&mut self, inputs: &[Value], timestamp: u32) {
+        self.nodes.insert_and_merge(inputs, timestamp, true, |prev| {
+            prev.unwrap_or(Value::fake())
+        });
     }
 
     /// Return a column index that contains (a superset of) the offsets for the

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -239,9 +239,10 @@ impl Function {
     /// This will succeed no matter the tuple is already present or not.
     /// In case the tuple is absent, it will use a dummy value for the output instead.
     pub fn subsume(&mut self, inputs: &[Value], timestamp: u32) {
-        self.nodes.insert_and_merge(inputs, timestamp, true, |prev| {
-            prev.unwrap_or(Value::fake())
-        });
+        self.nodes
+            .insert_and_merge(inputs, timestamp, true, |prev| {
+                prev.unwrap_or(Value::fake())
+            });
     }
 
     /// Return a column index that contains (a superset of) the offsets for the

--- a/src/function/table.rs
+++ b/src/function/table.rs
@@ -124,13 +124,6 @@ impl Table {
         Some(&self.vals[off].1)
     }
 
-    pub(crate) fn get_mut(&mut self, inputs: &[Value]) -> Option<&mut TupleOutput> {
-        let hash: u64 = hash_values(inputs);
-        let &TableOffset { off, .. } = self.table.find(hash, search_for!(self, hash, inputs))?;
-        debug_assert!(self.vals[off].0.live());
-        Some(&mut self.vals[off].1)
-    }
-
     /// Insert the given data into the table at the given timestamp. Return the
     /// previous value, if there was one.
     pub(crate) fn insert(&mut self, inputs: &[Value], out: Value, ts: u32) -> Option<Value> {


### PR DESCRIPTION
Fixes #462 