### PR TITLE
Replace `DUMMY_SPAN` with `Span::Panic` and `Span::Rust`

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -130,24 +130,6 @@ impl ResolvedExpr {
     }
 }
 
-impl Expr {
-    pub fn call_no_span(op: impl Into<Symbol>, children: impl IntoIterator<Item = Self>) -> Self {
-        Self::Call(
-            DUMMY_SPAN.clone(),
-            op.into(),
-            children.into_iter().collect(),
-        )
-    }
-
-    pub fn lit_no_span(lit: impl Into<Literal>) -> Self {
-        Self::Lit(DUMMY_SPAN.clone(), lit.into())
-    }
-
-    pub fn var_no_span(v: impl Into<Symbol>) -> Self {
-        Self::Var(DUMMY_SPAN.clone(), v.into())
-    }
-}
-
 impl<Head: Clone + Display, Leaf: Hash + Clone + Display + Eq> GenericExpr<Head, Leaf> {
     pub fn span(&self) -> Span {
         match self {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -130,6 +130,30 @@ impl ResolvedExpr {
     }
 }
 
+#[macro_export]
+macro_rules! call {
+    ($func:expr, $args:expr) => {
+        $crate::ast::GenericExpr::Call($crate::span!(), $func.into(), $args.into_iter().collect())
+    };
+}
+
+#[macro_export]
+macro_rules! lit {
+    ($lit:expr) => {
+        $crate::ast::GenericExpr::Lit($crate::span!(), $lit.into())
+    };
+}
+
+#[macro_export]
+macro_rules! var {
+    ($var:expr) => {
+        $crate::ast::GenericExpr::Var($crate::span!(), $var.into())
+    };
+}
+
+// Rust macro annoyance; see stackoverflow.com/questions/26731243/how-do-i-use-a-macro-across-module-files
+pub use {call, lit, var};
+
 impl<Head: Clone + Display, Leaf: Hash + Clone + Display + Eq> GenericExpr<Head, Leaf> {
     pub fn span(&self) -> Span {
         match self {

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -1034,7 +1034,7 @@ mod tests {
 
     #[test]
     fn rust_span_display() {
-        assert_eq!(format!("{}", span!()), "At 952:34 of src/ast/parse.rs");
+        assert_eq!(format!("{}", span!()), "At 1037:34 of src/ast/parse.rs");
     }
 
     #[test]

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -46,20 +46,48 @@ pub fn parse_expr(
 
 /// A [`Span`] contains the file name and a pair of offsets representing the start and the end.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Span(Arc<SrcFile>, usize, usize);
+pub enum Span {
+    /// Panics if a span is needed. Prefer `Span::Rust` (see `span!`)
+    /// unless this behaviour is explicitly desired.
+    Panic,
+    /// A span from a `.egg` file.
+    /// Constructed by `parse_program` and `parse_expr`.
+    Egglog {
+        file: Arc<SrcFile>,
+        i: usize,
+        j: usize,
+    },
+    /// A span from a `.rs` file. Constructed by the `span!` macro.
+    Rust {
+        file: &'static str,
+        line: u32,
+        column: u32,
+    },
+}
 
-lazy_static::lazy_static! {
-    pub static ref DUMMY_SPAN: Span = Span(Arc::new(SrcFile {name: None, contents: String::new()}), 0, 0);
+#[macro_export]
+macro_rules! span {
+    () => {
+        $crate::ast::Span::Rust {
+            file: file!(),
+            line: line!(),
+            column: column!(),
+        }
+    };
 }
 
 impl Span {
     pub fn string(&self) -> &str {
-        &self.0.contents[self.1..self.2]
+        match self {
+            Span::Panic => panic!("Span::Panic in Span::String"),
+            Span::Rust { .. } => todo!(),
+            Span::Egglog { file, i, j } => &file.contents[*i..*j],
+        }
     }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-struct SrcFile {
+pub struct SrcFile {
     name: Option<String>,
     contents: String,
 }
@@ -70,7 +98,7 @@ struct Location {
 }
 
 impl SrcFile {
-    pub fn get_location(&self, offset: usize) -> Location {
+    fn get_location(&self, offset: usize) -> Location {
         let mut line = 1;
         let mut col = 1;
         for (i, c) in self.contents.char_indices() {
@@ -98,26 +126,34 @@ impl Debug for Span {
 
 impl Display for Span {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let start = self.0.get_location(self.1);
-        let end = self.0.get_location((self.2.saturating_sub(1)).max(self.1));
-        let quote = self.string();
-        match (&self.0.name, start.line == end.line) {
-            (Some(filename), true) => write!(
-                f,
-                "In {}:{}-{} of {filename}: {quote}",
-                start.line, start.col, end.col
-            ),
-            (Some(filename), false) => write!(
-                f,
-                "In {}:{}-{}:{} of {filename}: {quote}",
-                start.line, start.col, end.line, end.col
-            ),
-            (None, false) => write!(
-                f,
-                "In {}:{}-{}:{}: {quote}",
-                start.line, start.col, end.line, end.col
-            ),
-            (None, true) => write!(f, "In {}:{}-{}: {quote}", start.line, start.col, end.col),
+        match self {
+            Span::Panic => panic!("Span::Panic in impl Display"),
+            Span::Rust { file, line, column } => write!(f, "At {line}:{column} of {file}"),
+            Span::Egglog { file, i, j } => {
+                let start = file.get_location(*i);
+                let end = file.get_location((j.saturating_sub(1)).max(*i));
+                let quote = self.string();
+                match (&file.name, start.line == end.line) {
+                    (Some(filename), true) => write!(
+                        f,
+                        "In {}:{}-{} of {filename}: {quote}",
+                        start.line, start.col, end.col
+                    ),
+                    (Some(filename), false) => write!(
+                        f,
+                        "In {}:{}-{}:{} of {filename}: {quote}",
+                        start.line, start.col, end.line, end.col
+                    ),
+                    (None, false) => write!(
+                        f,
+                        "In {}:{}-{}:{}: {quote}",
+                        start.line, start.col, end.line, end.col
+                    ),
+                    (None, true) => {
+                        write!(f, "In {}:{}-{}: {quote}", start.line, start.col, end.col)
+                    }
+                }
+            }
         }
     }
 }
@@ -837,12 +873,12 @@ impl Context {
         self.index == self.source.contents.len()
     }
 
-    fn next(&mut self) -> Result<(Token, Span), ParseError> {
+    fn next(&mut self) -> Result<(Token, (Arc<SrcFile>, usize, usize)), ParseError> {
         self.advance_past_whitespace();
-        let mut span = Span(self.source.clone(), self.index, self.index);
+        let mut span = (self.source.clone(), self.index, self.index);
 
         let Some(c) = self.current_char() else {
-            return error!(span, "unexpected end of file");
+            return error!(s(span), "unexpected end of file");
         };
         self.advance_char();
 
@@ -856,7 +892,7 @@ impl Context {
                 loop {
                     span.2 = self.index;
                     match self.current_char() {
-                        None => return error!(span, "string is missing end quote"),
+                        None => return error!(s(span), "string is missing end quote"),
                         Some('"') if !in_escape => break,
                         Some('\\') if !in_escape => in_escape = true,
                         Some(c) => {
@@ -866,7 +902,7 @@ impl Context {
                                 (true, 't') => '\t',
                                 (true, '\\') => '\\',
                                 (true, c) => {
-                                    return error!(span, "unrecognized escape character {c}")
+                                    return error!(s(span), "unrecognized escape character {c}")
                                 }
                             });
                             in_escape = false;
@@ -898,6 +934,10 @@ impl Context {
     }
 }
 
+fn s((file, i, j): (Arc<SrcFile>, usize, usize)) -> Span {
+    Span::Egglog { file, i, j }
+}
+
 enum Token {
     Open,
     Close,
@@ -906,7 +946,7 @@ enum Token {
 }
 
 fn sexp(ctx: &mut Context) -> Result<Sexp, ParseError> {
-    let mut stack: Vec<(Span, Vec<Sexp>)> = vec![];
+    let mut stack: Vec<((Arc<SrcFile>, usize, usize), Vec<Sexp>)> = vec![];
 
     loop {
         let (token, span) = ctx.next()?;
@@ -918,14 +958,15 @@ fn sexp(ctx: &mut Context) -> Result<Sexp, ParseError> {
             }
             Token::Close => {
                 if stack.is_empty() {
-                    return error!(span, "unexpected `)`");
+                    return error!(s(span), "unexpected `)`");
                 }
                 let (mut list_span, list) = stack.pop().unwrap();
                 list_span.2 = span.2;
-                Sexp::List(list, list_span)
+                Sexp::List(list, s(list_span))
             }
-            Token::String(s) => Sexp::Literal(Literal::String(s), span),
+            Token::String(sym) => Sexp::Literal(Literal::String(sym), s(span)),
             Token::Other => {
+                let span = s(span);
                 let s = span.string();
 
                 if s == "true" {
@@ -980,8 +1021,8 @@ mod tests {
     }
 
     #[test]
-    fn dummy_span_display() {
-        assert_eq!(format!("{}", *super::DUMMY_SPAN), "In 1:1-1: ");
+    fn rust_span_display() {
+        assert_eq!(format!("{}", span!()), "At 940:34 of src/ast/parse.rs");
     }
 
     #[test]

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,17 +1,7 @@
 use crate::{
-    ast::{
-        GenericAction, GenericActions, GenericExpr, GenericFact, MappedAction, ResolvedAction,
-        ResolvedActions, ResolvedExpr, ResolvedFact, ResolvedVar,
-    },
-    core::{
-        Atom, AtomTerm, CoreAction, CoreRule, GenericCoreActions, Query, ResolvedCall, SymbolOrEq,
-    },
-    sort::I64Sort,
-    typechecking::TypeError,
-    util::{FreshGen, HashSet, SymbolGen},
-    ArcSort, CorrespondingVar, Span, Symbol, TypeInfo, DUMMY_SPAN,
+    core::{Atom, CoreAction, CoreRule, GenericCoreActions, Query, SymbolOrEq},
+    *,
 };
-use core::{hash::Hash, panic};
 // Use immutable hashmap for performance
 // cloning assignments is common and O(1) with immutable hashmap
 use im_rc::HashMap;
@@ -243,7 +233,7 @@ impl Assignment<AtomTerm, ArcSort> {
                 let ty = global_ty
                     .clone()
                     // Span is ignored when looking up atom_terms
-                    .or_else(|| self.get(&AtomTerm::Var(DUMMY_SPAN.clone(), *var)).cloned())
+                    .or_else(|| self.get(&AtomTerm::Var(Span::Panic, *var)).cloned())
                     .expect("All variables should be assigned before annotation");
                 ResolvedExpr::Var(
                     span.clone(),
@@ -271,7 +261,7 @@ impl Assignment<AtomTerm, ArcSort> {
                     .iter()
                     .map(|arg| arg.output_type())
                     .chain(once(
-                        self.get(&AtomTerm::Var(DUMMY_SPAN.clone(), *corresponding_var))
+                        self.get(&AtomTerm::Var(span.clone(), *corresponding_var))
                             .unwrap()
                             .clone(),
                     ))

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -34,7 +34,7 @@ impl EGraph {
     ///     .unwrap();
     /// let mut termdag = TermDag::default();
     /// let (sort, value) = egraph
-    ///     .eval_expr(&egglog::ast::Expr::var_no_span("expr"))
+    ///     .eval_expr(&egglog::ast::Expr::Var(egglog::span!(), "expr".into()))
     ///     .unwrap();
     /// let (_, extracted) = egraph.extract(value, &mut termdag, &sort);
     /// assert_eq!(termdag.to_string(&extracted), "(Add 1 1)");

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -33,9 +33,7 @@ impl EGraph {
     ///     )
     ///     .unwrap();
     /// let mut termdag = TermDag::default();
-    /// let (sort, value) = egraph
-    ///     .eval_expr(&egglog::ast::Expr::Var(egglog::span!(), "expr".into()))
-    ///     .unwrap();
+    /// let (sort, value) = egraph.eval_expr(&egglog::var!("expr")).unwrap();
     /// let (_, extracted) = egraph.extract(value, &mut termdag, &sort);
     /// assert_eq!(termdag.to_string(&extracted), "(Add 1 1)");
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,12 +296,12 @@ impl Primitive {
     fn accept(&self, tys: &[Arc<dyn Sort>], typeinfo: &TypeInfo) -> bool {
         let mut constraints = vec![];
         let lits: Vec<_> = (0..tys.len())
-            .map(|i| AtomTerm::Literal(DUMMY_SPAN.clone(), Literal::Int(i as i64)))
+            .map(|i| AtomTerm::Literal(Span::Panic, Literal::Int(i as i64)))
             .collect();
         for (lit, ty) in lits.iter().zip(tys.iter()) {
             constraints.push(Constraint::Assign(lit.clone(), ty.clone()))
         }
-        constraints.extend(self.get_type_constraints(&DUMMY_SPAN).get(&lits, typeinfo));
+        constraints.extend(self.get_type_constraints(&Span::Panic).get(&lits, typeinfo));
         let problem = Problem {
             constraints,
             range: HashSet::default(),
@@ -535,7 +535,7 @@ impl EGraph {
                 self.msgs = messages;
                 Ok(())
             }
-            None => Err(Error::Pop(DUMMY_SPAN.clone())),
+            None => Err(Error::Pop(span!())),
         }
     }
 
@@ -710,7 +710,7 @@ impl EGraph {
         let f = self
             .functions
             .get(&sym)
-            .ok_or(TypeError::UnboundFunction(sym, DUMMY_SPAN.clone()))?;
+            .ok_or(TypeError::UnboundFunction(sym, span!()))?;
         let schema = f.schema.clone();
         let nodes = f
             .nodes
@@ -796,7 +796,7 @@ impl EGraph {
             let f = self
                 .functions
                 .get(&sym)
-                .ok_or(TypeError::UnboundFunction(sym, DUMMY_SPAN.clone()))?;
+                .ok_or(TypeError::UnboundFunction(sym, span!()))?;
             log::info!("Function {} has size {}", sym, f.nodes.len());
             self.print_msg(f.nodes.len().to_string());
             Ok(())
@@ -1122,7 +1122,7 @@ impl EGraph {
 
     pub fn eval_expr(&mut self, expr: &Expr) -> Result<(ArcSort, Value), Error> {
         let fresh_name = self.parser.symbol_gen.fresh(&"egraph_evalexpr".into());
-        let command = Command::Action(Action::Let(DUMMY_SPAN.clone(), fresh_name, expr.clone()));
+        let command = Command::Action(Action::Let(expr.span(), fresh_name, expr.clone()));
         self.run_program(vec![command])?;
         // find the table with the same name as the fresh name
         let func = self.functions.get(&fresh_name).unwrap();
@@ -1373,7 +1373,7 @@ impl EGraph {
         let mut contents = String::new();
         f.read_to_string(&mut contents).unwrap();
 
-        let span: Span = DUMMY_SPAN.clone();
+        let span: Span = span!();
         let mut actions: Vec<Action> = vec![];
         let mut str_buf: Vec<&str> = vec![];
         for line in contents.lines() {
@@ -1508,8 +1508,8 @@ impl EGraph {
     }
 
     /// Add a user-defined sort
-    pub fn add_arcsort(&mut self, arcsort: ArcSort) -> Result<(), TypeError> {
-        self.type_info.add_arcsort(arcsort, DUMMY_SPAN.clone())
+    pub fn add_arcsort(&mut self, arcsort: ArcSort, span: Span) -> Result<(), TypeError> {
+        self.type_info.add_arcsort(arcsort, span)
     }
 
     /// Add a user-defined primitive

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,10 +1,6 @@
+use crate::{extract::Extractor, util::HashMap, *};
 use ordered_float::NotNan;
 use std::collections::VecDeque;
-
-use crate::{
-    extract::Extractor, util::HashMap, ArcSort, EGraph, Function, Symbol, TermDag, TupleOutput,
-    Value,
-};
 
 pub struct SerializeConfig {
     // Maximumum number of functions to include in the serialized graph, any after this will be discarded
@@ -321,7 +317,7 @@ impl EGraph {
                             .extract_term(self, *value, &extractor, &mut termdag)
                             .expect("Extraction should be successful since extractor has been fully initialized");
 
-                    termdag.term_to_expr(&term).to_string()
+                    termdag.term_to_expr(&term, Span::Panic).to_string()
                 };
                 egraph.nodes.insert(
                     node_id.clone(),

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -411,9 +411,9 @@ fn call_fn(egraph: &mut EGraph, name: &Symbol, types: Vec<ArcSort>, args: Vec<Va
     let binding = IndexSet::from_iter(arg_vars.clone());
     let resolved_args = arg_vars
         .into_iter()
-        .map(|v| GenericExpr::Var(DUMMY_SPAN.clone(), v))
+        .map(|v| GenericExpr::Var(span!(), v))
         .collect();
-    let expr = GenericExpr::Call(DUMMY_SPAN.clone(), resolved_call, resolved_args);
+    let expr = GenericExpr::Call(span!(), resolved_call, resolved_args);
     // Similar to how the merge function is created in `Function::new`
     let (actions, mapped_expr) = expr
         .to_core_actions(

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -409,11 +409,8 @@ fn call_fn(egraph: &mut EGraph, name: &Symbol, types: Vec<ArcSort>, args: Vec<Va
         })
         .collect();
     let binding = IndexSet::from_iter(arg_vars.clone());
-    let resolved_args = arg_vars
-        .into_iter()
-        .map(|v| GenericExpr::Var(span!(), v))
-        .collect();
-    let expr = GenericExpr::Call(span!(), resolved_call, resolved_args);
+    let resolved_args = arg_vars.into_iter().map(|v| var!(v));
+    let expr = call!(resolved_call, resolved_args);
     // Similar to how the merge function is created in `Function::new`
     let (actions, mapped_expr) = expr
         .to_core_actions(

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -34,19 +34,19 @@ impl Default for TypeInfo {
             global_types: Default::default(),
         };
 
-        res.add_sort(UnitSort, DUMMY_SPAN.clone()).unwrap();
-        res.add_sort(StringSort, DUMMY_SPAN.clone()).unwrap();
-        res.add_sort(BoolSort, DUMMY_SPAN.clone()).unwrap();
-        res.add_sort(I64Sort, DUMMY_SPAN.clone()).unwrap();
-        res.add_sort(F64Sort, DUMMY_SPAN.clone()).unwrap();
-        res.add_sort(BigIntSort, DUMMY_SPAN.clone()).unwrap();
-        res.add_sort(BigRatSort, DUMMY_SPAN.clone()).unwrap();
+        res.add_sort(UnitSort, span!()).unwrap();
+        res.add_sort(StringSort, span!()).unwrap();
+        res.add_sort(BoolSort, span!()).unwrap();
+        res.add_sort(I64Sort, span!()).unwrap();
+        res.add_sort(F64Sort, span!()).unwrap();
+        res.add_sort(BigIntSort, span!()).unwrap();
+        res.add_sort(BigRatSort, span!()).unwrap();
 
-        res.add_presort::<MapSort>(DUMMY_SPAN.clone()).unwrap();
-        res.add_presort::<SetSort>(DUMMY_SPAN.clone()).unwrap();
-        res.add_presort::<VecSort>(DUMMY_SPAN.clone()).unwrap();
-        res.add_presort::<FunctionSort>(DUMMY_SPAN.clone()).unwrap();
-        res.add_presort::<MultiSetSort>(DUMMY_SPAN.clone()).unwrap();
+        res.add_presort::<MapSort>(span!()).unwrap();
+        res.add_presort::<SetSort>(span!()).unwrap();
+        res.add_presort::<VecSort>(span!()).unwrap();
+        res.add_presort::<FunctionSort>(span!()).unwrap();
+        res.add_presort::<MultiSetSort>(span!()).unwrap();
 
         res.add_primitive(ValueEq);
 
@@ -272,8 +272,8 @@ impl TypeInfo {
                 fdecl.span.clone(),
             ));
         }
-        bound_vars.insert("old".into(), (DUMMY_SPAN.clone(), output_type.clone()));
-        bound_vars.insert("new".into(), (DUMMY_SPAN.clone(), output_type.clone()));
+        bound_vars.insert("old".into(), (fdecl.span.clone(), output_type.clone()));
+        bound_vars.insert("new".into(), (fdecl.span.clone(), output_type.clone()));
 
         Ok(ResolvedFunctionDecl {
             name: fdecl.name,
@@ -502,7 +502,7 @@ impl TypeInfo {
         expr: &Expr,
         binding: &IndexMap<Symbol, (Span, ArcSort)>,
     ) -> Result<ResolvedExpr, TypeError> {
-        let action = Action::Expr(DUMMY_SPAN.clone(), expr.clone());
+        let action = Action::Expr(expr.span(), expr.clone());
         let typechecked_action = self.typecheck_action(symbol_gen, &action, binding)?;
         match typechecked_action {
             ResolvedAction::Expr(_, expr) => Ok(expr),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use egglog::{ast::Expr, EGraph, ExtractReport, Function, SerializeConfig, Term, Value};
+use egglog::{ast::Expr, *};
 use symbol_table::GlobalSymbol;
 
 #[test]
@@ -111,8 +111,9 @@ fn test_subsumed_unextractable_rebuild_arg() {
     let ExtractReport::Best { term, termdag, .. } = report else {
         panic!();
     };
-    let expr = termdag.term_to_expr(&term);
-    assert_eq!(expr, Expr::call_no_span(GlobalSymbol::from("exp"), vec![]));
+    let span = span!();
+    let expr = termdag.term_to_expr(&term, span.clone());
+    assert_eq!(expr, Expr::Call(span, GlobalSymbol::from("exp"), vec![]));
 }
 
 #[test]
@@ -162,8 +163,9 @@ fn test_subsumed_unextractable_rebuild_self() {
     let ExtractReport::Best { term, termdag, .. } = report else {
         panic!();
     };
-    let expr = termdag.term_to_expr(&term);
-    assert_eq!(expr, Expr::call_no_span(GlobalSymbol::from("exp"), vec![]));
+    let span = span!();
+    let expr = termdag.term_to_expr(&term, span.clone());
+    assert_eq!(expr, Expr::Call(span, GlobalSymbol::from("exp"), vec![]));
 }
 
 #[test]
@@ -398,7 +400,7 @@ fn test_value_to_classid() {
     let ExtractReport::Best { term, termdag, .. } = report else {
         panic!();
     };
-    let expr = termdag.term_to_expr(&term);
+    let expr = termdag.term_to_expr(&term, span!());
     let (sort, value) = egraph.eval_expr(&expr).unwrap();
 
     let serialized = egraph.serialize(SerializeConfig::default());


### PR DESCRIPTION
This PR improves error messages by introducing two new types of spans. The first is `Span::Rust`, which stores a location in a Rust file using [the `file!` macro family](https://doc.rust-lang.org/std/macro.file.html). The second is `Span::Panic`, which can be used when you know that the span should not be introspected; for an example, see the changes in `serialize.rs`.