### PR TITLE
Expose extraction module publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod actions;
 pub mod ast;
 pub mod constraint;
 mod core;
-mod extract;
+pub mod extract;
 mod function;
 mod gj;
 mod serialize;


### PR DESCRIPTION
It's currently impossible to define custom sorts outside of `egglog` due to the fact that types like `Extractor` and `Cost` aren't exposed. This PR fixes this by exposing `extractor` module.

The module is already using `pub` and `pub(crate)` in all the right places. I do wonder however if `costs` field of the `Extractor` needs to be public