### PR TITLE
Make the type constraint system user-extensible

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -278,7 +278,7 @@ impl Query<SymbolOrEq, Symbol> {
     pub fn get_constraints(
         &self,
         type_info: &TypeInfo,
-    ) -> Result<Vec<Constraint<AtomTerm, ArcSort>>, TypeError> {
+    ) -> Result<Vec<Box<dyn Constraint<AtomTerm, ArcSort>>>, TypeError> {
         let mut constraints = vec![];
         for atom in self.atoms.iter() {
             constraints.extend(atom.get_constraints(type_info)?.into_iter());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,7 @@ impl Primitive {
             .map(|i| AtomTerm::Literal(Span::Panic, Literal::Int(i as i64)))
             .collect();
         for (lit, ty) in lits.iter().zip(tys.iter()) {
-            constraints.push(Constraint::Assign(lit.clone(), ty.clone()))
+            constraints.push(constraint::assign(lit.clone(), ty.clone()))
         }
         constraints.extend(self.get_type_constraints(&Span::Panic).get(&lits, typeinfo));
         let problem = Problem {

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -238,10 +238,10 @@ impl TypeConstraint for FunctionCTorTypeConstraint {
         &self,
         arguments: &[AtomTerm],
         typeinfo: &TypeInfo,
-    ) -> Vec<Constraint<AtomTerm, ArcSort>> {
+    ) -> Vec<Box<dyn Constraint<AtomTerm, ArcSort>>> {
         // Must have at least one arg (plus the return value)
         if arguments.len() < 2 {
-            return vec![Constraint::Impossible(
+            return vec![constraint::impossible(
                 constraint::ImpossibleConstraint::ArityMismatch {
                     atom: core::Atom {
                         span: self.span.clone(),
@@ -252,7 +252,7 @@ impl TypeConstraint for FunctionCTorTypeConstraint {
                 },
             )];
         }
-        let output_sort_constraint: constraint::Constraint<_, ArcSort> = Constraint::Assign(
+        let output_sort_constraint: Box<dyn Constraint<_, ArcSort>> = constraint::assign(
             arguments[arguments.len() - 1].clone(),
             self.function.clone(),
         );
@@ -265,7 +265,7 @@ impl TypeConstraint for FunctionCTorTypeConstraint {
                 // the number of partial args must match the number of inputs from the func type minus the number from
                 // this function sort
                 if self.function.inputs.len() + n_partial_args != func_type.input.len() {
-                    return vec![Constraint::Impossible(
+                    return vec![constraint::impossible(
                         constraint::ImpossibleConstraint::ArityMismatch {
                             atom: core::Atom {
                                 span: self.span.clone(),
@@ -292,7 +292,7 @@ impl TypeConstraint for FunctionCTorTypeConstraint {
                         .map(|s| s.name())
                         .ne(actual_input.iter().map(|s| s.name()))
                 {
-                    return vec![Constraint::Impossible(
+                    return vec![constraint::impossible(
                         constraint::ImpossibleConstraint::FunctionMismatch {
                             expected_output,
                             expected_input,
@@ -308,7 +308,7 @@ impl TypeConstraint for FunctionCTorTypeConstraint {
                     .take(n_partial_args)
                     .zip(arguments.iter().skip(1))
                     .map(|(expected_sort, actual_term)| {
-                        Constraint::Assign(actual_term.clone(), expected_sort.clone())
+                        constraint::assign(actual_term.clone(), expected_sort.clone())
                     })
                     .chain(once(output_sort_constraint))
                     .collect();
@@ -317,7 +317,7 @@ impl TypeConstraint for FunctionCTorTypeConstraint {
 
         // Otherwise we just try assuming it's this function, we don't know if it is or not
         vec![
-            Constraint::Assign(arguments[0].clone(), Arc::new(StringSort)),
+            constraint::assign(arguments[0].clone(), Arc::new(StringSort)),
             output_sort_constraint,
         ]
     }


### PR DESCRIPTION
This PR allows users to BYO type constraints by making constraints trait-oriented rather than ADT-oriented. With this PR, we can implement #452 in `egglog-experimental` instead of in core egglog.

assigning @saulshanabrook and @oflatt for review

