### PR TITLE
Use SmallVec::from_slice instead of .into()

### DIFF
--- a/src/function/table.rs
+++ b/src/function/table.rs
@@ -185,7 +185,7 @@ impl Table {
         }
         let new_offset = self.vals.len();
         self.vals.push((
-            Input::new(inputs.into()),
+            Input::new(ValueVec::from_slice(inputs)),
             TupleOutput {
                 value: on_merge(None),
                 timestamp: ts,


### PR DESCRIPTION
Small performance gain since the generic From/Extend implementations do not (cannot) specialize on Copy vs Clone types.