### PR TITLE
S-Expression based parser

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -372,7 +372,7 @@ impl EGraph {
                 Instruction::Panic(msg) => panic!("Panic: {msg}"),
                 Instruction::Literal(lit) => match lit {
                     Literal::Int(i) => stack.push(Value::from(*i)),
-                    Literal::F64(f) => stack.push(Value::from(*f)),
+                    Literal::Float(f) => stack.push(Value::from(*f)),
                     Literal::String(s) => stack.push(Value::from(*s)),
                     Literal::Bool(b) => stack.push(Value::from(*b)),
                     Literal::Unit => stack.push(Value::unit()),

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -178,7 +178,8 @@ pub(crate) fn desugar_command(
                     span: span.clone(),
                     body: vec![Fact::Eq(
                         span.clone(),
-                        vec![Expr::Var(span.clone(), fresh), expr.clone()],
+                        Expr::Var(span.clone(), fresh),
+                        expr.clone(),
                     )],
                     head: Actions::singleton(Action::Extract(
                         span.clone(),
@@ -287,7 +288,8 @@ fn desugar_rewrite(
             span: span.clone(),
             body: [Fact::Eq(
                 span.clone(),
-                vec![Expr::Var(span, var), rewrite.lhs.clone()],
+                Expr::Var(span, var),
+                rewrite.lhs.clone(),
             )]
             .into_iter()
             .chain(rewrite.conditions.clone())

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -50,15 +50,9 @@ pub(crate) fn desugar_command(
             cost,
             unextractable,
         ))],
-        Command::Relation {
-            span,
-            constructor,
-            inputs,
-        } => vec![NCommand::Function(FunctionDecl::relation(
-            span,
-            constructor,
-            inputs,
-        ))],
+        Command::Relation { span, name, inputs } => vec![NCommand::Function(
+            FunctionDecl::relation(span, name, inputs),
+        )],
         Command::Datatype {
             span,
             name,

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -6,7 +6,7 @@ use std::{fmt::Display, hash::Hasher};
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum Literal {
     Int(i64),
-    F64(OrderedFloat<f64>),
+    Float(OrderedFloat<f64>),
     String(Symbol),
     Bool(bool),
     Unit,
@@ -33,14 +33,14 @@ macro_rules! impl_from {
 }
 
 impl_from!(Int(i64));
-impl_from!(F64(OrderedFloat<f64>));
+impl_from!(Float(OrderedFloat<f64>));
 impl_from!(String(Symbol));
 
 impl Display for Literal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
             Literal::Int(i) => Display::fmt(i, f),
-            Literal::F64(n) => {
+            Literal::Float(n) => {
                 // need to display with decimal if there is none
                 let str = n.to_string();
                 if let Ok(_num) = str.parse::<i64>() {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -111,7 +111,7 @@ where
                 },
                 FunctionSubtype::Relation => GenericCommand::Relation {
                     span: f.span.clone(),
-                    constructor: f.name,
+                    name: f.name,
                     inputs: f.schema.input.clone(),
                 },
                 FunctionSubtype::Custom => GenericCommand::Function {
@@ -430,7 +430,7 @@ where
     /// ```
     Relation {
         span: Span,
-        constructor: Symbol,
+        name: Symbol,
         inputs: Vec<Symbol>,
     },
 
@@ -793,9 +793,9 @@ where
             }
             GenericCommand::Relation {
                 span: _,
-                constructor,
+                name,
                 inputs,
-            } => list!("relation", constructor, list!(++ inputs)),
+            } => list!("relation", name, list!(++ inputs)),
             GenericCommand::AddRuleset(name) => list!("ruleset", name),
             GenericCommand::UnstableCombinedRuleset(name, others) => {
                 list!("unstable-combined-ruleset", name, ++ others)

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -846,19 +846,27 @@ fn sexp(ctx: &mut Context) -> Result<Sexp, ParseError> {
             Token::String(s) => Sexp::Literal(Literal::String(s), span),
             Token::Other => {
                 let s = span.string();
-                let int = s.parse::<i64>();
-                let float = s.parse::<f64>();
-                match s {
-                    "true" => Sexp::Literal(Literal::Bool(true), span),
-                    "false" => Sexp::Literal(Literal::Bool(false), span),
-                    _ if int.is_ok() => Sexp::Literal(Literal::Int(int.unwrap()), span),
-                    "NaN" => Sexp::Literal(Literal::Float(OrderedFloat(f64::NAN)), span),
-                    "inf" => Sexp::Literal(Literal::Float(OrderedFloat(f64::INFINITY)), span),
-                    "-inf" => Sexp::Literal(Literal::Float(OrderedFloat(f64::NEG_INFINITY)), span),
-                    _ if float.is_ok() && float.as_ref().unwrap().is_finite() => {
-                        Sexp::Literal(Literal::Float(OrderedFloat(float.unwrap())), span)
+
+                if s == "true" {
+                    Sexp::Literal(Literal::Bool(true), span)
+                } else if s == "false" {
+                    Sexp::Literal(Literal::Bool(false), span)
+                } else if let Ok(int) = s.parse::<i64>() {
+                    Sexp::Literal(Literal::Int(int), span)
+                } else if s == "NaN" {
+                    Sexp::Literal(Literal::Float(OrderedFloat(f64::NAN)), span)
+                } else if s == "inf" {
+                    Sexp::Literal(Literal::Float(OrderedFloat(f64::INFINITY)), span)
+                } else if s == "-inf" {
+                    Sexp::Literal(Literal::Float(OrderedFloat(f64::NEG_INFINITY)), span)
+                } else if let Ok(float) = s.parse::<f64>() {
+                    if float.is_finite() {
+                        Sexp::Literal(Literal::Float(OrderedFloat(float)), span)
+                    } else {
+                        Sexp::Atom(s.into(), span)
                     }
-                    _ => Sexp::Atom(s.into(), span),
+                } else {
+                    Sexp::Atom(s.into(), span)
                 }
             }
         };

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -773,15 +773,21 @@ impl Context {
                 let mut string = String::new();
 
                 loop {
+                    span.2 = self.index;
                     match self.current_char() {
-                        None => {
-                            span.2 = self.index;
-                            return error!(span, "string is missing end quote");
-                        }
+                        None => return error!(span, "string is missing end quote"),
                         Some('"') if !in_escape => break,
                         Some('\\') if !in_escape => in_escape = true,
                         Some(c) => {
-                            string.push(c);
+                            string.push(match (in_escape, c) {
+                                (false, c) => c,
+                                (true, 'n') => '\n',
+                                (true, 't') => '\t',
+                                (true, '\\') => '\\',
+                                (true, c) => {
+                                    return error!(span, "unrecognized escape character {c}")
+                                }
+                            });
                             in_escape = false;
                         }
                     }

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -685,8 +685,8 @@ fn fact(sexp: &Sexp) -> Result<Fact, ParseError> {
 
     Ok(match head.into() {
         "=" => match tail {
-            [_, _, ..] => Fact::Eq(span, map_fallible(tail, expr)?),
-            _ => return error!(span, "using = with less than two arguments is not allowed"),
+            [e1, e2] => Fact::Eq(span, expr(e1)?, expr(e2)?),
+            _ => return error!(span, "usage: (= <expr> <expr>)"),
         },
         _ => Fact::Fact(expr(sexp)?),
     })

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -4,16 +4,16 @@ use crate::*;
 use ordered_float::OrderedFloat;
 
 pub fn parse_program(filename: Option<String>, input: &str) -> Result<Vec<Command>, ParseError> {
-    let (out, _span, rest) = program(&Context::new(filename, input))?;
+    let (sexps, _span, rest) = all_sexps(&Context::new(filename, input))?;
     assert!(rest.is_at_end(), "did not parse entire program");
-    Ok(out)
+    sexps.iter().map(command).collect()
 }
 
 // currently only used for testing, but no reason it couldn't be used elsewhere later
 pub fn parse_expr(filename: Option<String>, input: &str) -> Result<Expr, ParseError> {
-    let (out, _span, rest) = expr(&Context::new(filename, input))?;
+    let (sexp, _span, rest) = sexp(&Context::new(filename, input))?;
     assert!(rest.is_at_end(), "did not parse entire expression");
-    Ok(out)
+    expr(&sexp)
 }
 
 /// A [`Span`] contains the file name and a pair of offsets representing the start and the end.
@@ -94,6 +94,619 @@ impl Display for Span {
     }
 }
 
+// We do an unidiomatic thing here by using a struct instead of an enum.
+// This is okay because we don't expect client code to respond
+// differently to different parse errors. The benefit of this is that
+// error messages are defined in the same place that they are created,
+// making it easier to improve errors over time.
+#[derive(Debug, Error)]
+pub struct ParseError(Span, String);
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}\nparse error: {}", self.0, self.1)
+    }
+}
+
+macro_rules! error {
+    ($span:expr, $($fmt:tt)*) => {
+        Err(ParseError($span, format!($($fmt)*)))
+    };
+}
+
+enum Sexp {
+    Literal(Literal, Span),
+    Atom(Symbol, Span),
+    // `List`s are always nonempty, since an
+    // empty list is actually a `Literal::Unit`
+    List(Vec<Sexp>, Span),
+}
+
+impl Sexp {
+    fn span(&self) -> Span {
+        match self {
+            Sexp::Literal(_, span) => span.clone(),
+            Sexp::Atom(_, span) => span.clone(),
+            Sexp::List(_, span) => span.clone(),
+        }
+    }
+
+    fn expect_uint(&self, e: &'static str) -> Result<usize, ParseError> {
+        if let Sexp::Literal(Literal::Int(x), _) = self {
+            if *x >= 0 {
+                return Ok(*x as usize);
+            }
+        }
+        error!(
+            self.span(),
+            "expected {e} to be a nonnegative integer literal"
+        )
+    }
+
+    fn expect_string(&self, e: &'static str) -> Result<String, ParseError> {
+        if let Sexp::Literal(Literal::String(x), _) = self {
+            return Ok(x.to_string());
+        }
+        error!(self.span(), "expected {e} to be a string literal")
+    }
+
+    fn expect_atom(&self, e: &'static str) -> Result<Symbol, ParseError> {
+        if let Sexp::Atom(symbol, _) = self {
+            return Ok(*symbol);
+        }
+        error!(self.span(), "expected {e}")
+    }
+
+    fn expect_list(&self, e: &'static str) -> Result<&[Sexp], ParseError> {
+        if let Sexp::List(sexps, _) = self {
+            return Ok(sexps);
+        } else if let Sexp::Literal(Literal::Unit, _) = self {
+            return Ok(&[]);
+        }
+        error!(self.span(), "expected {e}")
+    }
+
+    fn expect_call(&self, e: &'static str) -> Result<(Symbol, &[Sexp], Span), ParseError> {
+        if let Sexp::List(sexps, span) = self {
+            if let [Sexp::Atom(func, _), args @ ..] = sexps.as_slice() {
+                return Ok((*func, args, span.clone()));
+            }
+        }
+        error!(self.span(), "expected {e}")
+    }
+}
+
+// helper for mapping a function that returns `Result`
+fn map_fallible<T>(
+    slice: &[Sexp],
+    func: impl Fn(&Sexp) -> Result<T, ParseError>,
+) -> Result<Vec<T>, ParseError> {
+    slice.iter().map(func).collect::<Result<_, _>>()
+}
+
+fn command(sexp: &Sexp) -> Result<Command, ParseError> {
+    let (head, tail, span) = sexp.expect_call("command")?;
+
+    Ok(match head.into() {
+        "set-option" => match tail {
+            [name, value] => Command::SetOption {
+                name: name.expect_atom("option name")?,
+                value: expr(value)?,
+            },
+            _ => return error!(span, "usage: (set-option <name> <value>)"),
+        },
+        "sort" => match tail {
+            [name] => Command::Sort(span, name.expect_atom("sort name")?, None),
+            [name, call] => {
+                let (func, args, _) = call.expect_call("container sort declaration")?;
+                Command::Sort(
+                    span,
+                    name.expect_atom("sort name")?,
+                    Some((func, map_fallible(args, expr)?)),
+                )
+            }
+            _ => {
+                return error!(
+                    span,
+                    "usages:\n(sort <name>)\n(sort <name> (<container sort> <argument sort>*))"
+                )
+            }
+        },
+        "datatype" => match tail {
+            [name, variants @ ..] => Command::Datatype {
+                span,
+                name: name.expect_atom("sort name")?,
+                variants: map_fallible(variants, variant)?,
+            },
+            _ => return error!(span, "usage: (datatype <name> <variant>*)"),
+        },
+        "datatype*" => Command::Datatypes {
+            span,
+            datatypes: map_fallible(tail, rec_datatype)?,
+        },
+        "function" => match tail {
+            [name, inputs, output, merge @ ..] => Command::Function {
+                name: name.expect_atom("function name")?,
+                schema: schema(inputs, output)?,
+                merge: match merge {
+                    [Sexp::Atom(o, _)] if *o == ":no-merge".into() => None,
+                    [Sexp::Atom(o, _), e] if *o == ":merge".into() => Some(expr(e)?),
+                    [] => return error!(span, "functions are required to specify merge behaviour"),
+                    _ => return error!(span, "could not parse function options"),
+                },
+                span,
+            },
+            _ => {
+                let a = "(function <name> (<input sort>*) <output sort> :merge <expr>)";
+                let b = "(function <name> (<input sort>*) <output sort> :no-merge)";
+                return error!(span, "usages:\n{a}\n{b}");
+            }
+        },
+        "constructor" => match tail {
+            [name, inputs, output, options @ ..] => {
+                let mut cost = None;
+                let mut unextractable = false;
+
+                match options {
+                    [] => {}
+                    [Sexp::Atom(o, _)] if *o == ":unextractable".into() => unextractable = true,
+                    [Sexp::Atom(o, _), c] if *o == ":cost".into() => {
+                        cost = Some(c.expect_uint("cost")?)
+                    }
+                    _ => return error!(span, "could not parse constructor options"),
+                }
+
+                Command::Constructor {
+                    span,
+                    name: name.expect_atom("constructor name")?,
+                    schema: schema(inputs, output)?,
+                    cost,
+                    unextractable,
+                }
+            }
+            _ => {
+                let a = "(constructor <name> (<input sort>*) <output sort>)";
+                let b = "(constructor <name> (<input sort>*) <output sort> :cost <cost>)";
+                let c = "(constructor <name> (<input sort>*) <output sort> :unextractable)";
+                return error!(span, "usages:\n{a}\n{b}\n{c}");
+            }
+        },
+        "relation" => match tail {
+            [name, inputs] => Command::Relation {
+                span,
+                name: name.expect_atom("relation name")?,
+                inputs: map_fallible(inputs.expect_list("input sorts")?, |sexp| {
+                    sexp.expect_atom("input sort")
+                })?,
+            },
+            _ => return error!(span, "usage: (relation <name> (<input sort>*))"),
+        },
+        "ruleset" => match tail {
+            [name] => Command::AddRuleset(name.expect_atom("ruleset name")?),
+            _ => return error!(span, "usage: (ruleset <name>)"),
+        },
+        "unstable-combined-ruleset" => match tail {
+            [name, subrulesets @ ..] => Command::UnstableCombinedRuleset(
+                name.expect_atom("combined ruleset name")?,
+                map_fallible(subrulesets, |sexp| sexp.expect_atom("subruleset name"))?,
+            ),
+            _ => {
+                return error!(
+                    span,
+                    "usage: (unstable-combined-ruleset <name> <child ruleset>*)"
+                )
+            }
+        },
+        "rule" => match tail {
+            [lhs, rhs, options @ ..] => {
+                let body = map_fallible(lhs.expect_list("rule query")?, fact)?;
+                let head = map_fallible(rhs.expect_list("rule actions")?, action)?;
+                let head = GenericActions(head);
+
+                let mut ruleset = "".into();
+                let mut name = "".into();
+                let mut i = 0;
+                while i < options.len() {
+                    match options[i].expect_atom("rule option")?.into() {
+                        ":ruleset" => {
+                            i += 1;
+                            ruleset = options[i].expect_atom("ruleset name")?;
+                        }
+                        ":name" => {
+                            i += 1;
+                            name = options[i].expect_string("rule name")?.into();
+                        }
+                        _ => return error!(options[i].span(), "could not parse rule option"),
+                    }
+                    i += 1;
+                }
+
+                Command::Rule {
+                    ruleset,
+                    name,
+                    rule: Rule { span, head, body },
+                }
+            }
+            _ => return error!(span, "usage: (rule (<fact>*) (<action>*) <option>*)"),
+        },
+        "rewrite" => match tail {
+            [lhs, rhs, options @ ..] => {
+                let lhs = expr(lhs)?;
+                let rhs = expr(rhs)?;
+
+                let mut ruleset = "".into();
+                let mut conditions = Vec::new();
+                let mut subsume = false;
+                let mut i = 0;
+                while i < options.len() {
+                    match options[i].expect_atom("rewrite option")?.into() {
+                        ":ruleset" => {
+                            i += 1;
+                            ruleset = options[i].expect_atom("ruleset name")?;
+                        }
+                        ":subsume" => subsume = true,
+                        ":when" => {
+                            i += 1;
+                            conditions =
+                                map_fallible(options[i].expect_list("rewrite conditions")?, fact)?;
+                        }
+                        _ => return error!(options[i].span(), "could not parse rewrite option"),
+                    }
+                    i += 1;
+                }
+
+                Command::Rewrite(
+                    ruleset,
+                    Rewrite {
+                        span,
+                        lhs,
+                        rhs,
+                        conditions,
+                    },
+                    subsume,
+                )
+            }
+            _ => return error!(span, "usage: (rewrite <expr> <expr> <option>*)"),
+        },
+        "birewrite" => match tail {
+            [lhs, rhs, options @ ..] => {
+                let lhs = expr(lhs)?;
+                let rhs = expr(rhs)?;
+
+                let mut ruleset = "".into();
+                let mut conditions = Vec::new();
+                let mut i = 0;
+                while i < options.len() {
+                    match options[i].expect_atom("rewrite option")?.into() {
+                        ":ruleset" => {
+                            i += 1;
+                            ruleset = options[i].expect_atom("ruleset name")?;
+                        }
+                        ":when" => {
+                            i += 1;
+                            conditions =
+                                map_fallible(options[i].expect_list("rewrite conditions")?, fact)?;
+                        }
+                        _ => return error!(options[i].span(), "could not parse rewrite option"),
+                    }
+                    i += 1;
+                }
+
+                Command::BiRewrite(
+                    ruleset,
+                    Rewrite {
+                        span,
+                        lhs,
+                        rhs,
+                        conditions,
+                    },
+                )
+            }
+            _ => return error!(span, "usage: (birewrite <expr> <expr> <option>*)"),
+        },
+        "run" => {
+            if tail.is_empty() {
+                return error!(span, "usage: (run <ruleset>? <uint> <:until (<fact>*)>?)");
+            }
+
+            let has_ruleset = tail.len() >= 2 && tail[1].expect_uint("").is_ok();
+
+            let (ruleset, limit, options) = if has_ruleset {
+                (
+                    tail[0].expect_atom("ruleset name")?,
+                    tail[1].expect_uint("number of iterations")?,
+                    &tail[2..],
+                )
+            } else {
+                (
+                    "".into(),
+                    tail[0].expect_uint("number of iterations")?,
+                    &tail[1..],
+                )
+            };
+
+            let until = match options {
+                [] => None,
+                [Sexp::Atom(o, _), facts @ ..] if *o == ":until".into() => {
+                    Some(map_fallible(facts, fact)?)
+                }
+                _ => return error!(span, "could not parse run options"),
+            };
+
+            Command::RunSchedule(Schedule::Repeat(
+                span.clone(),
+                limit,
+                Box::new(Schedule::Run(span, RunConfig { ruleset, until })),
+            ))
+        }
+        "run-schedule" => {
+            Command::RunSchedule(Schedule::Sequence(span, map_fallible(tail, schedule)?))
+        }
+        "simplify" => match tail {
+            [s, e] => Command::Simplify {
+                span,
+                schedule: schedule(s)?,
+                expr: expr(e)?,
+            },
+            _ => return error!(span, "usage: (simplify <schedule> <expr>)"),
+        },
+        "query-extract" => match tail {
+            [options @ .., e] => {
+                let variants = match options {
+                    [] => 0,
+                    [Sexp::Atom(o, _), v] if *o == ":variants".into() => {
+                        v.expect_uint("number of variants")?
+                    }
+                    _ => return error!(span, "could not parse query-extract options"),
+                };
+                Command::QueryExtract {
+                    span,
+                    expr: expr(e)?,
+                    variants,
+                }
+            }
+            _ => return error!(span, "usage: (query-extract <:variants <uint>>? <expr>)"),
+        },
+        "check" => Command::Check(span, map_fallible(tail, fact)?),
+        "push" => match tail {
+            [] => Command::Push(1),
+            [n] => Command::Push(n.expect_uint("number of times to push")?),
+            _ => return error!(span, "usage: (push <uint>?)"),
+        },
+        "pop" => match tail {
+            [] => Command::Pop(span, 1),
+            [n] => Command::Pop(span, n.expect_uint("number of times to pop")?),
+            _ => return error!(span, "usage: (pop <uint>?)"),
+        },
+        "print-stats" => match tail {
+            [] => Command::PrintOverallStatistics,
+            _ => return error!(span, "usage: (print-stats)"),
+        },
+        "print-function" => match tail {
+            [name, rows] => Command::PrintFunction(
+                span,
+                name.expect_atom("table name")?,
+                rows.expect_uint("number of rows to print")?,
+            ),
+            _ => {
+                return error!(
+                    span,
+                    "usage: (print-function <table name> <number of rows>)"
+                )
+            }
+        },
+        "print-size" => match tail {
+            [] => Command::PrintSize(span, None),
+            [name] => Command::PrintSize(span, Some(name.expect_atom("table name")?)),
+            _ => return error!(span, "usage: (print-size <table name>?)"),
+        },
+        "input" => match tail {
+            [name, file] => Command::Input {
+                span,
+                name: name.expect_atom("table name")?,
+                file: file.expect_string("file name")?,
+            },
+            _ => return error!(span, "usage: (input <table name> \"<file name>\")"),
+        },
+        "output" => match tail {
+            [file, exprs @ ..] => Command::Output {
+                span,
+                file: file.expect_string("file name")?,
+                exprs: map_fallible(exprs, expr)?,
+            },
+            _ => return error!(span, "usage: (output <file name> <expr>+)"),
+        },
+        "include" => match tail {
+            [file] => Command::Include(span, file.expect_string("file name")?),
+            _ => return error!(span, "usage: (include <file name>)"),
+        },
+        "fail" => match tail {
+            [subcommand] => Command::Fail(span, Box::new(command(subcommand)?)),
+            _ => return error!(span, "usage: (fail <command>)"),
+        },
+        _ => Command::Action(action(sexp)?),
+    })
+}
+
+fn schema(input: &Sexp, output: &Sexp) -> Result<Schema, ParseError> {
+    Ok(Schema {
+        input: map_fallible(input.expect_list("input sorts")?, |sexp| {
+            sexp.expect_atom("input sort")
+        })?,
+        output: output.expect_atom("output sort")?,
+    })
+}
+
+fn rec_datatype(sexp: &Sexp) -> Result<(Span, Symbol, Subdatatypes), ParseError> {
+    let (head, tail, span) = sexp.expect_call("datatype")?;
+
+    Ok(match head.into() {
+        "sort" => match tail {
+            [name, call] => {
+                let name = name.expect_atom("sort name")?;
+                let (func, args, _) = call.expect_call("container sort declaration")?;
+                let args = map_fallible(args, expr)?;
+                (span, name, Subdatatypes::NewSort(func, args))
+            }
+            _ => {
+                return error!(
+                    span,
+                    "usage: (sort <name> (<container sort> <argument sort>*))"
+                )
+            }
+        },
+        _ => {
+            let variants = map_fallible(tail, variant)?;
+            (span, head, Subdatatypes::Variants(variants))
+        }
+    })
+}
+
+fn variant(sexp: &Sexp) -> Result<Variant, ParseError> {
+    let (name, tail, span) = sexp.expect_call("datatype variant")?;
+
+    let (types, cost) = match tail {
+        [types @ .., Sexp::Atom(o, _), c] if *o == ":cost".into() => {
+            (types, Some(c.expect_uint("cost")?))
+        }
+        types => (types, None),
+    };
+
+    Ok(Variant {
+        span,
+        name,
+        types: map_fallible(types, |sexp| sexp.expect_atom("variant argument type"))?,
+        cost,
+    })
+}
+
+fn schedule(sexp: &Sexp) -> Result<Schedule, ParseError> {
+    if let Sexp::Atom(ruleset, span) = sexp {
+        return Ok(Schedule::Run(
+            span.clone(),
+            RunConfig {
+                ruleset: *ruleset,
+                until: None,
+            },
+        ));
+    }
+
+    let (head, tail, span) = sexp.expect_call("schedule")?;
+
+    Ok(match head.into() {
+        "saturate" => Schedule::Saturate(
+            span.clone(),
+            Box::new(Schedule::Sequence(span, map_fallible(tail, schedule)?)),
+        ),
+        "seq" => Schedule::Sequence(span, map_fallible(tail, schedule)?),
+        "repeat" => match tail {
+            [limit, tail @ ..] => Schedule::Repeat(
+                span.clone(),
+                limit.expect_uint("number of iterations")?,
+                Box::new(Schedule::Sequence(span, map_fallible(tail, schedule)?)),
+            ),
+            _ => return error!(span, "usage: (repeat <number of iterations> <schedule>*)"),
+        },
+        "run" => {
+            let has_ruleset = match tail.first() {
+                None => false,
+                Some(Sexp::Atom(o, _)) if *o == ":until".into() => false,
+                _ => true,
+            };
+
+            let (ruleset, options) = if has_ruleset {
+                (tail[0].expect_atom("ruleset name")?, &tail[1..])
+            } else {
+                ("".into(), tail)
+            };
+
+            let until = match options {
+                [] => None,
+                [Sexp::Atom(o, _), facts @ ..] if *o == ":until".into() => {
+                    Some(map_fallible(facts, fact)?)
+                }
+                _ => return error!(span, "could not parse run options"),
+            };
+
+            Schedule::Run(span, RunConfig { ruleset, until })
+        }
+        _ => return error!(span, "expected either saturate, seq, repeat, or run"),
+    })
+}
+
+fn action(sexp: &Sexp) -> Result<Action, ParseError> {
+    let (head, tail, span) = sexp.expect_call("action")?;
+
+    Ok(match head.into() {
+        "let" => match tail {
+            [name, value] => Action::Let(span, name.expect_atom("binding name")?, expr(value)?),
+            _ => return error!(span, "usage: (let <name> <expr>)"),
+        },
+        "set" => match tail {
+            [call, value] => {
+                let (func, args, _) = call.expect_call("table lookup")?;
+                let args = map_fallible(args, expr)?;
+                let value = expr(value)?;
+                Action::Set(span, func, args, value)
+            }
+            _ => return error!(span, "usage: (set (<table name> <expr>*) <expr>)"),
+        },
+        "delete" => match tail {
+            [call] => {
+                let (func, args, _) = call.expect_call("table lookup")?;
+                let args = map_fallible(args, expr)?;
+                Action::Change(span, Change::Delete, func, args)
+            }
+            _ => return error!(span, "usage: (delete (<table name> <expr>*))"),
+        },
+        "subsume" => match tail {
+            [call] => {
+                let (func, args, _) = call.expect_call("table lookup")?;
+                let args = map_fallible(args, expr)?;
+                Action::Change(span, Change::Subsume, func, args)
+            }
+            _ => return error!(span, "usage: (subsume (<table name> <expr>*))"),
+        },
+        "union" => match tail {
+            [e1, e2] => Action::Union(span, expr(e1)?, expr(e2)?),
+            _ => return error!(span, "usage: (union <expr> <expr>)"),
+        },
+        "panic" => match tail {
+            [message] => Action::Panic(span, message.expect_string("error message")?),
+            _ => return error!(span, "usage: (panic <string>)"),
+        },
+        "extract" => match tail {
+            [e] => Action::Extract(span.clone(), expr(e)?, Expr::Lit(span, Literal::Int(0))),
+            [e, v] => Action::Extract(span, expr(e)?, expr(v)?),
+            _ => return error!(span, "usage: (extract <expr> <number of variants>?)"),
+        },
+        _ => Action::Expr(span, expr(sexp)?),
+    })
+}
+
+fn fact(sexp: &Sexp) -> Result<Fact, ParseError> {
+    let (head, tail, span) = sexp.expect_call("fact")?;
+
+    Ok(match head.into() {
+        "=" => match tail {
+            [_, _, ..] => Fact::Eq(span, map_fallible(tail, expr)?),
+            _ => return error!(span, "using = with less than two arguments is not allowed"),
+        },
+        _ => Fact::Fact(expr(sexp)?),
+    })
+}
+
+fn expr(sexp: &Sexp) -> Result<Expr, ParseError> {
+    Ok(match sexp {
+        Sexp::Literal(literal, span) => Expr::Lit(span.clone(), literal.clone()),
+        Sexp::Atom(symbol, span) => Expr::Var(span.clone(), *symbol),
+        Sexp::List(..) => {
+            let (func, args, span) = sexp.expect_call("call expression")?;
+            Expr::Call(span.clone(), func, map_fallible(args, expr)?)
+        }
+    })
+}
+
 #[derive(Clone, Debug)]
 struct Context {
     source: Arc<SrcFile>,
@@ -159,7 +772,7 @@ impl<T, F: Fn(&Context) -> Res<T> + Clone> Parser<T> for F {}
 fn ident(ctx: &Context) -> Res<Symbol> {
     let mut span = ctx.span();
     if ctx.index >= ctx.source.contents.len() {
-        return Err(ParseError::EndOfFile(span));
+        return error!(span, "unexpected end of file");
     }
 
     let mut next = ctx.clone();
@@ -167,7 +780,7 @@ fn ident(ctx: &Context) -> Res<Symbol> {
         match next.current_char() {
             None => break,
             Some(c) if c.is_alphanumeric() => {}
-            Some(c) if "-+*/?!=<>&|^/%_.".contains(c) => {}
+            Some(c) if "-+*/?!=<>&|^/%_.:".contains(c) => {}
             Some(_) => break,
         }
         next.advance_char();
@@ -175,7 +788,7 @@ fn ident(ctx: &Context) -> Res<Symbol> {
     span.2 = next.index;
 
     if span.1 == span.2 {
-        Err(ParseError::Ident(span))
+        error!(span, "expected identifier")
     } else {
         next.advance_past_whitespace();
         Ok((Symbol::from(span.string()), span, next))
@@ -193,7 +806,7 @@ fn text(s: &'static str) -> impl Parser<()> {
             next.advance_past_whitespace();
             Ok(((), span, next))
         } else {
-            Err(ParseError::Text(span, s))
+            error!(span, "expected \"{s}\"")
         }
     }
 }
@@ -246,509 +859,25 @@ fn sequence<T, U>(a: impl Parser<T>, b: impl Parser<U>) -> impl Parser<(T, U)> {
     }
 }
 
-macro_rules! sequences {
-    ( $x:expr ) => { $x };
-    ( $x:expr , $( $xs:expr ),+ $(,)? ) => {
-        sequence( $x, sequences!( $( $xs ),+ ) )
-    };
-}
-
-fn sequence3<T, U, V>(
-    a: impl Parser<T>,
-    b: impl Parser<U>,
-    c: impl Parser<V>,
-) -> impl Parser<(T, U, V)> {
-    map(sequences!(a, b, c), |(a, (b, c)), _| (a, b, c))
-}
-
-fn sequence4<T, U, V, W>(
-    a: impl Parser<T>,
-    b: impl Parser<U>,
-    c: impl Parser<V>,
-    d: impl Parser<W>,
-) -> impl Parser<(T, U, V, W)> {
-    map(sequences!(a, b, c, d), |(a, (b, (c, d))), _| (a, b, c, d))
-}
-
-fn option<T>(parser: impl Parser<T>) -> impl Parser<Option<T>> {
-    move |ctx| match parser(ctx) {
-        Ok((x, span, next)) => Ok((Some(x), span, next)),
-        Err(_) => Ok((None, ctx.span(), ctx.clone())),
-    }
-}
-
 fn parens<T>(f: impl Parser<T>) -> impl Parser<T> {
     map(
         choice(
-            sequence3(text("["), f.clone(), text("]")),
-            sequence3(text("("), f, text(")")),
+            sequence(text("["), sequence(f.clone(), text("]"))),
+            sequence(text("("), sequence(f, text(")"))),
         ),
-        |((), x, ()), _| x,
+        |((), (x, ())), _| x,
     )
 }
 
-fn program(ctx: &Context) -> Res<Vec<Command>> {
-    repeat_until(command, |ctx| ctx.index == ctx.source.contents.len())(ctx)
+fn all_sexps(ctx: &Context) -> Res<Vec<Sexp>> {
+    repeat_until(sexp, |ctx| ctx.index == ctx.source.contents.len())(ctx)
 }
 
-fn rec_datatype(ctx: &Context) -> Res<(Span, Symbol, Subdatatypes)> {
-    choice(
-        map(
-            parens(sequence3(
-                text("sort"),
-                ident,
-                parens(sequence(ident, repeat_until_end_paren(expr))),
-            )),
-            |((), name, (head, exprs)), span| (span, name, Subdatatypes::NewSort(head, exprs)),
-        ),
-        map(
-            parens(sequence(ident, repeat_until_end_paren(variant))),
-            |(name, variants), span| (span, name, Subdatatypes::Variants(variants)),
-        ),
-    )(ctx)
-}
-
-fn list<T>(f: impl Parser<T>) -> impl Parser<Vec<T>> {
-    parens(repeat_until_end_paren(f))
-}
-
-fn snd<T, U>(x: Option<(T, U)>, _span: Span) -> Option<U> {
-    x.map(|(_, x)| x)
-}
-
-fn ident_after_paren(ctx: &Context) -> &str {
-    match sequence(choice(text("("), text("[")), ident)(ctx) {
-        Ok((((), symbol), _, _)) => symbol.into(),
-        Err(_) => "",
-    }
-}
-
-fn command(ctx: &Context) -> Res<Command> {
-    match ident_after_paren(ctx) {
-        "set-option" => map(
-            parens(sequence3(text("set-option"), ident, expr)),
-            |((), name, value), _| Command::SetOption { name, value },
-        )(ctx),
-        "datatype" => map(
-            parens(sequence3(
-                text("datatype"),
-                ident,
-                repeat_until_end_paren(variant),
-            )),
-            |((), name, variants), span| Command::Datatype {
-                span,
-                name,
-                variants,
-            },
-        )(ctx),
-        "sort" => choice(
-            map(
-                parens(sequence3(
-                    text("sort"),
-                    ident,
-                    parens(sequence(ident, repeat_until_end_paren(expr))),
-                )),
-                |((), name, (head, tail)), span| Command::Sort(span, name, Some((head, tail))),
-            ),
-            map(parens(sequence(text("sort"), ident)), |((), name), span| {
-                Command::Sort(span, name, None)
-            }),
-        )(ctx),
-        "datatype*" => map(
-            parens(sequence(
-                text("datatype*"),
-                repeat_until_end_paren(rec_datatype),
-            )),
-            |((), datatypes), span| Command::Datatypes { span, datatypes },
-        )(ctx),
-        "function" => map(
-            parens(sequences!(
-                text("function"),
-                ident,
-                schema,
-                choice(
-                    map(sequence(text(":merge"), expr), |((), x), _| Some(x)),
-                    map(text(":no-merge"), |(), _| None)
-                ),
-            )),
-            |((), (name, (schema, merge))), span| Command::Function {
-                span,
-                name,
-                schema,
-                merge,
-            },
-        )(ctx),
-        "constructor" => map(
-            parens(sequences!(
-                text("constructor"),
-                ident,
-                schema,
-                cost,
-                map(option(text(":unextractable")), |x, _| x.is_some()),
-            )),
-            |((), (name, (schema, (cost, unextractable)))), span| Command::Constructor {
-                span,
-                name,
-                schema,
-                cost,
-                unextractable,
-            },
-        )(ctx),
-        "relation" => map(
-            parens(sequence3(text("relation"), ident, list(r#type))),
-            |((), constructor, inputs), span| Command::Relation {
-                span,
-                constructor,
-                inputs,
-            },
-        )(ctx),
-        "ruleset" => map(parens(sequence(text("ruleset"), ident)), |((), name), _| {
-            Command::AddRuleset(name)
-        })(ctx),
-        "unstable-combined-ruleset" => map(
-            parens(sequence3(
-                text("unstable-combined-ruleset"),
-                ident,
-                repeat_until_end_paren(ident),
-            )),
-            |((), name, subrulesets), _| Command::UnstableCombinedRuleset(name, subrulesets),
-        )(ctx),
-        "rule" => map(
-            parens(sequences!(
-                text("rule"),
-                list(fact),
-                map(list(action), |x, _| Actions::new(x)),
-                map(option(sequence(text(":ruleset"), ident)), snd),
-                map(option(sequence(text(":name"), string)), snd),
-            )),
-            |((), (body, (head, (ruleset, name)))), span| Command::Rule {
-                ruleset: ruleset.unwrap_or("".into()),
-                name: name.unwrap_or("".to_string()).into(),
-                rule: Rule { span, head, body },
-            },
-        )(ctx),
-        "rewrite" => map(
-            parens(sequences!(
-                text("rewrite"),
-                expr,
-                expr,
-                map(option(text(":subsume")), |x, _| x.is_some()),
-                map(option(sequence(text(":when"), list(fact))), snd),
-                map(option(sequence(text(":ruleset"), ident)), snd),
-            )),
-            |((), (lhs, (rhs, (subsume, (conditions, ruleset))))), span| {
-                Command::Rewrite(
-                    ruleset.unwrap_or("".into()),
-                    Rewrite {
-                        span,
-                        lhs,
-                        rhs,
-                        conditions: conditions.unwrap_or_default(),
-                    },
-                    subsume,
-                )
-            },
-        )(ctx),
-        "birewrite" => map(
-            parens(sequences!(
-                text("birewrite"),
-                expr,
-                expr,
-                map(option(sequence(text(":when"), list(fact))), snd),
-                map(option(sequence(text(":ruleset"), ident)), snd),
-            )),
-            |((), (lhs, (rhs, (conditions, ruleset)))), span| {
-                Command::BiRewrite(
-                    ruleset.unwrap_or("".into()),
-                    Rewrite {
-                        span,
-                        lhs,
-                        rhs,
-                        conditions: conditions.unwrap_or_default(),
-                    },
-                )
-            },
-        )(ctx),
-        "let" => map(
-            parens(sequence3(text("let"), ident, expr)),
-            |((), name, expr), span| Command::Action(Action::Let(span, name, expr)),
-        )(ctx),
-        "run" => choice(
-            map(
-                parens(sequence3(
-                    text("run"),
-                    unum,
-                    map(
-                        option(sequence(text(":until"), repeat_until_end_paren(fact))),
-                        snd,
-                    ),
-                )),
-                |((), limit, until), span| {
-                    Command::RunSchedule(Schedule::Repeat(
-                        span.clone(),
-                        limit,
-                        Box::new(Schedule::Run(
-                            span,
-                            RunConfig {
-                                ruleset: "".into(),
-                                until,
-                            },
-                        )),
-                    ))
-                },
-            ),
-            map(
-                parens(sequence4(
-                    text("run"),
-                    ident,
-                    unum,
-                    map(
-                        option(sequence(text(":until"), repeat_until_end_paren(fact))),
-                        snd,
-                    ),
-                )),
-                |((), ruleset, limit, until), span| {
-                    Command::RunSchedule(Schedule::Repeat(
-                        span.clone(),
-                        limit,
-                        Box::new(Schedule::Run(span, RunConfig { ruleset, until })),
-                    ))
-                },
-            ),
-        )(ctx),
-        "simplify" => map(
-            parens(sequence3(text("simplify"), schedule, expr)),
-            |((), schedule, expr), span| Command::Simplify {
-                span,
-                expr,
-                schedule,
-            },
-        )(ctx),
-        "query-extract" => map(
-            parens(sequence3(
-                text("query-extract"),
-                map(option(sequence(text(":variants"), unum)), snd),
-                expr,
-            )),
-            |((), variants, expr), span| Command::QueryExtract {
-                span,
-                expr,
-                variants: variants.unwrap_or(0),
-            },
-        )(ctx),
-        "check" => map(
-            parens(sequence(text("check"), repeat_until_end_paren(fact))),
-            |((), facts), span| Command::Check(span, facts),
-        )(ctx),
-        "run-schedule" => map(
-            parens(sequence(
-                text("run-schedule"),
-                repeat_until_end_paren(schedule),
-            )),
-            |((), scheds), span| Command::RunSchedule(Schedule::Sequence(span, scheds)),
-        )(ctx),
-        "print-stats" => map(parens(text("print-stats")), |(), _| {
-            Command::PrintOverallStatistics
-        })(ctx),
-        "push" => map(
-            parens(sequence(text("push"), option(unum))),
-            |((), n), _| Command::Push(n.unwrap_or(1)),
-        )(ctx),
-        "pop" => map(
-            parens(sequence(text("pop"), option(unum))),
-            |((), n), span| Command::Pop(span, n.unwrap_or(1)),
-        )(ctx),
-        "print-function" => map(
-            parens(sequence3(text("print-function"), ident, unum)),
-            |((), sym, n), span| Command::PrintFunction(span, sym, n),
-        )(ctx),
-        "print-size" => map(
-            parens(sequence(text("print-size"), option(ident))),
-            |((), sym), span| Command::PrintSize(span, sym),
-        )(ctx),
-        "input" => map(
-            parens(sequence3(text("input"), ident, string)),
-            |((), name, file), span| Command::Input { span, name, file },
-        )(ctx),
-        "output" => map(
-            parens(sequence4(
-                text("output"),
-                string,
-                expr,
-                repeat_until_end_paren(expr),
-            )),
-            |((), file, e, mut exprs), span| {
-                exprs.insert(0, e);
-                Command::Output { span, file, exprs }
-            },
-        )(ctx),
-        "fail" => map(parens(sequence(text("fail"), command)), |((), c), span| {
-            Command::Fail(span, Box::new(c))
-        })(ctx),
-        "include" => map(
-            parens(sequence(text("include"), string)),
-            |((), file), span| Command::Include(span, file),
-        )(ctx),
-        _ => map(non_let_action, |action, _| Command::Action(action))(ctx),
-    }
-}
-
-fn schedule(ctx: &Context) -> Res<Schedule> {
-    match ident_after_paren(ctx) {
-        "saturate" => map(
-            parens(sequence(text("saturate"), repeat_until_end_paren(schedule))),
-            |((), scheds), span| {
-                Schedule::Saturate(span.clone(), Box::new(Schedule::Sequence(span, scheds)))
-            },
-        )(ctx),
-        "seq" => map(
-            parens(sequence(text("seq"), repeat_until_end_paren(schedule))),
-            |((), scheds), span| Schedule::Sequence(span, scheds),
-        )(ctx),
-        "repeat" => map(
-            parens(sequence3(
-                text("repeat"),
-                unum,
-                repeat_until_end_paren(schedule),
-            )),
-            |((), limit, scheds), span| {
-                Schedule::Repeat(
-                    span.clone(),
-                    limit,
-                    Box::new(Schedule::Sequence(span, scheds)),
-                )
-            },
-        )(ctx),
-        "run" => choice(
-            map(
-                parens(sequence(
-                    text("run"),
-                    map(
-                        option(sequence(text(":until"), repeat_until_end_paren(fact))),
-                        snd,
-                    ),
-                )),
-                |((), until), span| {
-                    Schedule::Run(
-                        span,
-                        RunConfig {
-                            ruleset: "".into(),
-                            until,
-                        },
-                    )
-                },
-            ),
-            map(
-                parens(sequence3(
-                    text("run"),
-                    ident,
-                    map(
-                        option(sequence(text(":until"), repeat_until_end_paren(fact))),
-                        snd,
-                    ),
-                )),
-                |((), ruleset, until), span| Schedule::Run(span, RunConfig { ruleset, until }),
-            ),
-        )(ctx),
-        _ => map(ident, |ruleset, span| {
-            Schedule::Run(
-                span.clone(),
-                RunConfig {
-                    ruleset,
-                    until: None,
-                },
-            )
-        })(ctx),
-    }
-}
-
-fn cost(ctx: &Context) -> Res<Option<usize>> {
-    map(option(sequence(text(":cost"), unum)), snd)(ctx)
-}
-
-fn action(ctx: &Context) -> Res<Action> {
-    choice(
-        map(
-            parens(sequence3(text("let"), ident, expr)),
-            |((), name, expr), span| Action::Let(span, name, expr),
-        ),
-        non_let_action,
-    )(ctx)
-}
-
-fn non_let_action(ctx: &Context) -> Res<Action> {
-    match ident_after_paren(ctx) {
-        "set" => map(
-            parens(sequence3(
-                text("set"),
-                parens(sequence(ident, repeat_until_end_paren(expr))),
-                expr,
-            )),
-            |((), (f, args), v), span| Action::Set(span, f, args, v),
-        )(ctx),
-        "delete" => map(
-            parens(sequence(
-                text("delete"),
-                parens(sequence(ident, repeat_until_end_paren(expr))),
-            )),
-            |((), (f, args)), span| Action::Change(span, Change::Delete, f, args),
-        )(ctx),
-        "subsume" => map(
-            parens(sequence(
-                text("subsume"),
-                parens(sequence(ident, repeat_until_end_paren(expr))),
-            )),
-            |((), (f, args)), span| Action::Change(span, Change::Subsume, f, args),
-        )(ctx),
-        "union" => map(
-            parens(sequence3(text("union"), expr, expr)),
-            |((), e1, e2), span| Action::Union(span, e1, e2),
-        )(ctx),
-        "panic" => map(parens(sequence(text("panic"), string)), |(_, msg), span| {
-            Action::Panic(span, msg)
-        })(ctx),
-        "extract" => choice(
-            map(
-                parens(sequence(text("extract"), expr)),
-                |((), expr), span| {
-                    Action::Extract(span.clone(), expr, Expr::Lit(span, Literal::Int(0)))
-                },
-            ),
-            map(
-                parens(sequence3(text("extract"), expr, expr)),
-                |((), expr, variants), span| Action::Extract(span, expr, variants),
-            ),
-        )(ctx),
-        _ => map(call_expr, |e, span| Action::Expr(span, e))(ctx),
-    }
-}
-
-fn fact(ctx: &Context) -> Res<Fact> {
-    let (call_expr, span, next) = call_expr(ctx)?;
-    match call_expr {
-        Expr::Call(_, head, ref tail) => {
-            let fact = match head.into() {
-                "=" if tail.len() < 2 => return Err(ParseError::EqFactLt2(span)),
-                "=" => Fact::Eq(span.clone(), tail.clone()),
-                _ => Fact::Fact(call_expr),
-            };
-            Ok((fact, span, next))
-        }
-        _ => unreachable!(),
-    }
-}
-
-fn schema(ctx: &Context) -> Res<Schema> {
-    map(sequence(list(r#type), r#type), |(input, output), _| {
-        Schema { input, output }
-    })(ctx)
-}
-
-fn expr(ctx: &Context) -> Res<Expr> {
+fn sexp(ctx: &Context) -> Res<Sexp> {
     choices!(
-        call_expr,
-        map(literal, |literal, span| Expr::Lit(span, literal)),
-        map(ident, |ident, span| Expr::Var(span, ident)),
+        map(literal, Sexp::Literal),
+        map(ident, Sexp::Atom),
+        map(parens(repeat_until_end_paren(sexp)), Sexp::List),
     )(ctx)
 }
 
@@ -767,50 +896,15 @@ fn r#bool(ctx: &Context) -> Res<bool> {
     match span.string() {
         "true" => Ok((true, span, next)),
         "false" => Ok((false, span, next)),
-        _ => Err(ParseError::Bool(span)),
+        _ => error!(span, "expected boolean literal"),
     }
-}
-
-fn call_expr(ctx: &Context) -> Res<Expr> {
-    map(
-        parens(sequence(ident, repeat_until_end_paren(expr))),
-        |(head, tail), span| Expr::Call(span, head, tail),
-    )(ctx)
-}
-
-fn variant(ctx: &Context) -> Res<Variant> {
-    map(
-        parens(sequence3(
-            ident,
-            repeat_until(r#type, |ctx| r#type(ctx).is_err()),
-            cost,
-        )),
-        |(name, types, cost), span| Variant {
-            span,
-            name,
-            types,
-            cost,
-        },
-    )(ctx)
-}
-
-fn r#type(ctx: &Context) -> Res<Symbol> {
-    ident(ctx)
 }
 
 fn num(ctx: &Context) -> Res<i64> {
     let (_, span, next) = ident(ctx)?;
     match span.string().parse::<i64>() {
         Ok(x) => Ok((x, span, next)),
-        Err(_) => Err(ParseError::Int(span)),
-    }
-}
-
-fn unum(ctx: &Context) -> Res<usize> {
-    let (_, span, next) = ident(ctx)?;
-    match span.string().parse::<usize>() {
-        Ok(x) => Ok((x, span, next)),
-        Err(_) => Err(ParseError::Int(span)),
+        Err(_) => error!(span, "expected integer literal"),
     }
 }
 
@@ -822,11 +916,11 @@ fn r#f64(ctx: &Context) -> Res<OrderedFloat<f64>> {
         "inf" => Ok((OrderedFloat(f64::INFINITY), span, next)),
         "-inf" => Ok((OrderedFloat(f64::NEG_INFINITY), span, next)),
         _ => match span.string().parse::<f64>() {
-            Err(_) => Err(ParseError::Float(span)),
+            Err(_) => error!(span, "expected floating point literal"),
             // Rust will parse "infinity" as a float, which we don't want
             // we're only using `parse` to avoid implementing it ourselves anyway
             Ok(x) => match x.classify() {
-                Nan | Infinite => Err(ParseError::Float(span)),
+                Nan | Infinite => error!(span, "expected floating point literal"),
                 Zero | Subnormal | Normal => Ok((OrderedFloat(x), span, next)),
             },
         },
@@ -836,7 +930,7 @@ fn r#f64(ctx: &Context) -> Res<OrderedFloat<f64>> {
 fn string(ctx: &Context) -> Res<String> {
     let mut span = Span(ctx.source.clone(), ctx.index, ctx.index);
     if ctx.current_char() != Some('"') {
-        return Err(ParseError::String(span));
+        return error!(span, "expected string literal");
     }
 
     let mut next = ctx.clone();
@@ -847,7 +941,7 @@ fn string(ctx: &Context) -> Res<String> {
         match next.current_char() {
             None => {
                 span.2 = next.index;
-                return Err(ParseError::MissingEndQuote(span));
+                return error!(span, "string is missing end quote");
             }
             Some('"') if !in_escape => break,
             Some('\\') if !in_escape => in_escape = true,
@@ -865,30 +959,6 @@ fn string(ctx: &Context) -> Res<String> {
     let s = span.string();
     let s = &s[1..s.len() - 1];
     Ok((s.to_string(), span, next))
-}
-
-#[derive(Debug, Error)]
-pub enum ParseError {
-    #[error("{0}\nexpected \"{1}\"")]
-    Text(Span, &'static str),
-    #[error("{0}\nexpected string")]
-    String(Span),
-    #[error("{0}\nmissing end quote for string")]
-    MissingEndQuote(Span),
-    #[error("{0}\nunexpected end of file")]
-    EndOfFile(Span),
-    #[error("{0}\nexpected identifier")]
-    Ident(Span),
-    #[error("{0}\nexpected integer literal")]
-    Int(Span),
-    #[error("{0}\nexpected unsigned integer literal")]
-    Uint(Span),
-    #[error("{0}\nexpected floating point literal")]
-    Float(Span),
-    #[error("{0}\nexpected boolean literal")]
-    Bool(Span),
-    #[error("{0}\nusing = with less than two arguments is not allowed")]
-    EqFactLt2(Span),
 }
 
 #[cfg(test)]

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -153,10 +153,8 @@ impl<'a> GlobalRemover<'a> {
                     .map(|(old, new)| {
                         GenericFact::Eq(
                             new.span(),
-                            vec![
-                                GenericExpr::Call(new.span(), resolved_var_to_call(old), vec![]),
-                                new.clone(),
-                            ],
+                            GenericExpr::Call(new.span(), resolved_var_to_call(old), vec![]),
+                            new.clone(),
                         )
                     })
                     .collect();

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -288,12 +288,10 @@ impl Assignment<AtomTerm, ArcSort> {
         typeinfo: &TypeInfo,
     ) -> ResolvedFact {
         match facts {
-            GenericFact::Eq(span, facts) => ResolvedFact::Eq(
+            GenericFact::Eq(span, e1, e2) => ResolvedFact::Eq(
                 span.clone(),
-                facts
-                    .iter()
-                    .map(|expr| self.annotate_expr(expr, typeinfo))
-                    .collect(),
+                self.annotate_expr(e1, typeinfo),
+                self.annotate_expr(e2, typeinfo),
             ),
             GenericFact::Fact(expr) => ResolvedFact::Fact(self.annotate_expr(expr, typeinfo)),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,7 +678,7 @@ impl EGraph {
     pub fn eval_lit(&self, lit: &Literal) -> Value {
         match lit {
             Literal::Int(i) => i.store(&I64Sort).unwrap(),
-            Literal::F64(f) => f.store(&F64Sort).unwrap(),
+            Literal::Float(f) => f.store(&F64Sort).unwrap(),
             Literal::String(s) => s.store(&StringSort).unwrap(),
             Literal::Unit => ().store(&UnitSort).unwrap(),
             Literal::Bool(b) => b.store(&BoolSort).unwrap(),
@@ -1356,7 +1356,7 @@ impl EGraph {
                 match s.parse::<i64>() {
                     Ok(i) => Expr::Lit(span.clone(), Literal::Int(i)),
                     Err(_) => match s.parse::<f64>() {
-                        Ok(f) => Expr::Lit(span.clone(), Literal::F64(f.into())),
+                        Ok(f) => Expr::Lit(span.clone(), Literal::Float(f.into())),
                         Err(_) => Expr::Lit(span.clone(), Literal::String(s.into())),
                     },
                 }

--- a/src/sort/f64.rs
+++ b/src/sort/f64.rs
@@ -58,7 +58,7 @@ impl Sort for F64Sort {
             1,
             GenericExpr::Lit(
                 DUMMY_SPAN.clone(),
-                Literal::F64(OrderedFloat(f64::from_bits(value.bits))),
+                Literal::Float(OrderedFloat(f64::from_bits(value.bits))),
             ),
         )
     }

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -219,7 +219,7 @@ impl PrimitiveLike for ValueEq {
 pub fn literal_sort(lit: &Literal) -> ArcSort {
     match lit {
         Literal::Int(_) => Arc::new(I64Sort) as ArcSort,
-        Literal::F64(_) => Arc::new(F64Sort) as ArcSort,
+        Literal::Float(_) => Arc::new(F64Sort) as ArcSort,
         Literal::String(_) => Arc::new(StringSort) as ArcSort,
         Literal::Bool(_) => Arc::new(BoolSort) as ArcSort,
         Literal::Unit => Arc::new(UnitSort) as ArcSort,

--- a/tests/cyk.egg
+++ b/tests/cyk.egg
@@ -91,7 +91,7 @@
 (check (P 5 1 (NonTerm "S")))
 (fail (check (P 5 1 (NonTerm "B"))))
 (let test2 (B 5 1 (NonTerm "S")))
-(query-extract:variants 10  test2)
+(query-extract :variants 10 test2)
 
 (pop)
 


### PR DESCRIPTION
Fixes #488.

Implements an S-expression based parser, greatly improving error messages in the process. For example, we now print usage strings if the parser is unable to recognize a specific command.