### PR TITLE
Remove :on_merge

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -214,7 +214,7 @@ impl EGraph {
 
         if let Some(old_value) = old_value {
             if new_value != old_value {
-                let merged: Value = match function.merge.merge_vals.clone() {
+                let merged: Value = match function.merge.clone() {
                     MergeFn::AssertEq => {
                         return Err(Error::MergeError(table, new_value, old_value));
                     }
@@ -234,14 +234,6 @@ impl EGraph {
                     let args = &stack[new_len..];
                     let function = self.functions.get_mut(&table).unwrap();
                     function.insert(args, merged, self.timestamp);
-                }
-                // re-borrow
-                let function = self.functions.get_mut(&table).unwrap();
-                if let Some(prog) = function.merge.on_merge.clone() {
-                    let values = [old_value, new_value];
-                    // We need to pass a new stack instead of reusing the old one
-                    // because Load(Stack(idx)) use absolute index.
-                    self.run_actions(&mut Vec::new(), &values, &prog)?;
                 }
             }
         } else {

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -34,17 +34,8 @@ pub(crate) fn desugar_command(
             name,
             schema,
             merge,
-            merge_action,
-            cost,
-            unextractable,
         } => vec![NCommand::Function(FunctionDecl::function(
-            span,
-            name,
-            schema,
-            merge,
-            merge_action,
-            cost,
-            unextractable,
+            span, name, schema, merge,
         ))],
         Command::Constructor {
             span,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -119,9 +119,6 @@ where
                     schema: f.schema.clone(),
                     name: f.name,
                     merge: f.merge.clone(),
-                    merge_action: f.merge_action.clone(),
-                    cost: f.cost,
-                    unextractable: f.unextractable,
                 },
             },
             GenericNCommand::AddRuleset(name) => GenericCommand::AddRuleset(*name),
@@ -481,9 +478,6 @@ where
         name: Symbol,
         schema: Schema,
         merge: Option<GenericExpr<Head, Leaf>>,
-        merge_action: GenericActions<Head, Leaf>,
-        cost: Option<usize>,
-        unextractable: bool,
     },
 
     /// Using the `ruleset` command, defines a new
@@ -745,9 +739,6 @@ where
                 name,
                 schema,
                 merge,
-                merge_action,
-                cost,
-                unextractable,
             } => {
                 let mut res = vec![
                     Sexp::Symbol("function".into()),
@@ -758,24 +749,6 @@ where
                     res.extend(contents);
                 } else {
                     unreachable!();
-                }
-
-                if let Some(cost) = cost {
-                    res.extend(vec![
-                        Sexp::Symbol(":cost".into()),
-                        Sexp::Symbol(cost.to_string()),
-                    ]);
-                }
-
-                if *unextractable {
-                    res.push(Sexp::Symbol(":unextractable".into()));
-                }
-
-                if !merge_action.is_empty() {
-                    res.push(Sexp::Symbol(":on_merge".into()));
-                    res.push(Sexp::List(
-                        merge_action.iter().map(|a| a.to_sexp()).collect(),
-                    ));
                 }
 
                 if let Some(merge) = &merge {
@@ -1007,7 +980,6 @@ where
     pub subtype: FunctionSubtype,
     pub schema: Schema,
     pub merge: Option<GenericExpr<Head, Leaf>>,
-    pub merge_action: GenericActions<Head, Leaf>,
     pub cost: Option<usize>,
     pub unextractable: bool,
     /// Globals are desugared to functions, with this flag set to true.
@@ -1062,18 +1034,14 @@ impl FunctionDecl {
         name: Symbol,
         schema: Schema,
         merge: Option<GenericExpr<Symbol, Symbol>>,
-        merge_action: GenericActions<Symbol, Symbol>,
-        cost: Option<usize>,
-        unextractable: bool,
     ) -> Self {
         Self {
             name,
             subtype: FunctionSubtype::Custom,
             schema,
             merge,
-            merge_action,
-            cost,
-            unextractable,
+            cost: None,
+            unextractable: false,
             ignore_viz: false,
             span,
         }
@@ -1091,7 +1059,6 @@ impl FunctionDecl {
             subtype: FunctionSubtype::Constructor,
             schema,
             merge: None,
-            merge_action: Actions::default(),
             cost,
             unextractable,
             ignore_viz: false,
@@ -1108,7 +1075,6 @@ impl FunctionDecl {
                 output: Symbol::from("Unit"),
             },
             merge: None,
-            merge_action: Actions::default(),
             cost: None,
             unextractable: false,
             ignore_viz: false,
@@ -1131,7 +1097,6 @@ where
             subtype: self.subtype,
             schema: self.schema,
             merge: self.merge.map(|expr| expr.visit_exprs(f)),
-            merge_action: self.merge_action.visit_exprs(f),
             cost: self.cost,
             unextractable: self.unextractable,
             ignore_viz: self.ignore_viz,
@@ -1167,13 +1132,6 @@ where
 
         if self.unextractable {
             res.push(Sexp::Symbol(":unextractable".into()));
-        }
-
-        if !self.merge_action.is_empty() {
-            res.push(Sexp::Symbol(":on_merge".into()));
-            res.push(Sexp::List(
-                self.merge_action.iter().map(|a| a.to_sexp()).collect(),
-            ));
         }
 
         if let Some(merge) = &self.merge {
@@ -1462,10 +1420,6 @@ where
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = &GenericAction<Head, Leaf>> {
         self.0.iter()
-    }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
     }
 
     pub(crate) fn visit_exprs(

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -366,21 +366,13 @@ fn command(ctx: &Context) -> Res<Command> {
                 text("function"),
                 ident,
                 schema,
-                cost,
-                map(option(text(":unextractable")), |x, _| x.is_some()),
-                map(option(sequence(text(":on_merge"), list(action))), snd),
                 map(option(sequence(text(":merge"), expr)), snd),
             )),
-            |((), (name, (schema, (cost, (unextractable, (merge_action, merge)))))), span| {
-                Command::Function {
-                    span,
-                    name,
-                    schema,
-                    merge,
-                    merge_action: Actions::new(merge_action.unwrap_or_default()),
-                    cost,
-                    unextractable,
-                }
+            |((), (name, (schema, merge))), span| Command::Function {
+                span,
+                name,
+                schema,
+                merge,
             },
         )(ctx),
         "constructor" => map(

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -100,7 +100,6 @@ impl<'a> GlobalRemover<'a> {
                             output: ty.name(),
                         },
                         merge: None,
-                        merge_action: GenericActions(vec![]),
                         cost: None,
                         unextractable: true,
                         ignore_viz: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,17 +644,12 @@ impl EGraph {
         let mut stack = Vec::new();
         let mut function = self.functions.get_mut(&func).unwrap();
         let n_unions = self.unionfind.n_unions();
-        let merge_prog = match &function.merge.merge_vals {
+        let merge_prog = match &function.merge {
             MergeFn::Expr(e) => Some(e.clone()),
             MergeFn::AssertEq | MergeFn::Union => None,
         };
 
         for (inputs, old, new) in merges {
-            if let Some(prog) = function.merge.on_merge.clone() {
-                self.run_actions(&mut stack, &[*old, *new], &prog).unwrap();
-                function = self.functions.get_mut(&func).unwrap();
-                stack.clear();
-            }
             if let Some(prog) = &merge_prog {
                 // TODO: error handling?
                 self.run_actions(&mut stack, &[*old, *new], prog).unwrap();

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -283,7 +283,6 @@ impl TypeInfo {
                 Some(merge) => Some(self.typecheck_expr(symbol_gen, merge, &bound_vars)?),
                 None => None,
             },
-            merge_action: self.typecheck_actions(symbol_gen, &fdecl.merge_action, &bound_vars)?,
             cost: fdecl.cost,
             unextractable: fdecl.unextractable,
             ignore_viz: fdecl.ignore_viz,

--- a/tests/cykjson.egg
+++ b/tests/cykjson.egg
@@ -8,7 +8,7 @@
 
 
 (relation P (i64 i64 String))
-(function B (i64 i64 String) tree :cost 100000)
+(function B (i64 i64 String) tree)
 
 (rule ((End a s)
        (= s (getString pos)))

--- a/tests/python_array_optimize.egg
+++ b/tests/python_array_optimize.egg
@@ -1381,7 +1381,7 @@
         :ruleset program_gen_ruleset )
 (constructor Program_expr_to_statement (Program) Program)
 (rewrite (Program_statement p1 p2) (Program___add__ p1 (Program_expr_to_statement p2)) :ruleset program_gen_ruleset)
-(function Program_parent (Program) Program :unextractable :merge old)
+(function Program_parent (Program) Program :merge old)
 (rule ((= p (Program_expr_to_statement p1))
        (Program_compile p i))
       ((set (Program_parent p1) p)

--- a/tests/set.egg
+++ b/tests/set.egg
@@ -25,7 +25,7 @@
 (sort ISet)
 (constructor IS (ISetBase) ISet)
 
-(function ISet-get (ISet i64) i64 :unextractable)
+(function ISet-get (ISet i64) i64)
 (rule ((IS x) (> (set-length x) 0))
     ((set (ISet-get (IS x) 0) (set-get x 0))))
 (rule ((ISet-get (IS x) j)


### PR DESCRIPTION
This PR removes `:on_merge`. Oliver says we don't need it.

It also removes `:cost` and `:unextractable` from `function`s, since they can no longer ever be extracted (right?).