### PR TITLE
Expose EgglogSpan publicly and add debug to spans

### DIFF
--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -16,14 +16,14 @@ pub enum Span {
     Rust(Arc<RustSpan>),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EgglogSpan {
-    file: Arc<SrcFile>,
-    i: usize,
-    j: usize,
+    pub file: Arc<SrcFile>,
+    pub i: usize,
+    pub j: usize,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RustSpan {
     pub file: &'static str,
     pub line: u32,
@@ -51,10 +51,10 @@ impl Span {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SrcFile {
-    name: Option<String>,
-    contents: String,
+    pub name: Option<String>,
+    pub contents: String,
 }
 
 struct Location {


### PR DESCRIPTION
This PR makes public the fields on the egglog span so that we can access them from the Python bindings. In Python, I have been generally converting to/from egglog sructs by creating a corresponding Python class and copying all of their fields. To do so , it has to be public.

I also use the debug formatting to allow pretty printing in Python as the rust struct.

See https://github.com/egraphs-good/egglog-python/pull/258 for the corresponding PR on the Python side.