### PR TITLE
Subsumption in frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=7fcbb19#7fcbb194553aa7e5847bf7d54a7eca2c28cbb235"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=d1c00f2#d1c00f2c517211b9ed66e845cee8b1f0e4f28229"
 dependencies = [
  "arc-swap",
  "rayon",
@@ -289,7 +289,7 @@ dependencies = [
 [[package]]
 name = "core-relations"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=7fcbb19#7fcbb194553aa7e5847bf7d54a7eca2c28cbb235"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=d1c00f2#d1c00f2c517211b9ed66e845cee8b1f0e4f28229"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=7fcbb19#7fcbb194553aa7e5847bf7d54a7eca2c28cbb235"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=d1c00f2#d1c00f2c517211b9ed66e845cee8b1f0e4f28229"
 dependencies = [
  "anyhow",
  "core-relations",
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=7fcbb19#7fcbb194553aa7e5847bf7d54a7eca2c28cbb235"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=d1c00f2#d1c00f2c517211b9ed66e845cee8b1f0e4f28229"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1456,7 +1456,7 @@ checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=7fcbb19#7fcbb194553aa7e5847bf7d54a7eca2c28cbb235"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=d1c00f2#d1c00f2c517211b9ed66e845cee8b1f0e4f28229"
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=d1c00f2#d1c00f2c517211b9ed66e845cee8b1f0e4f28229"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=5d0fd85#5d0fd859d62eb7a6607c073d0c5d7446c0d1b5a3"
 dependencies = [
  "arc-swap",
  "rayon",
@@ -289,7 +289,7 @@ dependencies = [
 [[package]]
 name = "core-relations"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=d1c00f2#d1c00f2c517211b9ed66e845cee8b1f0e4f28229"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=5d0fd85#5d0fd859d62eb7a6607c073d0c5d7446c0d1b5a3"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=d1c00f2#d1c00f2c517211b9ed66e845cee8b1f0e4f28229"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=5d0fd85#5d0fd859d62eb7a6607c073d0c5d7446c0d1b5a3"
 dependencies = [
  "anyhow",
  "core-relations",
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=d1c00f2#d1c00f2c517211b9ed66e845cee8b1f0e4f28229"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=5d0fd85#5d0fd859d62eb7a6607c073d0c5d7446c0d1b5a3"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1456,7 +1456,7 @@ checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=d1c00f2#d1c00f2c517211b9ed66e845cee8b1f0e4f28229"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=5d0fd85#5d0fd859d62eb7a6607c073d0c5d7446c0d1b5a3"
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ thiserror = "1"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "7fcbb19" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "7fcbb19" }
+core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "d1c00f2" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "d1c00f2" }
 
 # Need to add "js" feature for "graphviz-rust" to work in wasm
 getrandom = { version = "0.2.10", optional = true, features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ thiserror = "1"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "d1c00f2" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "d1c00f2" }
+core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "5d0fd85" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "5d0fd85" }
 
 # Need to add "js" feature for "graphviz-rust" to work in wasm
 getrandom = { version = "0.2.10", optional = true, features = ["js"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1092,7 +1092,7 @@ impl EGraph {
                 self.backend.new_rule(name.into(), self.seminaive),
                 &self.functions,
             );
-            translator.query(&query);
+            translator.query(&query, false);
             translator.actions(&actions);
             translator.finish().build()
         };
@@ -1225,7 +1225,7 @@ impl EGraph {
 
             let mut translator =
                 BackendRule::new(self.backend.new_rule("check_facts", false), &self.functions);
-            translator.query(&query);
+            translator.query(&query, true);
             let mut rb = translator.finish();
             rb.call_external_func(ext_id, &[], egglog_bridge::ColumnTy::Id);
             let id = rb.build();
@@ -1652,13 +1652,17 @@ impl<'a> BackendRule<'a> {
         args.into_iter().map(|x| self.entry(x)).collect()
     }
 
-    fn query(&mut self, query: &core::Query<ResolvedCall, ResolvedVar>) {
+    fn query(&mut self, query: &core::Query<ResolvedCall, ResolvedVar>, include_subsumed: bool) {
         for atom in &query.atoms {
             let args = self.args(&atom.args);
             match &atom.head {
                 ResolvedCall::Func(f) => {
                     let f = self.func(f);
-                    self.rb.query_table(f, &args).unwrap()
+                    let is_subsumed = match include_subsumed {
+                        true => None,
+                        false => Some(false),
+                    };
+                    self.rb.query_table(f, &args, is_subsumed).unwrap()
                 }
                 ResolvedCall::Primitive(p) => {
                     let (p, ty) = self.prim(p);
@@ -1706,7 +1710,7 @@ impl<'a> BackendRule<'a> {
                         let args = self.args(args);
                         match change {
                             Change::Delete => self.rb.remove(f, &args),
-                            Change::Subsume => todo!("no subsumption yet"),
+                            Change::Subsume => self.rb.subsume(f, &args),
                         }
                     }
                 },


### PR DESCRIPTION
Wires subsumption up to the new backend. Passes `subsume.egg` if the `extract`s are removed.