### PR TITLE
Add `find_variants` to `Extractor`

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -78,7 +78,7 @@ impl EGraph {
         termdag: &mut TermDag,
     ) -> Vec<Term> {
         Extractor::new(self, termdag)
-            .find_variants(value, termdag, sort.clone(), limit)
+            .find_variants(value, termdag, sort, limit)
             .unwrap()
     }
 }
@@ -139,11 +139,11 @@ impl<'a> Extractor<'a> {
         &self,
         value: Value,
         termdag: &mut TermDag,
-        sort: ArcSort,
+        sort: &ArcSort,
         limit: usize,
     ) -> Option<Vec<Term>> {
         let output_sort = sort.name();
-        let output_value = self.egraph.find(&sort, value);
+        let output_value = self.egraph.find(sort, value);
         let terms = self
             .ctors
             .iter()

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -77,9 +77,7 @@ impl EGraph {
         limit: usize,
         termdag: &mut TermDag,
     ) -> Vec<Term> {
-        Extractor::new(self, termdag)
-            .find_variants(value, termdag, sort, limit)
-            .unwrap()
+        Extractor::new(self, termdag).find_variants(value, termdag, sort, limit)
     }
 }
 
@@ -141,7 +139,7 @@ impl<'a> Extractor<'a> {
         termdag: &mut TermDag,
         sort: &ArcSort,
         limit: usize,
-    ) -> Option<Vec<Term>> {
+    ) -> Vec<Term> {
         let output_sort = sort.name();
         let output_value = self.egraph.find(sort, value);
         let terms = self
@@ -170,11 +168,8 @@ impl<'a> Extractor<'a> {
             .take(limit)
             .collect::<Vec<Term>>();
 
-        if terms.is_empty() {
-            None
-        } else {
-            Some(terms)
-        }
+        // TODO: what happens if `terms` is empty?
+        terms
     }
 
     fn node_total_cost(

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -70,6 +70,7 @@ impl EGraph {
         })
     }
 
+    /// Extracts up to `limit` terms for a given `value`.
     pub fn extract_variants(
         &mut self,
         sort: &ArcSort,
@@ -133,6 +134,7 @@ impl<'a> Extractor<'a> {
         }
     }
 
+    /// Extracts up to `limit` terms for a given `value`.
     pub fn find_variants(
         &self,
         value: Value,


### PR DESCRIPTION
The `EGraph` type implements `extract` and `extract_variants`, but the extractor only implements `find_best`. Adds `find_variants` to `Extractor` which is basically a copy of the original `extract_variants` function.