### PR TITLE
Fix non-hygienic mention of Arc in add_primitives macro

### DIFF
--- a/src/sort/macros.rs
+++ b/src/sort/macros.rs
@@ -7,6 +7,7 @@ macro_rules! add_primitives {
         #[allow(unused_imports, non_snake_case)]
         {
             use $crate::{*, ast::*, sort::*, constraint::*};
+            use ::std::sync::Arc;
 
             struct MyPrim {$(
                 $param: Arc<<$param_t as FromSort>::Sort>,


### PR DESCRIPTION
This macro fails to expand if you don't import `std::sync::Arc` at invocation site. 