### PR TITLE
Preserve rule names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1093,19 +1093,6 @@ impl EGraph {
         }
     }
 
-    pub(crate) fn add_rule(
-        &mut self,
-        rule: ast::ResolvedRule,
-        ruleset: Symbol,
-    ) -> Result<Symbol, Error> {
-        let name = ast::desugar::rule_name(&GenericCommand::Rule {
-            rule: rule.clone(),
-            name: "".into(),
-            ruleset,
-        });
-        self.add_rule_with_name(name, rule, ruleset)
-    }
-
     fn eval_actions(&mut self, actions: &ResolvedActions) -> Result<(), Error> {
         let (actions, _) = actions.to_core_actions(
             &self.type_info,
@@ -1242,7 +1229,7 @@ impl EGraph {
                 rule,
                 name,
             } => {
-                self.add_rule(rule, ruleset)?;
+                self.add_rule_with_name(name, rule, ruleset)?;
                 log::info!("Declared rule {name}.")
             }
             ResolvedNCommand::RunSchedule(sched) => {


### PR DESCRIPTION
Rule names were previously ignored due to a mistake in desugaring. No more!

[Simple repro](https://egraphs-good.github.io/egglog/?program=XQAAgAB-AAAAAAAAAAAUGQgnfMUD9dO1z5tXL2V7YXwuMzFgetbWNpK1v545cybgIYFxXuXImLjr-e9Z3XLAFZO76y0A1XWNcAiy8dwWQ74D_a5qlrtqw1i83DA0d39yhk_ruUX_3q4AAA%253D%253D)

```
(datatype A (B) (C) (D))
(rule () ((union (B) (C))))
(rule () ((union (C) (D))) :name "cd")
(let b (B))
(run 1)
(print-stats)
```

Current output:
```
Overall statistics:
Rule (rule ()       ((union (B ) (C )))          ): search 0.000s, apply 0.000s, num matches 0
Rule (rule ()       ((union (C ) (D )))          ): search 0.000s, apply 0.000s, num matches 0
Ruleset : search 0.000s, apply 0.000s, rebuild 0.000s
```

New output:
```
Overall statistics:
Rule (rule ()       ((union (B ) (C )))          ): search 0.000s, apply 0.000s, num matches 0
Rule cd: search 0.000s, apply 0.000s, num matches 0
Ruleset : search 0.000s, apply 0.000s, rebuild 0.000s
```

(as for why I need names - I discovered the issue while implementing a simple filtering system for egglog rewrite rule application statistics based on names of rules I care about at any given moment)