### PR TITLE
Fix primitives in queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=efa796c#efa796cdf3c32e3dc278221646b603b70353af87"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=2e0866d#2e0866da2ff4e95adf4d269bc7699d2f3222e5da"
 dependencies = [
  "arc-swap",
  "rayon",
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "core-relations"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=efa796c#efa796cdf3c32e3dc278221646b603b70353af87"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=2e0866d#2e0866da2ff4e95adf4d269bc7699d2f3222e5da"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=efa796c#efa796cdf3c32e3dc278221646b603b70353af87"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=2e0866d#2e0866da2ff4e95adf4d269bc7699d2f3222e5da"
 dependencies = [
  "anyhow",
  "core-relations",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=efa796c#efa796cdf3c32e3dc278221646b603b70353af87"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=2e0866d#2e0866da2ff4e95adf4d269bc7699d2f3222e5da"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1462,7 +1462,7 @@ checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=efa796c#efa796cdf3c32e3dc278221646b603b70353af87"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=2e0866d#2e0866da2ff4e95adf4d269bc7699d2f3222e5da"
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=7c0d408#7c0d4086b0f2ee3233099f31ce5d47791b542cb9"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=efa796c#efa796cdf3c32e3dc278221646b603b70353af87"
 dependencies = [
  "arc-swap",
  "rayon",
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "core-relations"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=7c0d408#7c0d4086b0f2ee3233099f31ce5d47791b542cb9"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=efa796c#efa796cdf3c32e3dc278221646b603b70353af87"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=7c0d408#7c0d4086b0f2ee3233099f31ce5d47791b542cb9"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=efa796c#efa796cdf3c32e3dc278221646b603b70353af87"
 dependencies = [
  "anyhow",
  "core-relations",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=7c0d408#7c0d4086b0f2ee3233099f31ce5d47791b542cb9"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=efa796c#efa796cdf3c32e3dc278221646b603b70353af87"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1462,7 +1462,7 @@ checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=7c0d408#7c0d4086b0f2ee3233099f31ce5d47791b542cb9"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=efa796c#efa796cdf3c32e3dc278221646b603b70353af87"
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ thiserror = "1"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "efa796c" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "efa796c" }
+core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "2e0866d" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "2e0866d" }
 
 # Need to add "js" feature for "graphviz-rust" to work in wasm
 getrandom = { version = "0.2.10", optional = true, features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ thiserror = "1"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "7c0d408" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "7c0d408" }
+core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "efa796c" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "efa796c" }
 
 # Need to add "js" feature for "graphviz-rust" to work in wasm
 getrandom = { version = "0.2.10", optional = true, features = ["js"] }

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -498,7 +498,11 @@ fn translate_expr_to_mergefn(
 ) -> Result<egglog_bridge::MergeFn, Error> {
     match expr {
         GenericExpr::Lit(_, literal) => {
-            let val = translate_literal(&egraph.backend, literal);
+            let egglog_bridge::QueryEntry::Const { val, .. } =
+                translate_literal(&egraph.backend, literal)
+            else {
+                unreachable!()
+            };
             Ok(egglog_bridge::MergeFn::Const(val))
         }
         GenericExpr::Var(span, resolved_var) => match resolved_var.name.as_str() {

--- a/src/function/mod.rs
+++ b/src/function/mod.rs
@@ -498,11 +498,7 @@ fn translate_expr_to_mergefn(
 ) -> Result<egglog_bridge::MergeFn, Error> {
     match expr {
         GenericExpr::Lit(_, literal) => {
-            let egglog_bridge::QueryEntry::Const { val, .. } =
-                translate_literal(&egraph.backend, literal)
-            else {
-                unreachable!()
-            };
+            let val = literal_to_value(&egraph.backend, literal);
             Ok(egglog_bridge::MergeFn::Const(val))
         }
         GenericExpr::Var(span, resolved_var) => match resolved_var.name.as_str() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1625,9 +1625,7 @@ impl<'a> BackendRule<'a> {
                     v.sort.column_ty(self.rb.egraph().primitives()),
                     v.name.into(),
                 ),
-                core::GenericAtomTerm::Literal(_, l) => {
-                    translate_literal(self.rb.egraph(), l).into()
-                }
+                core::GenericAtomTerm::Literal(_, l) => translate_literal(self.rb.egraph(), l),
                 core::GenericAtomTerm::Global(..) => {
                     panic!("Globals should have been desugared")
                 }
@@ -1655,18 +1653,15 @@ impl<'a> BackendRule<'a> {
 
     fn query(&mut self, query: &core::Query<ResolvedCall, ResolvedVar>) {
         for atom in &query.atoms {
+            let args = self.args(&atom.args);
             match &atom.head {
                 ResolvedCall::Func(f) => {
-                    let f = self.func(f).into();
-                    let args = self.args(&atom.args);
-                    self.rb.add_atom(f, &args).unwrap()
+                    let f = self.func(f);
+                    self.rb.query_table(f, &args).unwrap()
                 }
                 ResolvedCall::Primitive(p) => {
                     let (p, ty) = self.prim(p);
-                    let (v, args) = atom.args.split_last().unwrap();
-                    let args = self.args(args);
-                    let y = self.rb.call_external_func(p, &args, ty).into();
-                    self.entries.insert(v.clone(), y);
+                    self.rb.query_prim(p, &args, ty).unwrap()
                 }
             }
         }
@@ -1680,7 +1675,7 @@ impl<'a> BackendRule<'a> {
                     let args = self.args(args);
                     let y = match f {
                         ResolvedCall::Func(f) => {
-                            let f = self.func(f).into();
+                            let f = self.func(f);
                             self.rb.lookup(f, &args).into()
                         }
                         ResolvedCall::Primitive(p) => {
@@ -1730,13 +1725,13 @@ impl<'a> BackendRule<'a> {
     }
 }
 
-fn translate_literal(egraph: &egglog_bridge::EGraph, l: &Literal) -> core_relations::Value {
+fn translate_literal(egraph: &egglog_bridge::EGraph, l: &Literal) -> egglog_bridge::QueryEntry {
     match l {
-        Literal::Int(x) => egraph.primitives().get::<i64>(*x),
-        Literal::Float(x) => egraph.primitives().get::<sort::F>(*x),
-        Literal::String(x) => egraph.primitives().get::<sort::S>(*x),
-        Literal::Bool(x) => egraph.primitives().get::<bool>(*x),
-        Literal::Unit => egraph.primitives().get::<()>(()),
+        Literal::Int(x) => egraph.primitive_constant::<i64>(*x),
+        Literal::Float(x) => egraph.primitive_constant::<sort::F>(*x),
+        Literal::String(x) => egraph.primitive_constant::<sort::S>(*x),
+        Literal::Bool(x) => egraph.primitive_constant::<bool>(*x),
+        Literal::Unit => egraph.primitive_constant::<()>(()),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1625,7 +1625,7 @@ impl<'a> BackendRule<'a> {
                     v.sort.column_ty(self.rb.egraph().primitives()),
                     v.name.into(),
                 ),
-                core::GenericAtomTerm::Literal(_, l) => translate_literal(self.rb.egraph(), l),
+                core::GenericAtomTerm::Literal(_, l) => literal_to_entry(self.rb.egraph(), l),
                 core::GenericAtomTerm::Global(..) => {
                     panic!("Globals should have been desugared")
                 }
@@ -1725,13 +1725,23 @@ impl<'a> BackendRule<'a> {
     }
 }
 
-fn translate_literal(egraph: &egglog_bridge::EGraph, l: &Literal) -> egglog_bridge::QueryEntry {
+fn literal_to_entry(egraph: &egglog_bridge::EGraph, l: &Literal) -> egglog_bridge::QueryEntry {
     match l {
         Literal::Int(x) => egraph.primitive_constant::<i64>(*x),
         Literal::Float(x) => egraph.primitive_constant::<sort::F>(*x),
         Literal::String(x) => egraph.primitive_constant::<sort::S>(*x),
         Literal::Bool(x) => egraph.primitive_constant::<bool>(*x),
         Literal::Unit => egraph.primitive_constant::<()>(()),
+    }
+}
+
+fn literal_to_value(egraph: &egglog_bridge::EGraph, l: &Literal) -> core_relations::Value {
+    match l {
+        Literal::Int(x) => egraph.primitives().get::<i64>(*x),
+        Literal::Float(x) => egraph.primitives().get::<sort::F>(*x),
+        Literal::String(x) => egraph.primitives().get::<sort::S>(*x),
+        Literal::Bool(x) => egraph.primitives().get::<bool>(*x),
+        Literal::Unit => egraph.primitives().get::<()>(()),
     }
 }
 


### PR DESCRIPTION
This PR doesn't actually work; it causes fewer tests to pass than before. I've looked at the `bignum` test, and it seems to fail by not finding the variable that is returned from a primitive, but I'm not sure how to fix it.