### PR TITLE
Add repro-new-backend tests

### DIFF
--- a/tests/repro-new-backend-delete.egg
+++ b/tests/repro-new-backend-delete.egg
@@ -1,0 +1,4 @@
+(relation A ())
+(A)
+(rule ((A)) ((delete (A))))
+(run 1)

--- a/tests/repro-new-backend-prims.egg
+++ b/tests/repro-new-backend-prims.egg
@@ -1,0 +1,11 @@
+(function predicate (i64) bool :merge (or old new))
+
+(set (predicate 1) false)
+
+(check (= false (predicate 1)))
+
+(set (predicate 2) false)
+
+(set (predicate 1) true)
+
+(check (= false (predicate x)) (predicate (+ x 1)))


### PR DESCRIPTION
Adds a minimized `prims.egg` test and the test from #546.

Both tests are currently failing.
