### PR TITLE
Thread-safe EGraph struct

### DIFF
--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -217,19 +217,19 @@ fn map_fallible<T>(
         .collect::<Result<_, _>>()
 }
 
-pub trait Macro<T>: Send {
+pub trait Macro<T>: Send + Sync {
     fn name(&self) -> Symbol;
     fn parse(&self, args: &[Sexp], span: Span, parser: &mut Parser) -> Result<T, ParseError>;
 }
 
-pub struct SimpleMacro<T, F: Fn(&[Sexp], Span, &mut Parser) -> Result<T, ParseError> + Send>(
+pub struct SimpleMacro<T, F: Fn(&[Sexp], Span, &mut Parser) -> Result<T, ParseError> + Send + Sync>(
     Symbol,
     F,
 );
 
 impl<T, F> SimpleMacro<T, F>
 where
-    F: Fn(&[Sexp], Span, &mut Parser) -> Result<T, ParseError> + Send,
+    F: Fn(&[Sexp], Span, &mut Parser) -> Result<T, ParseError> + Send + Sync,
 {
     pub fn new(head: &str, f: F) -> Self {
         Self(head.into(), f)
@@ -238,7 +238,7 @@ where
 
 impl<T, F> Macro<T> for SimpleMacro<T, F>
 where
-    F: Fn(&[Sexp], Span, &mut Parser) -> Result<T, ParseError> + Send,
+    F: Fn(&[Sexp], Span, &mut Parser) -> Result<T, ParseError> + Send + Sync,
 {
     fn name(&self) -> Symbol {
         self.0
@@ -251,9 +251,9 @@ where
 
 #[derive(Clone)]
 pub struct Parser {
-    commands: HashMap<Symbol, Arc<dyn Macro<Vec<Command>> + Send + Sync>>,
-    actions: HashMap<Symbol, Arc<dyn Macro<Vec<Action>> + Send + Sync>>,
-    exprs: HashMap<Symbol, Arc<dyn Macro<Expr> + Send + Sync>>,
+    commands: HashMap<Symbol, Arc<dyn Macro<Vec<Command>>>>,
+    actions: HashMap<Symbol, Arc<dyn Macro<Vec<Action>>>>,
+    exprs: HashMap<Symbol, Arc<dyn Macro<Expr>>>,
     pub symbol_gen: SymbolGen,
 }
 
@@ -289,15 +289,15 @@ impl Parser {
         self.parse_expr(&sexp)
     }
 
-    pub fn add_command_macro(&mut self, ma: Arc<dyn Macro<Vec<Command>> + Send + Sync>) {
+    pub fn add_command_macro(&mut self, ma: Arc<dyn Macro<Vec<Command>>>) {
         self.commands.insert(ma.name(), ma);
     }
 
-    pub fn add_action_macro(&mut self, ma: Arc<dyn Macro<Vec<Action>> + Send + Sync>) {
+    pub fn add_action_macro(&mut self, ma: Arc<dyn Macro<Vec<Action>>>) {
         self.actions.insert(ma.name(), ma);
     }
 
-    pub fn add_expr_macro(&mut self, ma: Arc<dyn Macro<Expr> + Send + Sync>) {
+    pub fn add_expr_macro(&mut self, ma: Arc<dyn Macro<Expr>>) {
         self.exprs.insert(ma.name(), ma);
     }
 

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -17,7 +17,7 @@ pub struct Function {
     pub merge: MergeFn,
     pub(crate) nodes: table::Table,
     sorts: HashSet<Symbol>,
-    pub(crate) indexes: Vec<Rc<ColumnIndex>>,
+    pub(crate) indexes: Vec<Arc<ColumnIndex>>,
     pub(crate) rebuild_indexes: Vec<Option<CompositeColumnIndex>>,
     index_updated_through: usize,
     updates: usize,
@@ -30,7 +30,7 @@ pub enum MergeFn {
     Union,
     // the rc is make sure it's cheaply clonable, since calling the merge fn
     // requires a clone
-    Expr(Rc<Program>),
+    Expr(Arc<Program>),
 }
 
 /// All information we know determined by the input.
@@ -125,7 +125,7 @@ impl Function {
             let program = egraph
                 .compile_expr(&binding, &actions, &target)
                 .map_err(Error::TypeErrors)?;
-            MergeFn::Expr(Rc::new(program))
+            MergeFn::Expr(Arc::new(program))
         } else if decl.subtype == FunctionSubtype::Constructor {
             MergeFn::Union
         } else {
@@ -136,7 +136,7 @@ impl Function {
             input
                 .iter()
                 .chain(once(&output))
-                .map(|x| Rc::new(ColumnIndex::new(x.name()))),
+                .map(|x| Arc::new(ColumnIndex::new(x.name()))),
         );
 
         let rebuild_indexes = Vec::from_iter(input.iter().chain(once(&output)).map(|x| {
@@ -179,7 +179,7 @@ impl Function {
         self.nodes.clear();
         self.indexes
             .iter_mut()
-            .for_each(|x| Rc::make_mut(x).clear());
+            .for_each(|x| Arc::make_mut(x).clear());
         self.rebuild_indexes.iter_mut().for_each(|x| {
             if let Some(x) = x {
                 x.clear()
@@ -224,7 +224,7 @@ impl Function {
         &self,
         col: usize,
         timestamps: &Range<u32>,
-    ) -> Option<Rc<ColumnIndex>> {
+    ) -> Option<Arc<ColumnIndex>> {
         let range = self.nodes.transform_range(timestamps);
         if range.end > self.index_updated_through {
             return None;
@@ -255,7 +255,7 @@ impl Function {
             .zip(self.rebuild_indexes.iter_mut())
             .enumerate()
         {
-            let as_mut = Rc::make_mut(index);
+            let as_mut = Arc::make_mut(index);
             if col == self.schema.input.len() {
                 for (slot, _, out) in self.nodes.iter_range(offsets.clone(), true) {
                     as_mut.add(out.value, slot)
@@ -300,7 +300,7 @@ impl Function {
         for index in &mut self.indexes {
             // Everything works if we don't have a unique copy of the indexes,
             // but we ought to be able to avoid this copy.
-            Rc::make_mut(index).clear();
+            Arc::make_mut(index).clear();
         }
         for rebuild_index in self.rebuild_indexes.iter_mut().flatten() {
             rebuild_index.clear();

--- a/src/gj.rs
+++ b/src/gj.rs
@@ -797,7 +797,7 @@ type RowIdx = u32;
 #[derive(Debug)]
 enum LazyTrieInner {
     Borrowed {
-        index: Rc<ColumnIndex>,
+        index: Arc<ColumnIndex>,
         map: HashMap<Value, LazyTrie>,
     },
     Delayed(SmallVec<[RowIdx; 4]>),
@@ -822,7 +822,7 @@ impl LazyTrie {
             LazyTrieInner::Borrowed { index, .. } => index.len(),
         }
     }
-    fn from_column_index(index: Rc<ColumnIndex>) -> LazyTrie {
+    fn from_column_index(index: Arc<ColumnIndex>) -> LazyTrie {
         LazyTrie(UnsafeCell::new(LazyTrieInner::Borrowed {
             index,
             map: Default::default(),


### PR DESCRIPTION
We can make the EGraph implements the `Send` trait by substituting some of the components with thread-safe alternatives so this works:

```
    lazy_static! {
        pub static ref RT: Mutex<EGraph> = Mutex::new(EGraph::default());
    }
``` 