### PR TITLE
Refactor sort extraction API

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -154,8 +154,8 @@ impl<'a> Extractor<'a> {
             let (cost, node) = self.costs.get(&id)?.clone();
             Some((cost, node))
         } else {
-            let (cost, node) = sort.extract_expr(self.egraph, value, self, termdag)?;
-            Some((cost, termdag.expr_to_term(&node)))
+            let (cost, node) = sort.extract_term(self.egraph, value, self, termdag)?;
+            Some((cost, node))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -711,7 +711,12 @@ impl EGraph {
                 if a_type.is_eq_sort() {
                     children.push(extractor.find_best(a, &mut termdag, a_type).unwrap().1);
                 } else {
-                    children.push(termdag.expr_to_term(&a_type.make_expr(self, a).1));
+                    children.push(
+                        a_type
+                            .extract_term(self, a, &extractor, &mut termdag)
+                            .unwrap()
+                            .1,
+                    )
                 };
             }
 
@@ -721,7 +726,11 @@ impl EGraph {
                     .unwrap()
                     .1
             } else {
-                termdag.expr_to_term(&schema.output.make_expr(self, out.value).1)
+                schema
+                    .output
+                    .extract_term(self, out.value, &extractor, &mut termdag)
+                    .unwrap()
+                    .1
             };
             terms.push((termdag.app(sym, children), out));
         }

--- a/src/sort/bigint.rs
+++ b/src/sort/bigint.rs
@@ -63,21 +63,20 @@ impl Sort for BigIntSort {
         add_primitives!(eg, "from-string" = |a: Symbol| -> Opt<Z> { a.as_str().parse::<Z>().ok() });
    }
 
-    fn make_expr(&self, _egraph: &EGraph, value: Value) -> (Cost, Expr) {
+    fn extract_term(
+        &self,
+        _egraph: &EGraph,
+        value: Value,
+        _extractor: &Extractor,
+        termdag: &mut TermDag,
+    ) -> Option<(Cost, Term)> {
         #[cfg(debug_assertions)]
         debug_assert_eq!(value.tag, self.name());
 
         let bigint = Z::load(self, &value);
-        (
-            1,
-            Expr::call_no_span(
-                "from-string",
-                vec![GenericExpr::Lit(
-                    DUMMY_SPAN.clone(),
-                    Literal::String(bigint.to_string().into()),
-                )],
-            ),
-        )
+
+        let as_string = termdag.lit(Literal::String(bigint.to_string().into()));
+        Some((1, termdag.app("from-string".into(), vec![as_string])))
     }
 }
 

--- a/src/sort/bool.rs
+++ b/src/sort/bool.rs
@@ -27,14 +27,17 @@ impl Sort for BoolSort {
         add_primitives!(eg, "=>" = |a: bool, b: bool| -> bool { !a || b });
     }
 
-    fn make_expr(&self, _egraph: &EGraph, value: Value) -> (Cost, Expr) {
+    fn extract_term(
+        &self,
+        _egraph: &EGraph,
+        value: Value,
+        _extractor: &Extractor,
+        termdag: &mut TermDag,
+    ) -> Option<(Cost, Term)> {
         #[cfg(debug_assertions)]
         debug_assert_eq!(value.tag, self.name());
 
-        (
-            1,
-            GenericExpr::Lit(DUMMY_SPAN.clone(), Literal::Bool(value.bits > 0)),
-        )
+        Some((1, termdag.lit(Literal::Bool(value.bits > 0))))
     }
 }
 

--- a/src/sort/f64.rs
+++ b/src/sort/f64.rs
@@ -50,17 +50,20 @@ impl Sort for F64Sort {
 
     }
 
-    fn make_expr(&self, _egraph: &EGraph, value: Value) -> (Cost, Expr) {
+    fn extract_term(
+        &self,
+        _egraph: &EGraph,
+        value: Value,
+        _extractor: &Extractor,
+        termdag: &mut TermDag,
+    ) -> Option<(Cost, Term)> {
         #[cfg(debug_assertions)]
         debug_assert_eq!(value.tag, self.name());
 
-        (
+        Some((
             1,
-            GenericExpr::Lit(
-                DUMMY_SPAN.clone(),
-                Literal::Float(OrderedFloat(f64::from_bits(value.bits))),
-            ),
-        )
+            termdag.lit(Literal::Float(OrderedFloat(f64::from_bits(value.bits)))),
+        ))
     }
 }
 

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -185,34 +185,24 @@ impl Sort for FunctionSort {
         });
     }
 
-    fn make_expr(&self, egraph: &EGraph, value: Value) -> (Cost, Expr) {
-        let mut termdag = TermDag::default();
-        let extractor = Extractor::new(egraph, &mut termdag);
-        self.extract_expr(egraph, value, &extractor, &mut termdag)
-            .expect("Extraction should be successful since extractor has been fully initialized")
-    }
-
-    fn extract_expr(
+    fn extract_term(
         &self,
         _egraph: &EGraph,
         value: Value,
         extractor: &Extractor,
         termdag: &mut TermDag,
-    ) -> Option<(Cost, Expr)> {
+    ) -> Option<(Cost, Term)> {
         let ValueFunction(name, inputs) = ValueFunction::load(self, &value);
         let (cost, args) = inputs.into_iter().try_fold(
-            (
-                1usize,
-                vec![GenericExpr::Lit(DUMMY_SPAN.clone(), Literal::String(name))],
-            ),
+            (1usize, vec![termdag.lit(Literal::String(name))]),
             |(cost, mut args), (sort, value)| {
                 let (new_cost, term) = extractor.find_best(value, termdag, &sort)?;
-                args.push(termdag.term_to_expr(&term));
+                args.push(term);
                 Some((cost.saturating_add(new_cost), args))
             },
         )?;
 
-        Some((cost, Expr::call_no_span("unstable-fn", args)))
+        Some((cost, termdag.app("unstable-fn".into(), args)))
     }
 }
 

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -70,14 +70,14 @@ impl Sort for I64Sort {
 
     }
 
-    fn make_expr(&self, _egraph: &EGraph, value: Value) -> (Cost, Expr) {
-        #[cfg(debug_assertions)]
-        debug_assert_eq!(value.tag, self.name());
-
-        (
-            1,
-            GenericExpr::Lit(DUMMY_SPAN.clone(), Literal::Int(value.bits as _)),
-        )
+    fn extract_term(
+        &self,
+        _egraph: &EGraph,
+        value: Value,
+        _extractor: &Extractor,
+        termdag: &mut TermDag,
+    ) -> Option<(Cost, Term)> {
+        Some((1, termdag.lit(Literal::Int(value.bits as _))))
     }
 }
 

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -168,33 +168,23 @@ impl Sort for MapSort {
         });
     }
 
-    fn make_expr(&self, egraph: &EGraph, value: Value) -> (Cost, Expr) {
-        let mut termdag = TermDag::default();
-        let extractor = Extractor::new(egraph, &mut termdag);
-        self.extract_expr(egraph, value, &extractor, &mut termdag)
-            .expect("Extraction should be successful since extractor has been fully initialized")
-    }
-
-    fn extract_expr(
+    fn extract_term(
         &self,
         _egraph: &EGraph,
         value: Value,
         extractor: &Extractor,
         termdag: &mut TermDag,
-    ) -> Option<(Cost, Expr)> {
+    ) -> Option<(Cost, Term)> {
         let map = ValueMap::load(self, &value);
-        let mut expr = Expr::call_no_span("map-empty", []);
+        let mut term = termdag.app("map-empty".into(), vec![]);
         let mut cost = 0usize;
         for (k, v) in map.iter().rev() {
             let k = extractor.find_best(*k, termdag, &self.key)?;
             let v = extractor.find_best(*v, termdag, &self.value)?;
             cost = cost.saturating_add(k.0).saturating_add(v.0);
-            expr = Expr::call_no_span(
-                "map-insert",
-                [expr, termdag.term_to_expr(&k.1), termdag.term_to_expr(&v.1)],
-            )
+            term = termdag.app("map-insert".into(), vec![term, k.1, v.1]);
         }
-        Some((cost, expr))
+        Some((cost, term))
     }
 }
 

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -105,18 +105,6 @@ pub trait Sort: Any + Send + Sync + Debug {
         _extractor: &Extractor,
         _termdag: &mut TermDag,
     ) -> Option<(Cost, Term)>;
-
-    /// Extracting an expression (with smallest cost) out of a primitive value.
-    /// The default implementation uses [`Sort::extract_term`].
-    fn make_expr(&self, egraph: &EGraph, value: Value) -> (Cost, Expr) {
-        let mut termdag = TermDag::default();
-        let extractor = Extractor::new(egraph, &mut termdag);
-        let (cost, term) = self
-            .extract_term(egraph, value, &extractor, &mut termdag)
-            .expect("Extraction should be successful since extractor has been fully initialized");
-
-        (cost, termdag.term_to_expr(&term))
-    }
 }
 
 // Note: this trait is currently intended to be implemented on the

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -97,22 +97,25 @@ pub trait Sort: Any + Send + Sync + Debug {
         let _ = info;
     }
 
-    /// Extracting an expression (with smallest cost) out of a primitive value
-    fn make_expr(&self, egraph: &EGraph, value: Value) -> (Cost, Expr);
-
-    /// For values like EqSort containers, to make/extract an expression from it
-    /// requires an extractor. Moreover, the extraction may be unsuccessful if
-    /// the extractor is not fully initialized.
-    ///
-    /// The default behavior is to call make_expr
-    fn extract_expr(
+    /// Extracting a term (with smallest cost) out of a primitive value
+    fn extract_term(
         &self,
         egraph: &EGraph,
         value: Value,
         _extractor: &Extractor,
         _termdag: &mut TermDag,
-    ) -> Option<(Cost, Expr)> {
-        Some(self.make_expr(egraph, value))
+    ) -> Option<(Cost, Term)>;
+
+    /// Extracting an expression (with smallest cost) out of a primitive value.
+    /// The default implementation uses [`Sort::extract_term`].
+    fn make_expr(&self, egraph: &EGraph, value: Value) -> (Cost, Expr) {
+        let mut termdag = TermDag::default();
+        let extractor = Extractor::new(egraph, &mut termdag);
+        let (cost, term) = self
+            .extract_term(egraph, value, &extractor, &mut termdag)
+            .expect("Extraction should be successful since extractor has been fully initialized");
+
+        (cost, termdag.term_to_expr(&term))
     }
 }
 
@@ -161,8 +164,14 @@ impl Sort for EqSort {
         }
     }
 
-    fn make_expr(&self, _egraph: &EGraph, _value: Value) -> (Cost, Expr) {
-        unimplemented!("No make_expr for EqSort {}", self.name)
+    fn extract_term(
+        &self,
+        _egraph: &EGraph,
+        _value: Value,
+        _extractor: &Extractor,
+        _termdag: &mut TermDag,
+    ) -> Option<(Cost, Term)> {
+        unimplemented!("No extract_term for EqSort {}", self.name)
     }
 }
 

--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -20,15 +20,18 @@ impl Sort for StringSort {
         self
     }
 
-    fn make_expr(&self, _egraph: &EGraph, value: Value) -> (Cost, Expr) {
+    fn extract_term(
+        &self,
+        _egraph: &EGraph,
+        value: Value,
+        _extractor: &Extractor,
+        termdag: &mut TermDag,
+    ) -> Option<(Cost, Term)> {
         #[cfg(debug_assertions)]
         debug_assert_eq!(value.tag, self.name());
 
         let sym = Symbol::from(NonZeroU32::new(value.bits as _).unwrap());
-        (
-            1,
-            GenericExpr::Lit(DUMMY_SPAN.clone(), Literal::String(sym)),
-        )
+        Some((1, termdag.lit(Literal::String(sym))))
     }
 
     fn register_primitives(self: Arc<Self>, typeinfo: &mut TypeInfo) {

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -21,14 +21,14 @@ impl Sort for UnitSort {
         type_info.add_primitive(NotEqualPrimitive { unit: self })
     }
 
-    fn make_expr(&self, _egraph: &EGraph, value: Value) -> (Cost, Expr) {
-        #[cfg(debug_assertions)]
-        debug_assert_eq!(value.tag, self.name());
-
-        #[cfg(not(debug_assertions))]
-        let _ = value;
-
-        (1, GenericExpr::Lit(DUMMY_SPAN.clone(), Literal::Unit))
+    fn extract_term(
+        &self,
+        _egraph: &EGraph,
+        _value: Value,
+        _extractor: &Extractor,
+        termdag: &mut TermDag,
+    ) -> Option<(Cost, Term)> {
+        Some((1, termdag.lit(Literal::Unit)))
     }
 }
 


### PR DESCRIPTION
[Zulip thread](https://egraphs.zulipchat.com/#narrow/channel/375765-egg.2Fegglog/topic/bottleneck.20in.20run_program.20function)

This fixes a part of the issue in #492 not concerning stringification. Original test still doesn't run on my computer due to a crash in `TermDag::to_string` (I suspect I don't have enough memory?)

The main contribution here is making extraction for `Sorts` return a `Term` instead of `Expr`. This cuts down the extraction time significantly. I was able to verify this by replacing extraction command with `(extract 1)` in the original test case (this is a meaningful test case since extract command still computes optimal extraction for *all* e-classes).

Ideally this would also get rid of `is_eq_sort` checks by moving that logic to the `extract_expr` for `EqSort`. This is currently impossible since `EGraph::find` accepts `ArcSort`, but I can change it to be `Sort` to make this simplification in this PR as well.