### PR TITLE
Subsume should succeed even when the tuple is not present

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -386,10 +386,18 @@ impl EGraph {
                             function.remove(args, self.timestamp);
                         }
                         Change::Subsume => {
-                            if function.decl.merge.is_some() {
+                            if function.decl.subtype != FunctionSubtype::Constructor {
                                 return Err(Error::SubsumeMergeError(*f));
                             }
-                            function.subsume(args);
+                            function
+                                .nodes
+                                .insert_and_merge(args, self.timestamp, true, |old| {
+                                    old.unwrap_or_else(|| Value {
+                                        #[cfg(debug_assertions)]
+                                        tag: function.schema.output.name(),
+                                        bits: self.unionfind.make_set(),
+                                    })
+                                });
                         }
                     }
                     stack.truncate(new_len);

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -212,11 +212,6 @@ impl Function {
         res
     }
 
-    /// Mark the given inputs as subsumed.
-    pub fn subsume(&mut self, inputs: &[Value]) {
-        self.nodes.get_mut(inputs).unwrap().subsumed = true;
-    }
-
     /// Return a column index that contains (a superset of) the offsets for the
     /// given column. This method can return nothing if the indexes available
     /// contain too many irrelevant offsets.

--- a/src/function/table.rs
+++ b/src/function/table.rs
@@ -124,13 +124,6 @@ impl Table {
         Some(&self.vals[off].1)
     }
 
-    pub(crate) fn get_mut(&mut self, inputs: &[Value]) -> Option<&mut TupleOutput> {
-        let hash: u64 = hash_values(inputs);
-        let &TableOffset { off, .. } = self.table.find(hash, search_for!(self, hash, inputs))?;
-        debug_assert!(self.vals[off].0.live());
-        Some(&mut self.vals[off].1)
-    }
-
     /// Insert the given data into the table at the given timestamp. Return the
     /// previous value, if there was one.
     pub(crate) fn insert(&mut self, inputs: &[Value], out: Value, ts: u32) -> Option<Value> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -430,7 +430,7 @@ fn test_serialize_subsume_status() {
         None,
         egglog::SerializedNode::Function {
             name: ("a").into(),
-            offset: 0,
+            offset: 1,
         },
     );
     let b_id = egraph.to_node_id(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -360,7 +360,7 @@ fn test_subsume_primitive() {
         (subsume (one))
         "#,
     );
-    assert!(res.is_ok());
+    assert!(res.is_err());
 }
 
 #[test]


### PR DESCRIPTION
Subsumes #478 and fixes #462 