### PR TITLE
Expose egglog REPL as a function

### DIFF
--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -1015,8 +1015,10 @@ fn sexp(ctx: &mut Context) -> Result<Sexp, ParseError> {
 
 fn all_sexps(mut ctx: Context) -> Result<Vec<Sexp>, ParseError> {
     let mut sexps = Vec::new();
+    ctx.advance_past_whitespace();
     while !ctx.is_at_end() {
         sexps.push(sexp(&mut ctx)?);
+        ctx.advance_past_whitespace();
     }
     Ok(sexps)
 }

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -1035,8 +1035,9 @@ mod tests {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn rust_span_display() {
-        assert_eq!(format!("{}", span!()), "At 1037:34 of src/ast/parse.rs");
+        assert_eq!(format!("{}", span!()), format!("At {}:34 of src/ast/parse.rs", line!()));
     }
 
     #[test]

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -832,13 +832,13 @@ fn expr(sexp: &Sexp, parser: &Parser) -> Result<Expr, ParseError> {
 }
 
 #[derive(Clone, Debug)]
-struct Context {
+pub(crate) struct Context {
     source: Arc<SrcFile>,
     index: usize,
 }
 
 impl Context {
-    fn new(name: Option<String>, contents: &str) -> Context {
+    pub(crate) fn new(name: Option<String>, contents: &str) -> Context {
         Context {
             source: Arc::new(SrcFile {
                 name,
@@ -913,6 +913,7 @@ impl Context {
                                 (true, 'n') => '\n',
                                 (true, 't') => '\t',
                                 (true, '\\') => '\\',
+                                (true, '\"') => '\"',
                                 (true, c) => {
                                     return error!(s(span), "unrecognized escape character {c}")
                                 }
@@ -1013,7 +1014,7 @@ fn sexp(ctx: &mut Context) -> Result<Sexp, ParseError> {
     }
 }
 
-fn all_sexps(mut ctx: Context) -> Result<Vec<Sexp>, ParseError> {
+pub(crate) fn all_sexps(mut ctx: Context) -> Result<Vec<Sexp>, ParseError> {
     let mut sexps = Vec::new();
     ctx.advance_past_whitespace();
     while !ctx.is_at_end() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1455,11 +1455,16 @@ impl EGraph {
                     continue;
                 }
 
-                self.run_command(processed)?;
+                let result = self.run_command(processed);
 
                 if self.is_interactive_mode() {
-                    self.print_msg("(done)".into());
+                    self.print_msg(match result {
+                        Ok(()) => "(done)".into(),
+                        Err(_) => "(error)".into(),
+                    });
                 }
+
+                result?
             }
         }
         log::logger().flush();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod core;
 pub mod extract;
 mod function;
 mod gj;
+mod repl;
 mod serialize;
 pub mod sort;
 mod termdag;
@@ -1455,6 +1456,10 @@ impl EGraph {
                 }
 
                 self.run_command(processed)?;
+
+                if self.is_interactive_mode() {
+                    self.print_msg("(done)".into());
+                }
             }
         }
         log::logger().flush();

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,8 @@ fn main() {
 
     if args.inputs.is_empty() {
         let mut egraph = mk_egraph();
+
+        log::info!("Welcome to Egglog REPL! (build: {})", env!("FULL_VERSION"));
         match egraph.repl() {
             Ok(()) => std::process::exit(0),
             Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use egglog::{EGraph, RunMode, SerializeConfig};
-use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -7,6 +7,7 @@ impl EGraph {
     pub fn repl(&mut self) -> io::Result<()> {
         self.repl_with(io::stdin(), io::stdout())
     }
+
     pub fn repl_with<R, W>(&mut self, input: R, mut output: W) -> io::Result<()>
     where
         R: Read,
@@ -27,8 +28,6 @@ impl EGraph {
 
         if !cmd_buffer.is_empty() {
             run_command_in_scripting(self, &cmd_buffer, &mut output)?;
-
-            log::logger().flush();
         }
 
         Ok(())

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -48,9 +48,7 @@ where
                 writeln!(output, "{msg}")?;
             }
         }
-        Err(err) => {
-            log::error!("{err}");
-        }
+        Err(err) => log::error!("{err}"),
     }
     Ok(())
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,0 +1,152 @@
+use std::io::{self, Read};
+use std::io::{BufRead, BufReader, Write};
+
+use crate::EGraph;
+
+impl EGraph {
+    pub fn repl(&mut self) -> io::Result<()> {
+        self.repl_with(io::stdin(), io::stdout())
+    }
+    pub fn repl_with<R, W>(&mut self, input: R, mut output: W) -> io::Result<()>
+    where
+        R: Read,
+        W: Write,
+    {
+        log::info!("Welcome to Egglog REPL! (build: {})", env!("FULL_VERSION"));
+
+        let mut cmd_buffer = String::new();
+
+        for line in BufReader::new(input).lines() {
+            let line_str = line?;
+            cmd_buffer.push_str(&line_str);
+            cmd_buffer.push('\n');
+            // handles multi-line commands
+            if should_eval(&cmd_buffer) {
+                run_command_in_scripting(self, &cmd_buffer, &mut output)?;
+                cmd_buffer = String::new();
+            }
+        }
+
+        if !cmd_buffer.is_empty() {
+            run_command_in_scripting(self, &cmd_buffer, &mut output)?;
+
+            log::logger().flush();
+        }
+
+        Ok(())
+    }
+}
+
+// test if the current command should be evaluated
+// upon success, return the number of commands to evaluate
+fn should_eval(curr_cmd: &str) -> bool {
+    let mut paren_count = 0;
+    let mut indices = curr_cmd.chars();
+    while let Some(ch) = indices.next() {
+        match ch {
+            '(' => paren_count += 1,
+            ')' => {
+                paren_count -= 1;
+                // if we have a negative count,
+                // this means excessive closing parenthesis
+                // which we would like to throw an error eagerly
+                if paren_count < 0 {
+                    return false;
+                }
+            }
+            ';' => {
+                // `any` moves the iterator forward until it finds a match
+                if !indices.any(|ch| ch == '\n') {
+                    return false;
+                }
+            }
+            '"' => {
+                if !indices.any(|ch| ch == '"') {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    paren_count <= 0
+}
+
+fn run_command_in_scripting<W>(egraph: &mut EGraph, command: &str, mut output: W) -> io::Result<()>
+where
+    W: Write,
+{
+    match egraph.parse_and_run_program(None, command) {
+        Ok(msgs) => {
+            for msg in msgs {
+                writeln!(output, "{msg}")?;
+            }
+        }
+        Err(err) => {
+            log::error!("{err}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_eval() {
+        #[rustfmt::skip]
+        let test_cases = vec![
+            vec![
+                "(extract",
+                "\"1",
+                ")",
+                "(",
+                ")))",
+                "\"",
+                ";; )",
+                ")"
+            ],
+            vec![
+                "(extract 1) (extract",
+                "2) (",
+                "extract 3) (extract 4) ;;;; ("
+            ]];
+        for test in test_cases {
+            let mut cmd_buffer = String::new();
+            for (i, line) in test.iter().enumerate() {
+                cmd_buffer.push_str(line);
+                cmd_buffer.push('\n');
+                assert_eq!(should_eval(&cmd_buffer), i == test.len() - 1);
+            }
+        }
+    }
+
+    #[test]
+    fn test_repl() {
+        let mut egraph = EGraph::default();
+
+        let input = "(extract 1)";
+        let mut output = Vec::new();
+        egraph.repl_with(input.as_bytes(), &mut output).unwrap();
+        assert_eq!(String::from_utf8(output).unwrap(), "1\n");
+
+        let input = "\n\n\n";
+        let mut output = Vec::new();
+        egraph.repl_with(input.as_bytes(), &mut output).unwrap();
+        assert_eq!(String::from_utf8(output).unwrap(), "");
+
+        let input = "(set-option interactive_mode 1)";
+        let mut output = Vec::new();
+        egraph.repl_with(input.as_bytes(), &mut output).unwrap();
+        assert_eq!(String::from_utf8(output).unwrap(), "(done)\n");
+
+        let input = "(set-option interactive_mode 1)\n(extract 1)(extract 2)\n";
+        let mut output = Vec::new();
+        egraph.repl_with(input.as_bytes(), &mut output).unwrap();
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "(done)\n1\n(done)\n2\n(done)\n"
+        );
+    }
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -12,8 +12,6 @@ impl EGraph {
         R: Read,
         W: Write,
     {
-        log::info!("Welcome to Egglog REPL! (build: {})", env!("FULL_VERSION"));
-
         let mut cmd_buffer = String::new();
 
         for line in BufReader::new(input).lines() {


### PR DESCRIPTION
This PR should subsume #486 by exposing the repl functionality of egglog as a public function. Compared to #486, this handles for multi-line commands and does not introduce duplicate code.

Other minor changes:

* Fix a bug with the parser where input consisting of newline characters cause the parser to fail (see [this program](https://egraphs-good.github.io/egglog/?program=XQAAgAADAAAAAAAAAAAFaD3_____4AAAAA%253D%253D) ).
* Move implementation for `interactive_mode` to `run_commands` for correct handling, since the previous logic for `interactive_mode` assumes one command per line and just prints `(done)` for each line of the input.