### PR TITLE
Include serialization in benchmarking

### DIFF
--- a/benches/example_benchmarks.rs
+++ b/benches/example_benchmarks.rs
@@ -9,6 +9,8 @@ fn run_example(filename: &str, program: &str, no_messages: bool) {
     egraph
         .parse_and_run_program(Some(filename.to_owned()), program)
         .unwrap();
+    // test performance of serialization as well
+    let _ = egraph.serialize(egglog::SerializeConfig::default());
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {


### PR DESCRIPTION
I extracted on line from https://github.com/egraphs-good/egglog/pull/520 to see how much adding serialization adds to our benchmark and make that one clearer how much performance it gains!