### PR TITLE
Fix parser ignoring errors

### DIFF
--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -275,7 +275,7 @@ impl Parser {
         input: &str,
     ) -> Result<Vec<Command>, ParseError> {
         let sexps = all_sexps(Context::new(filename, input))?;
-        let nested = map_fallible(&sexps, self, Self::parse_command)?;
+        let nested: Vec<Vec<_>> = map_fallible(&sexps, self, Self::parse_command)?;
         Ok(nested.into_iter().flatten().collect())
     }
 
@@ -426,7 +426,7 @@ impl Parser {
                 [lhs, rhs, rest @ ..] => {
                     let body =
                         map_fallible(lhs.expect_list("rule query")?, self, Self::parse_fact)?;
-                    let head =
+                    let head: Vec<Vec<_>> =
                         map_fallible(rhs.expect_list("rule actions")?, self, Self::parse_action)?;
                     let head = GenericActions(head.into_iter().flatten().collect());
 
@@ -647,9 +647,8 @@ impl Parser {
                 _ => return error!(span, "usage: (fail <command>)"),
             },
             _ => self
-                .parse_action(sexp)
+                .parse_action(sexp)?
                 .into_iter()
-                .flatten()
                 .map(Command::Action)
                 .collect(),
         })


### PR DESCRIPTION
Thanks to @FTRobbin for finding this; on line 652 of `parse.rs`, we were flattening a `Result` iterator instead of propagating the error. This had the effect of silently discarding top-level actions that failed to parse!

I've also added type annotations to the other sites in this file where we use `flatten` to make sure that this isn't happening there.