### PR TITLE
Make parser extensible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,6 @@ dependencies = [
  "codspeed-criterion-compat",
  "egraph-serialize",
  "env_logger",
- "generic_symbolic_expressions",
  "getrandom",
  "glob",
  "hashbrown",
@@ -466,12 +465,6 @@ dependencies = [
  "typenum",
  "version_check",
 ]
-
-[[package]]
-name = "generic_symbolic_expressions"
-version = "5.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597eb584fb7cfd1935294fc3608a453fc35a58dfa9da4299c8fd3bc75a4c0b4b"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,6 @@ lazy_static = "1.4"
 num = "0.4.3"
 smallvec = "1.11"
 
-generic_symbolic_expressions = "5.0.4"
-
 egraph-serialize = { version = "0.2.0", default-features = false }
 
 # binary dependencies

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -102,11 +102,11 @@ pub(crate) fn desugar_command(
 
             res
         }
-        Command::Rewrite(ruleset, rewrite, subsume) => {
-            desugar_rewrite(ruleset, rewrite_name(&rewrite).into(), &rewrite, subsume)
+        Command::Rewrite(ruleset, ref rewrite, subsume) => {
+            desugar_rewrite(ruleset, rule_name(&command), rewrite, subsume)
         }
-        Command::BiRewrite(ruleset, rewrite) => {
-            desugar_birewrite(ruleset, rewrite_name(&rewrite).into(), &rewrite)
+        Command::BiRewrite(ruleset, ref rewrite) => {
+            desugar_birewrite(ruleset, rule_name(&command), rewrite)
         }
         Command::Include(span, file) => {
             let s = std::fs::read_to_string(&file)
@@ -120,10 +120,10 @@ pub(crate) fn desugar_command(
         Command::Rule {
             ruleset,
             mut name,
-            rule,
+            ref rule,
         } => {
             if name == "".into() {
-                name = rule.to_string().replace('\"', "'").into();
+                name = rule_name(&command);
             }
 
             let result = vec![NCommand::NormRule {
@@ -349,6 +349,10 @@ fn desugar_simplify(
     res
 }
 
-pub(crate) fn rewrite_name(rewrite: &Rewrite) -> String {
-    rewrite.to_string().replace('\"', "'")
+pub fn rule_name<Head, Leaf>(command: &GenericCommand<Head, Leaf>) -> Symbol
+where
+    Head: Clone + Display,
+    Leaf: Clone + PartialEq + Eq + Hash + Display,
+{
+    command.to_string().replace('\"', "'").into()
 }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1,4 +1,3 @@
-use super::ToSexp;
 use crate::{core::ResolvedCall, *};
 use ordered_float::OrderedFloat;
 use std::{fmt::Display, hash::Hasher};
@@ -94,12 +93,6 @@ impl SymbolLike for ResolvedVar {
 impl Display for ResolvedVar {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name)
-    }
-}
-
-impl ToSexp for ResolvedVar {
-    fn to_sexp(&self) -> Sexp {
-        Sexp::Symbol(self.name.to_string())
     }
 }
 
@@ -250,31 +243,18 @@ impl<Head: Clone + Display, Leaf: Hash + Clone + Display + Eq> GenericExpr<Head,
     }
 }
 
-impl<Head: Display, Leaf: Display> GenericExpr<Head, Leaf> {
-    /// Converts this expression into a
-    /// s-expression (symbolic expression).
-    /// Example: `(Add (Add 2 3) 4)`
-    pub fn to_sexp(&self) -> Sexp {
-        let res = match self {
-            GenericExpr::Lit(_ann, lit) => Sexp::Symbol(lit.to_string()),
-            GenericExpr::Var(_ann, v) => Sexp::Symbol(v.to_string()),
-            GenericExpr::Call(_ann, op, children) => Sexp::List(
-                vec![Sexp::Symbol(op.to_string())]
-                    .into_iter()
-                    .chain(children.iter().map(|c| c.to_sexp()))
-                    .collect(),
-            ),
-        };
-        res
-    }
-}
-
 impl<Head, Leaf> Display for GenericExpr<Head, Leaf>
 where
     Head: Display,
     Leaf: Display,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_sexp())
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            GenericExpr::Lit(_ann, lit) => write!(f, "{lit}"),
+            GenericExpr::Var(_ann, var) => write!(f, "{var}"),
+            GenericExpr::Call(_ann, op, children) => {
+                write!(f, "({} {})", op, ListDisplay(children, " "))
+            }
+        }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -7,10 +7,8 @@ use crate::{
     core::{GenericAtom, GenericAtomTerm, HeadOrEq, Query, ResolvedCall},
     *,
 };
-use ::core::fmt;
 pub use expr::*;
 pub use parse::*;
-use std::fmt::Display;
 pub use symbol_table::GlobalSymbol as Symbol;
 
 #[derive(Clone, Debug)]
@@ -231,46 +229,6 @@ pub enum GenericSchedule<Head, Leaf> {
     Sequence(Span, Vec<GenericSchedule<Head, Leaf>>),
 }
 
-pub trait ToSexp {
-    fn to_sexp(&self) -> Sexp;
-}
-
-impl ToSexp for str {
-    fn to_sexp(&self) -> Sexp {
-        Sexp::Symbol(String::from(self))
-    }
-}
-
-impl ToSexp for Symbol {
-    fn to_sexp(&self) -> Sexp {
-        Sexp::Symbol(self.to_string())
-    }
-}
-
-impl ToSexp for usize {
-    fn to_sexp(&self) -> Sexp {
-        Sexp::Symbol(self.to_string())
-    }
-}
-
-impl ToSexp for Sexp {
-    fn to_sexp(&self) -> Sexp {
-        self.clone()
-    }
-}
-
-macro_rules! list {
-    ($($e:expr,)* ++ $tail:expr) => {{
-        let mut list: Vec<Sexp> = vec![$($e.to_sexp(),)*];
-        list.extend($tail.iter().map(|e| e.to_sexp()));
-        Sexp::List(list)
-    }};
-    ($($e:expr),*) => {{
-        let list: Vec<Sexp> = vec![ $($e.to_sexp(),)* ];
-        Sexp::List(list)
-    }};
-}
-
 impl<Head, Leaf> GenericSchedule<Head, Leaf>
 where
     Head: Clone + Display,
@@ -296,20 +254,16 @@ where
     }
 }
 
-impl<Head: Display, Leaf: Display> ToSexp for GenericSchedule<Head, Leaf> {
-    fn to_sexp(&self) -> Sexp {
-        match self {
-            GenericSchedule::Saturate(_ann, sched) => list!("saturate", sched),
-            GenericSchedule::Repeat(_ann, size, sched) => list!("repeat", size, sched),
-            GenericSchedule::Run(_ann, config) => config.to_sexp(),
-            GenericSchedule::Sequence(_ann, scheds) => list!("seq", ++ scheds),
-        }
-    }
-}
-
 impl<Head: Display, Leaf: Display> Display for GenericSchedule<Head, Leaf> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_sexp())
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            GenericSchedule::Saturate(_ann, sched) => write!(f, "(saturate {sched})"),
+            GenericSchedule::Repeat(_ann, size, sched) => write!(f, "(repeat {size} {sched})"),
+            GenericSchedule::Run(_ann, config) => write!(f, "{config}"),
+            GenericSchedule::Sequence(_ann, scheds) => {
+                write!(f, "(seq {})", ListDisplay(scheds, " "))
+            }
+        }
     }
 }
 
@@ -712,27 +666,29 @@ where
     Include(Span, String),
 }
 
-impl<Head, Leaf> ToSexp for GenericCommand<Head, Leaf>
+impl<Head, Leaf> Display for GenericCommand<Head, Leaf>
 where
-    Head: Clone + Display + ToSexp,
-    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
+    Head: Clone + Display,
+    Leaf: Clone + PartialEq + Eq + Display + Hash,
 {
-    fn to_sexp(&self) -> Sexp {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            GenericCommand::SetOption { name, value } => list!("set-option", name, value),
+            GenericCommand::SetOption { name, value } => write!(f, "(set-option {name} {value})"),
             GenericCommand::Rewrite(name, rewrite, subsume) => {
-                rewrite.to_sexp(*name, false, *subsume)
+                rewrite.fmt_with_ruleset(f, *name, false, *subsume)
             }
-            GenericCommand::BiRewrite(name, rewrite) => rewrite.to_sexp(*name, true, false),
+            GenericCommand::BiRewrite(name, rewrite) => {
+                rewrite.fmt_with_ruleset(f, *name, true, false)
+            }
             GenericCommand::Datatype {
                 span: _,
                 name,
                 variants,
-            } => list!("datatype", name, ++ variants),
-            GenericCommand::Action(a) => a.to_sexp(),
-            GenericCommand::Sort(_span, name, None) => list!("sort", name),
+            } => write!(f, "(datatype {name} {})", ListDisplay(variants, " ")),
+            GenericCommand::Action(a) => write!(f, "{a}"),
+            GenericCommand::Sort(_span, name, None) => write!(f, "(sort {name})"),
             GenericCommand::Sort(_span, name, Some((name2, args))) => {
-                list!("sort", name, list!( name2, ++ args))
+                write!(f, "(sort {name} ({name2} {}))", ListDisplay(args, " "))
             }
             GenericCommand::Function {
                 span: _,
@@ -740,25 +696,13 @@ where
                 schema,
                 merge,
             } => {
-                let mut res = vec![
-                    Sexp::Symbol("function".into()),
-                    Sexp::Symbol(name.to_string()),
-                ];
-
-                if let Sexp::List(contents) = schema.to_sexp() {
-                    res.extend(contents);
-                } else {
-                    unreachable!();
-                }
-
+                write!(f, "(function {name} {schema}")?;
                 if let Some(merge) = &merge {
-                    res.push(Sexp::Symbol(":merge".into()));
-                    res.push(merge.to_sexp());
+                    write!(f, " :merge {merge}")?;
                 } else {
-                    res.push(Sexp::Symbol(":no-merge".into()));
+                    write!(f, " :no-merge")?;
                 }
-
-                Sexp::List(res)
+                write!(f, ")")
             }
             GenericCommand::Constructor {
                 span: _,
@@ -767,121 +711,86 @@ where
                 cost,
                 unextractable,
             } => {
-                let mut res = vec![
-                    Sexp::Symbol("constructor".into()),
-                    Sexp::Symbol(name.to_string()),
-                ];
-
-                if let Sexp::List(contents) = schema.to_sexp() {
-                    res.extend(contents);
-                } else {
-                    unreachable!();
-                }
-
+                write!(f, "(constructor {name} {schema}")?;
                 if let Some(cost) = cost {
-                    res.extend(vec![
-                        Sexp::Symbol(":cost".into()),
-                        Sexp::Symbol(cost.to_string()),
-                    ]);
+                    write!(f, " :cost {cost}")?;
                 }
-
                 if *unextractable {
-                    res.push(Sexp::Symbol(":unextractable".into()));
+                    write!(f, " :unextractable")?;
                 }
-
-                Sexp::List(res)
+                write!(f, ")")
             }
             GenericCommand::Relation {
                 span: _,
                 name,
                 inputs,
-            } => list!("relation", name, list!(++ inputs)),
-            GenericCommand::AddRuleset(name) => list!("ruleset", name),
+            } => {
+                write!(f, "(relation {name} ({}))", ListDisplay(inputs, " "))
+            }
+            GenericCommand::AddRuleset(name) => write!(f, "(ruleset {name})"),
             GenericCommand::UnstableCombinedRuleset(name, others) => {
-                list!("unstable-combined-ruleset", name, ++ others)
+                write!(
+                    f,
+                    "(unstable-combined-ruleset {name} {})",
+                    ListDisplay(others, " ")
+                )
             }
-            GenericCommand::Rule {
-                name,
-                ruleset,
-                rule,
-            } => rule.to_sexp(*ruleset, *name),
-            GenericCommand::RunSchedule(sched) => list!("run-schedule", sched),
-            GenericCommand::PrintOverallStatistics => list!("print-stats"),
-            GenericCommand::QueryExtract {
-                span: _,
-                variants,
-                expr,
-            } => {
-                list!("query-extract", ":variants", variants, expr)
-            }
-            GenericCommand::Check(_ann, facts) => list!("check", ++ facts),
-            GenericCommand::Push(n) => list!("push", n),
-            GenericCommand::Pop(_span, n) => list!("pop", n),
-            GenericCommand::PrintFunction(_span, name, n) => list!("print-function", name, n),
-            GenericCommand::PrintSize(_span, name) => list!("print-size", ++ name),
-            GenericCommand::Input {
-                span: _,
-                name,
-                file,
-            } => {
-                list!("input", name, format!("\"{}\"", file))
-            }
-            GenericCommand::Output {
-                span: _,
-                file,
-                exprs,
-            } => {
-                list!("output", format!("\"{}\"", file), ++ exprs)
-            }
-            GenericCommand::Fail(_span, cmd) => list!("fail", cmd),
-            GenericCommand::Include(_span, file) => list!("include", format!("\"{}\"", file)),
-            GenericCommand::Simplify {
-                span: _,
-                expr,
-                schedule,
-            } => list!("simplify", schedule, expr),
-            GenericCommand::Datatypes { span: _, datatypes } => {
-                let datatypes: Vec<_> = datatypes
-                    .iter()
-                    .map(|(_, name, variants)| match variants {
-                        Subdatatypes::Variants(variants) => list!(name, ++ variants),
-                        Subdatatypes::NewSort(head, args) => {
-                            list!("sort", name, list!(head, ++ args))
-                        }
-                    })
-                    .collect();
-                list!("datatype*", ++ datatypes)
-            }
-        }
-    }
-}
-
-impl<Head, Leaf> Display for GenericNCommand<Head, Leaf>
-where
-    Head: Clone + Display + ToSexp,
-    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_command())
-    }
-}
-
-impl<Head, Leaf> Display for GenericCommand<Head, Leaf>
-where
-    Head: Clone + Display + ToSexp,
-    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
             GenericCommand::Rule {
                 ruleset,
                 name,
                 rule,
             } => rule.fmt_with_ruleset(f, *ruleset, *name),
+            GenericCommand::RunSchedule(sched) => write!(f, "(run-schedule {sched})"),
+            GenericCommand::PrintOverallStatistics => write!(f, "(print-stats)"),
+            GenericCommand::QueryExtract {
+                span: _,
+                variants,
+                expr,
+            } => {
+                write!(f, "(query-extract :variants {variants} {expr})")
+            }
             GenericCommand::Check(_ann, facts) => {
                 write!(f, "(check {})", ListDisplay(facts, "\n"))
             }
-            _ => write!(f, "{}", self.to_sexp()),
+            GenericCommand::Push(n) => write!(f, "(push {n})"),
+            GenericCommand::Pop(_span, n) => write!(f, "(pop {n})"),
+            GenericCommand::PrintFunction(_span, name, n) => {
+                write!(f, "(print-function {name} {n})")
+            }
+            GenericCommand::PrintSize(_span, name) => {
+                write!(f, "(print-size {})", ListDisplay(name, " "))
+            }
+            GenericCommand::Input {
+                span: _,
+                name,
+                file,
+            } => write!(f, "(input {name} {file:?})"),
+            GenericCommand::Output {
+                span: _,
+                file,
+                exprs,
+            } => write!(f, "(output {file:?} {})", ListDisplay(exprs, " ")),
+            GenericCommand::Fail(_span, cmd) => write!(f, "(fail {cmd})"),
+            GenericCommand::Include(_span, file) => write!(f, "(include {file:?})"),
+            GenericCommand::Simplify {
+                span: _,
+                expr,
+                schedule,
+            } => write!(f, "(simplify {schedule} {expr})"),
+            GenericCommand::Datatypes { span: _, datatypes } => {
+                let datatypes: Vec<_> = datatypes
+                    .iter()
+                    .map(|(_, name, variants)| match variants {
+                        Subdatatypes::Variants(variants) => {
+                            format!("({name} {})", ListDisplay(variants, " "))
+                        }
+                        Subdatatypes::NewSort(head, args) => {
+                            format!("(sort {name} ({head} {}))", ListDisplay(args, " "))
+                        }
+                    })
+                    .collect();
+                write!(f, "(datatype* {})", ListDisplay(datatypes, " "))
+            }
         }
     }
 }
@@ -892,15 +801,9 @@ pub struct IdentSort {
     pub sort: Symbol,
 }
 
-impl ToSexp for IdentSort {
-    fn to_sexp(&self) -> Sexp {
-        list!(self.ident, self.sort)
-    }
-}
-
 impl Display for IdentSort {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_sexp())
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "({} {})", self.ident, self.sort)
     }
 }
 
@@ -931,22 +834,20 @@ where
     }
 }
 
-impl<Head: Display, Leaf: Display> ToSexp for GenericRunConfig<Head, Leaf>
+impl<Head: Display, Leaf: Display> Display for GenericRunConfig<Head, Leaf>
 where
     Head: Display,
     Leaf: Display,
 {
-    fn to_sexp(&self) -> Sexp {
-        let mut res = vec![Sexp::Symbol("run".into())];
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "(run")?;
         if self.ruleset != "".into() {
-            res.push(Sexp::Symbol(self.ruleset.to_string()));
+            write!(f, " {}", self.ruleset)?;
         }
         if let Some(until) = &self.until {
-            res.push(Sexp::Symbol(":until".into()));
-            res.extend(until.iter().map(|fact| fact.to_sexp()));
+            write!(f, " :until {}", ListDisplay(until, " "))?;
         }
-
-        Sexp::List(res)
+        write!(f, ")")
     }
 }
 
@@ -960,8 +861,8 @@ pub enum FunctionSubtype {
     Custom,
 }
 
-impl fmt::Display for FunctionSubtype {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl Display for FunctionSubtype {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             FunctionSubtype::Constructor => write!(f, "Constructor"),
             FunctionSubtype::Relation => write!(f, "Relation"),
@@ -998,17 +899,16 @@ pub struct Variant {
     pub cost: Option<usize>,
 }
 
-impl ToSexp for Variant {
-    fn to_sexp(&self) -> Sexp {
-        let mut res = vec![Sexp::Symbol(self.name.to_string())];
+impl Display for Variant {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "({}", self.name)?;
         if !self.types.is_empty() {
-            res.extend(self.types.iter().map(|s| Sexp::Symbol(s.to_string())));
+            write!(f, " {}", ListDisplay(&self.types, " "))?;
         }
         if let Some(cost) = self.cost {
-            res.push(Sexp::Symbol(":cost".into()));
-            res.push(Sexp::Symbol(cost.to_string()));
+            write!(f, " :cost {cost}")?;
         }
-        Sexp::List(res)
+        write!(f, ")")
     }
 }
 
@@ -1018,9 +918,9 @@ pub struct Schema {
     pub output: Symbol,
 }
 
-impl ToSexp for Schema {
-    fn to_sexp(&self) -> Sexp {
-        list!(list!(++ self.input), self.output)
+impl Display for Schema {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "({}) {}", ListDisplay(&self.input, " "), self.output)
     }
 }
 
@@ -1107,44 +1007,6 @@ where
     }
 }
 
-impl<Head, Leaf> ToSexp for GenericFunctionDecl<Head, Leaf>
-where
-    Head: Clone + Display + ToSexp,
-    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
-{
-    // Not used
-    fn to_sexp(&self) -> Sexp {
-        let mut res = vec![
-            Sexp::Symbol(self.subtype.to_string()),
-            Sexp::Symbol(self.name.to_string()),
-        ];
-
-        if let Sexp::List(contents) = self.schema.to_sexp() {
-            res.extend(contents);
-        } else {
-            unreachable!();
-        }
-
-        if let Some(cost) = self.cost {
-            res.extend(vec![
-                Sexp::Symbol(":cost".into()),
-                Sexp::Symbol(cost.to_string()),
-            ]);
-        }
-
-        if self.unextractable {
-            res.push(Sexp::Symbol(":unextractable".into()));
-        }
-
-        if let Some(merge) = &self.merge {
-            res.push(Sexp::Symbol(":merge".into()));
-            res.push(merge.to_sexp());
-        }
-
-        Sexp::List(res)
-    }
-}
-
 pub type Fact = GenericFact<Symbol, Symbol>;
 pub(crate) type ResolvedFact = GenericFact<ResolvedCall, ResolvedVar>;
 pub(crate) type MappedFact<Head, Leaf> = GenericFact<CorrespondingVar<Head, Leaf>, Leaf>;
@@ -1220,15 +1082,11 @@ where
     }
 }
 
-impl<Head: Display, Leaf: Display> ToSexp for GenericFact<Head, Leaf>
-where
-    Head: Display,
-    Leaf: Display,
-{
-    fn to_sexp(&self) -> Sexp {
+impl<Head: Display, Leaf: Display> Display for GenericFact<Head, Leaf> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            GenericFact::Eq(_, e1, e2) => list!("=", e1, e2),
-            GenericFact::Fact(expr) => expr.to_sexp(),
+            GenericFact::Eq(_, e1, e2) => write!(f, "(= {e1} {e2})"),
+            GenericFact::Fact(expr) => write!(f, "{expr}"),
         }
     }
 }
@@ -1286,16 +1144,6 @@ where
     }
 }
 
-impl<Head, Leaf> Display for GenericFact<Head, Leaf>
-where
-    Head: Display,
-    Leaf: Display,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_sexp())
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CorrespondingVar<Head, Leaf>
 where
@@ -1321,7 +1169,7 @@ where
     Head: Clone + Display,
     Leaf: Clone + PartialEq + Eq + Display + Hash,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{} -> {}", self.head, self.to)
     }
 }
@@ -1429,28 +1277,30 @@ where
     }
 }
 
-impl<Head, Leaf> ToSexp for GenericAction<Head, Leaf>
+impl<Head, Leaf> Display for GenericAction<Head, Leaf>
 where
-    Head: Clone + Display + ToSexp,
-    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
+    Head: Clone + Display,
+    Leaf: Clone + PartialEq + Eq + Display + Hash,
 {
-    fn to_sexp(&self) -> Sexp {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            GenericAction::Let(_ann, lhs, rhs) => list!("let", lhs, rhs),
-            GenericAction::Set(_ann, lhs, args, rhs) => list!("set", list!(lhs, ++ args), rhs),
-            GenericAction::Union(_ann, lhs, rhs) => list!("union", lhs, rhs),
-            GenericAction::Change(_ann, change, lhs, args) => {
-                list!(
-                    match change {
-                        Change::Delete => "delete",
-                        Change::Subsume => "subsume",
-                    },
-                    list!(lhs, ++ args)
-                )
+            GenericAction::Let(_ann, lhs, rhs) => write!(f, "(let {lhs} {rhs})"),
+            GenericAction::Set(_ann, lhs, args, rhs) => {
+                write!(f, "(set ({lhs} {}) {rhs})", ListDisplay(args, " "))
             }
-            GenericAction::Extract(_ann, expr, variants) => list!("extract", expr, variants),
-            GenericAction::Panic(_ann, msg) => list!("panic", format!("\"{}\"", msg.clone())),
-            GenericAction::Expr(_ann, e) => e.to_sexp(),
+            GenericAction::Union(_ann, lhs, rhs) => write!(f, "(union {lhs} {rhs})"),
+            GenericAction::Change(_ann, change, lhs, args) => {
+                let change = match change {
+                    Change::Delete => "delete",
+                    Change::Subsume => "subsume",
+                };
+                write!(f, "({change} ({lhs} {}))", ListDisplay(args, " "))
+            }
+            GenericAction::Extract(_ann, expr, variants) => {
+                write!(f, "(extract {expr} {variants})")
+            }
+            GenericAction::Panic(_ann, msg) => write!(f, "(panic {msg:?})"),
+            GenericAction::Expr(_ann, e) => write!(f, "{e}"),
         }
     }
 }
@@ -1576,16 +1426,6 @@ where
     }
 }
 
-impl<Head, Leaf> Display for GenericAction<Head, Leaf>
-where
-    Head: Clone + Display + ToSexp,
-    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_sexp())
-    }
-}
-
 #[derive(Clone, Debug)]
 pub(crate) struct CompiledRule {
     pub(crate) query: CompiledQuery,
@@ -1629,12 +1469,12 @@ where
 
 impl<Head, Leaf> GenericRule<Head, Leaf>
 where
-    Head: Clone + Display + ToSexp,
-    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
+    Head: Clone + Display,
+    Leaf: Clone + PartialEq + Eq + Display + Hash,
 {
     pub(crate) fn fmt_with_ruleset(
         &self,
-        f: &mut std::fmt::Formatter<'_>,
+        f: &mut Formatter,
         ruleset: Symbol,
         name: Symbol,
     ) -> std::fmt::Result {
@@ -1676,40 +1516,6 @@ where
     }
 }
 
-impl<Head, Leaf> GenericRule<Head, Leaf>
-where
-    Head: Clone + Display + ToSexp,
-    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
-{
-    /// Converts this rule into an s-expression.
-    pub fn to_sexp(&self, ruleset: Symbol, name: Symbol) -> Sexp {
-        let mut res = vec![
-            Sexp::Symbol("rule".into()),
-            Sexp::List(self.body.iter().map(|f| f.to_sexp()).collect()),
-            Sexp::List(self.head.0.iter().map(|a| a.to_sexp()).collect()),
-        ];
-        if ruleset != "".into() {
-            res.push(Sexp::Symbol(":ruleset".into()));
-            res.push(Sexp::Symbol(ruleset.to_string()));
-        }
-        if name != "".into() {
-            res.push(Sexp::Symbol(":name".into()));
-            res.push(Sexp::Symbol(format!("\"{}\"", name)));
-        }
-        Sexp::List(res)
-    }
-}
-
-impl<Head, Leaf> Display for GenericRule<Head, Leaf>
-where
-    Head: Clone + Display + ToSexp,
-    Leaf: Clone + PartialEq + Eq + Display + Hash + ToSexp,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.fmt_with_ruleset(f, "".into(), "".into())
-    }
-}
-
 pub type Rewrite = GenericRewrite<Symbol, Symbol>;
 
 #[derive(Clone, Debug)]
@@ -1722,38 +1528,29 @@ pub struct GenericRewrite<Head, Leaf> {
 
 impl<Head: Display, Leaf: Display> GenericRewrite<Head, Leaf> {
     /// Converts the rewrite into an s-expression.
-    pub fn to_sexp(&self, ruleset: Symbol, is_bidirectional: bool, subsume: bool) -> Sexp {
-        let mut res = vec![
-            Sexp::Symbol(if is_bidirectional {
-                "birewrite".into()
-            } else {
-                "rewrite".into()
-            }),
-            self.lhs.to_sexp(),
-            self.rhs.to_sexp(),
-        ];
+    pub fn fmt_with_ruleset(
+        &self,
+        f: &mut Formatter,
+        ruleset: Symbol,
+        is_bidirectional: bool,
+        subsume: bool,
+    ) -> std::fmt::Result {
+        let direction = if is_bidirectional {
+            "birewrite"
+        } else {
+            "rewrite"
+        };
+        write!(f, "({direction} {} {}", self.lhs, self.rhs)?;
         if subsume {
-            res.push(Sexp::Symbol(":subsume".into()));
+            write!(f, " :subsume")?;
         }
-
         if !self.conditions.is_empty() {
-            res.push(Sexp::Symbol(":when".into()));
-            res.push(Sexp::List(
-                self.conditions.iter().map(|f| f.to_sexp()).collect(),
-            ));
+            write!(f, " :when ({})", ListDisplay(&self.conditions, " "))?;
         }
-
         if ruleset != "".into() {
-            res.push(Sexp::Symbol(":ruleset".into()));
-            res.push(Sexp::Symbol(ruleset.to_string()));
+            write!(f, " :ruleset {ruleset}")?;
         }
-        Sexp::List(res)
-    }
-}
-
-impl<Head: Display, Leaf: Display> Display for GenericRewrite<Head, Leaf> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_sexp("".into(), false, false))
+        write!(f, ")")
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -125,12 +125,6 @@ impl Display for ResolvedCall {
     }
 }
 
-impl ToSexp for ResolvedCall {
-    fn to_sexp(&self) -> Sexp {
-        Sexp::Symbol(self.to_string())
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum GenericAtomTerm<Leaf> {
     Var(Span, Leaf),

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -119,7 +119,7 @@ impl Function {
             let (actions, mapped_expr) = merge_expr.to_core_actions(
                 &egraph.type_info,
                 &mut binding.clone(),
-                &mut egraph.symbol_gen,
+                &mut egraph.parser.symbol_gen,
             )?;
             let target = mapped_expr.get_corresponding_var_or_lit(&egraph.type_info);
             let program = egraph

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1060,11 +1060,10 @@ impl EGraph {
 
     fn add_rule_with_name(
         &mut self,
-        name: String,
+        name: Symbol,
         rule: ast::ResolvedRule,
         ruleset: Symbol,
     ) -> Result<Symbol, Error> {
-        let name = Symbol::from(name);
         let core_rule =
             rule.to_canonicalized_core_rule(&self.type_info, &mut self.parser.symbol_gen)?;
         let (query, actions) = (core_rule.body, core_rule.head);
@@ -1099,7 +1098,11 @@ impl EGraph {
         rule: ast::ResolvedRule,
         ruleset: Symbol,
     ) -> Result<Symbol, Error> {
-        let name = format!("{}", rule);
+        let name = ast::desugar::rule_name(&GenericCommand::Rule {
+            rule: rule.clone(),
+            name: "".into(),
+            ruleset,
+        });
         self.add_rule_with_name(name, rule, ruleset)
     }
 

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -419,7 +419,7 @@ fn call_fn(egraph: &mut EGraph, name: &Symbol, types: Vec<ArcSort>, args: Vec<Va
         .to_core_actions(
             &egraph.type_info,
             &mut binding.clone(),
-            &mut egraph.symbol_gen,
+            &mut egraph.parser.symbol_gen,
         )
         .unwrap();
     let target = mapped_expr.get_corresponding_var_or_lit(&egraph.type_info);

--- a/src/termdag.rs
+++ b/src/termdag.rs
@@ -198,7 +198,7 @@ mod tests {
     use crate::ast::*;
 
     fn parse_term(s: &str) -> (TermDag, Term) {
-        let e = parse_expr(None, s).unwrap();
+        let e = parse_expr(None, s, &Default::default()).unwrap();
         let mut td = TermDag::default();
         let t = td.expr_to_term(&e);
         (td, t)
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn test_to_from_expr() {
         let s = r#"(f (g x y) x y (g x y))"#;
-        let e = parse_expr(None, s).unwrap();
+        let e = parse_expr(None, s, &Default::default()).unwrap();
         let mut td = TermDag::default();
         assert_eq!(td.size(), 0);
         let t = td.expr_to_term(&e);

--- a/src/termdag.rs
+++ b/src/termdag.rs
@@ -226,10 +226,10 @@ mod tests {
             ]
         );
         let e2 = td.term_to_expr(&t);
-        // This is tested using Sexp's equality because e1 and e2 have different
+        // This is tested using string equality because e1 and e2 have different
         // annotations. A better way to test this would be to implement a map_ann
         // function for GenericExpr.
-        assert_eq!(e.to_sexp(), e2.to_sexp()); // roundtrip
+        assert_eq!(format!("{e}"), format!("{e2}")); // roundtrip
     }
 
     #[test]


### PR DESCRIPTION
This PR adds a `Macros` struct that can be used to extend the parser from external crates. This introduces a name conflict with the existing public `Sexp` dependency. Since I don't believe that we need this dependency, I have removed it, which breaks all of the code that depends on the `ToSexp` trait, which is basically just resugaring. Since I do not see the value in resugaring I have removed it. However, I am open to having my mind changed on resugaring, in which case I will reimplement `Display` for the affected structs without using `ToSexp`.