### PR TITLE
Extract action for the new backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,10 +271,14 @@ dependencies = [
 name = "concurrency"
 version = "0.1.0"
 <<<<<<< HEAD
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
 >>>>>>> 561c7be (Things are starting to blow up)
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
+>>>>>>> 2acaa7e (Extraction core logic)
 dependencies = [
  "arc-swap",
  "rayon",
@@ -294,10 +298,14 @@ dependencies = [
 name = "core-relations"
 version = "0.1.0"
 <<<<<<< HEAD
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
 >>>>>>> 561c7be (Things are starting to blow up)
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
+>>>>>>> 2acaa7e (Extraction core logic)
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -509,6 +517,7 @@ dependencies = [
  "num",
  "numeric-id",
  "ordered-float",
+ "queues",
  "rustc-hash 1.1.0",
  "smallvec",
  "symbol_table",
@@ -519,10 +528,14 @@ dependencies = [
 name = "egglog-bridge"
 version = "0.1.0"
 <<<<<<< HEAD
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
 >>>>>>> 561c7be (Things are starting to blow up)
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
+>>>>>>> 2acaa7e (Extraction core logic)
 dependencies = [
  "anyhow",
  "core-relations",
@@ -965,7 +978,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1107,6 +1120,12 @@ checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "queues"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1475abae4f8ad4998590fe3acfe20104f0a5d48fc420c817cd2c09c3f56151f0"
 
 [[package]]
 name = "quote"
@@ -1471,10 +1490,14 @@ checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 name = "union-find"
 version = "0.1.0"
 <<<<<<< HEAD
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
 >>>>>>> 561c7be (Things are starting to blow up)
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
+>>>>>>> 2acaa7e (Extraction core logic)
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ name = "egglog"
 version = "0.4.0"
 dependencies = [
  "add_primitive",
+ "arc-swap",
  "chrono",
  "clap",
  "codspeed-criterion-compat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ name = "concurrency"
 version = "0.1.0"
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
@@ -279,6 +280,9 @@ source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc36
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
 >>>>>>> 2acaa7e (Extraction core logic)
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=dbb77d7#dbb77d7750ef1a28b908bfb2c0c096f801fc076e"
+>>>>>>> 6fdb923 (Test passing)
 dependencies = [
  "arc-swap",
  "rayon",
@@ -299,6 +303,7 @@ name = "core-relations"
 version = "0.1.0"
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
@@ -306,6 +311,9 @@ source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc36
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
 >>>>>>> 2acaa7e (Extraction core logic)
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=dbb77d7#dbb77d7750ef1a28b908bfb2c0c096f801fc076e"
+>>>>>>> 6fdb923 (Test passing)
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -529,6 +537,7 @@ name = "egglog-bridge"
 version = "0.1.0"
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
@@ -536,6 +545,9 @@ source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc36
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
 >>>>>>> 2acaa7e (Extraction core logic)
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=dbb77d7#dbb77d7750ef1a28b908bfb2c0c096f801fc076e"
+>>>>>>> 6fdb923 (Test passing)
 dependencies = [
  "anyhow",
  "core-relations",
@@ -978,7 +990,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=dbb77d7#dbb77d7750ef1a28b908bfb2c0c096f801fc076e"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1491,6 +1503,7 @@ name = "union-find"
 version = "0.1.0"
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
@@ -1498,6 +1511,9 @@ source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc36
 =======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
 >>>>>>> 2acaa7e (Extraction core logic)
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=dbb77d7#dbb77d7750ef1a28b908bfb2c0c096f801fc076e"
+>>>>>>> 6fdb923 (Test passing)
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,11 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
+>>>>>>> 561c7be (Things are starting to blow up)
 dependencies = [
  "arc-swap",
  "rayon",
@@ -289,7 +293,11 @@ dependencies = [
 [[package]]
 name = "core-relations"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
+>>>>>>> 561c7be (Things are starting to blow up)
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -509,7 +517,11 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
+>>>>>>> 561c7be (Things are starting to blow up)
 dependencies = [
  "anyhow",
  "core-relations",
@@ -952,7 +964,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1457,7 +1469,11 @@ checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 [[package]]
 name = "union-find"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
+=======
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
+>>>>>>> 561c7be (Things are starting to blow up)
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ name = "add_primitive"
 version = "0.1.0"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arc-swap"
@@ -101,9 +101,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitmaps"
@@ -130,12 +130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,9 +149,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "num-traits",
 ]
@@ -191,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -201,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -213,14 +207,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -231,24 +225,53 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codspeed"
-version = "2.7.2"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450a0e9df9df1c154156f4344f99d8f6f6e69d0fc4de96ef6e2e68b2ec3bce97"
+checksum = "93f4cce9c27c49c4f101fffeebb1826f41a9df2e7498b7cd4d95c0658b796c6c"
 dependencies = [
  "colored",
  "libc",
+ "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
 name = "codspeed-criterion-compat"
-version = "2.7.2"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb1a6cb9c20e177fde58cdef97c1c7c9264eb1424fe45c4fccedc2fb078a569"
+checksum = "c3c23d880a28a2aab52d38ca8481dd7a3187157d0a952196b6db1db3c8499725"
 dependencies = [
  "codspeed",
+ "codspeed-criterion-compat-walltime",
  "colored",
- "criterion",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a2f7365e347f4f22a67e9ea689bf7bc89900a354e22e26cf8a531a42c8fbb"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
 ]
 
 [[package]]
@@ -270,19 +293,7 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
-=======
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
->>>>>>> 561c7be (Things are starting to blow up)
-=======
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
->>>>>>> 2acaa7e (Extraction core logic)
-=======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=dbb77d7#dbb77d7750ef1a28b908bfb2c0c096f801fc076e"
->>>>>>> 6fdb923 (Test passing)
 dependencies = [
  "arc-swap",
  "rayon",
@@ -301,19 +312,7 @@ dependencies = [
 [[package]]
 name = "core-relations"
 version = "0.1.0"
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
-=======
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
->>>>>>> 561c7be (Things are starting to blow up)
-=======
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
->>>>>>> 2acaa7e (Extraction core logic)
-=======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=dbb77d7#dbb77d7750ef1a28b908bfb2c0c096f801fc076e"
->>>>>>> 6fdb923 (Test passing)
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -322,7 +321,7 @@ dependencies = [
  "dashmap",
  "dyn-clone",
  "fixedbitset 0.5.7",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "indexmap",
  "lazy_static",
  "log",
@@ -331,9 +330,9 @@ dependencies = [
  "petgraph",
  "rand",
  "rayon",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "union-find",
  "web-time",
 ]
@@ -345,32 +344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
 ]
 
 [[package]]
@@ -398,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -490,15 +463,15 @@ dependencies = [
 
 [[package]]
 name = "dot-structures"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675e35c02a51bb4d4618cb4885b3839ce6d1787c97b664474d9208d074742e20"
+checksum = "498cfcded997a93eb31edd639361fa33fd229a8784e953b37d71035fe3890b7b"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "egglog"
@@ -513,9 +486,9 @@ dependencies = [
  "egglog-bridge",
  "egraph-serialize",
  "env_logger",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "glob",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "im-rc",
  "indexmap",
  "instant",
@@ -535,24 +508,12 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "0.1.0"
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
-=======
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
->>>>>>> 561c7be (Things are starting to blow up)
-=======
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
->>>>>>> 2acaa7e (Extraction core logic)
-=======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=dbb77d7#dbb77d7750ef1a28b908bfb2c0c096f801fc076e"
->>>>>>> 6fdb923 (Test passing)
 dependencies = [
  "anyhow",
  "core-relations",
  "dyn-clone",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "indexmap",
  "log",
  "num-rational",
@@ -581,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_logger"
@@ -600,15 +561,15 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -634,9 +595,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -650,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -663,14 +624,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -697,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if 1.0.0",
  "crunchy",
@@ -713,9 +674,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -736,15 +697,15 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "im-rc"
@@ -762,12 +723,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -807,11 +768,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.1",
  "libc",
  "windows-sys",
 ]
@@ -833,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -855,9 +816,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libtest-mimic"
@@ -872,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -888,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -998,15 +959,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "ordered-float"
@@ -1034,20 +995,20 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1055,22 +1016,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -1117,18 +1078,18 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1141,12 +1102,18 @@ checksum = "1475abae4f8ad4998590fe3acfe20104f0a5d48fc420c817cd2c09c3f56151f0"
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -1176,7 +1143,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "serde",
 ]
 
@@ -1211,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -1255,15 +1222,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -1274,15 +1241,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1301,29 +1268,29 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1334,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -1355,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "strsim"
@@ -1373,7 +1340,7 @@ checksum = "f19bffd69fb182e684d14e3c71d04c0ef33d1641ac0b9e81c712c734e83703bc"
 dependencies = [
  "crossbeam-utils",
  "foldhash",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -1389,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,13 +1367,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if 1.0.0",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1432,11 +1398,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1447,18 +1413,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1482,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -1494,26 +1460,14 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "union-find"
 version = "0.1.0"
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=e1c938d#e1c938d223ea6c423c9ff455c7a26130ff5ee736"
-=======
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bdc2e0dbc368992c23e218610d723c87a0d8174f#bdc2e0dbc368992c23e218610d723c87a0d8174f"
->>>>>>> 561c7be (Things are starting to blow up)
-=======
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=609b3de#609b3dee487a1f827464aab391e9d50e9cd2f4c9"
->>>>>>> 2acaa7e (Extraction core logic)
-=======
 source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=dbb77d7#dbb77d7750ef1a28b908bfb2c0c096f801fc076e"
->>>>>>> 6fdb923 (Test passing)
 dependencies = [
  "concurrency",
  "crossbeam",
@@ -1525,6 +1479,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "version_check"
@@ -1550,9 +1513,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -1579,7 +1542,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1601,7 +1564,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1779,30 +1742,29 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,9 @@ thiserror = "1"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "e1c938d" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "e1c938d" }
-numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "e1c938d" }
+core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "bdc2e0dbc368992c23e218610d723c87a0d8174f" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "bdc2e0dbc368992c23e218610d723c87a0d8174f" }
+numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "bdc2e0dbc368992c23e218610d723c87a0d8174f" }
 
 # Need to add "js" feature for "graphviz-rust" to work in wasm
 getrandom = { version = "0.2.10", optional = true, features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,13 @@ smallvec = "1.11"
 symbol_table = { version = "0.4.0", features = ["global"] }
 thiserror = "1"
 arc-swap = "1.7.1"
+queues = "1.1.0"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "bdc2e0dbc368992c23e218610d723c87a0d8174f" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "bdc2e0dbc368992c23e218610d723c87a0d8174f" }
-numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "bdc2e0dbc368992c23e218610d723c87a0d8174f" }
+core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "609b3de" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "609b3de" }
+numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "609b3de" }
 
 # Need to add "js" feature for "graphviz-rust" to work in wasm
 getrandom = { version = "0.2.10", optional = true, features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,9 @@ queues = "1.1.0"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "609b3de" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "609b3de" }
-numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "609b3de" }
+core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "dbb77d7" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "dbb77d7" }
+numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "dbb77d7" }
 
 # Need to add "js" feature for "graphviz-rust" to work in wasm
 getrandom = { version = "0.2.10", optional = true, features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ rustc-hash = "1.1"
 smallvec = "1.11"
 symbol_table = { version = "0.4.0", features = ["global"] }
 thiserror = "1"
+arc-swap = "1.7.1"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -267,10 +267,12 @@ impl PreExtractionWriter for EgraphMsgWriter {
     }
 
     fn extract_output_variants(&self, termdag: &TermDag, terms: &[Term], _costs: &[Cost]) {
+        log::info!("New extractor extracted variants:");
         let mut msg = String::default();
         msg += "(\n";
         for expr in terms {
             let str = termdag.to_string(expr);
+            log::info!("   {str}");
             msg += &format!("   {str}\n");
         }
         msg += ")";
@@ -681,16 +683,13 @@ impl ExternalFunction for ExtractorAlter {
                             &costs,
                         ) {
                             if !reconstruction_round {
-                                log::debug!("Got cost: {:?}", (target, new_cost));
                                 match costs.get_mut(&target_sort.name()).unwrap().entry(target) {
                                     HEntry::Vacant(e) => {
-                                        log::debug! {"Inserted new cost"};
                                         ensure_fixpoint = false;
                                         e.insert(new_cost);
                                     }
                                     HEntry::Occupied(mut e) => {
                                         if new_cost < *(e.get()) {
-                                            log::debug! {"Updated new cost"};
                                             ensure_fixpoint = false;
                                             e.insert(new_cost);
                                         }
@@ -750,8 +749,6 @@ impl ExternalFunction for ExtractorAlter {
                 &filtered_func,
                 &parent_edge,
             );
-
-            log::debug!("Got termdag: {:?}, term: {:?}", termdag, term);
 
             self.writer
                 .extract_output_single(&termdag, &term, best_cost);

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -231,12 +231,14 @@ pub trait ExtractionWriter : PreExtractionWriter + Send + Sync {}
 
 #[derive(Clone)]
 pub struct EgraphMsgWriter {
-    msgs : Arc<Mutex<Option<Vec<String>>>>
+    msgs : Arc<Mutex<Option<Vec<String>>>>,
+    report : Arc<Mutex<Option<crate::ExtractReport>>>,
 }
 
 impl EgraphMsgWriter {
-    pub fn new(msgs: Arc<Mutex<Option<Vec<String>>>>) -> Self {
-        EgraphMsgWriter { msgs: msgs }
+    pub fn new(msgs: Arc<Mutex<Option<Vec<String>>>>,
+               report: Arc<Mutex<Option<crate::ExtractReport>>>) -> Self {
+        EgraphMsgWriter { msgs: msgs, report: report }
     }
 
     fn print_msg(&self, msg: String) {
@@ -250,8 +252,9 @@ impl EgraphMsgWriter {
 impl PreExtractionWriter for EgraphMsgWriter {
     fn extract_output_single(&self, termdag: &TermDag, term: &Term, cost: Cost) {
         let extracted = termdag.to_string(&term);
-        log::info!("extracted with cost {cost}: {extracted}");
+        log::info!("New extractor extracted with cost {cost}: {extracted}");
         self.print_msg(extracted);
+        let _ = self.report.lock().unwrap().insert(crate::ExtractReport::Best { termdag: (termdag.clone()), cost: cost, term: (term.clone()) });
     }
 }
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,7 +1,10 @@
+use std::sync::{Arc, Mutex};
+
 use crate::ast::Symbol;
-use crate::sort::I64Sort;
+use crate::sort;
 use crate::termdag::{Term, TermDag};
 use crate::util::HashMap;
+use crate::IndexMap;
 use crate::{ArcSort, EGraph, Error, Function, HEntry, Id, Value};
 
 pub type Cost = usize;
@@ -218,12 +221,19 @@ impl<'a> Extractor<'a> {
 
 #[derive(Clone)]
 pub struct ExtractorAlter {
-    
+    rootsort : ArcSort,
+    functions : Arc<Mutex<IndexMap<Symbol, Function>>>
 }
 
-impl Default for ExtractorAlter {
-    fn default() -> Self {
-        ExtractorAlter {}
+impl ExtractorAlter {
+    pub fn new(
+        rootsort : ArcSort,
+        functions : Arc<Mutex<IndexMap<Symbol, Function>>>
+    ) -> Self {
+        ExtractorAlter {  
+            rootsort,
+            functions,
+        }
     }
 }
 
@@ -233,7 +243,8 @@ impl ExternalFunction for ExtractorAlter {
         assert!(args.len() == 2);
         let target = args[0];
         let nvariants = exec_state.prims().unwrap::<i64>(args[1]);
-        print!("target = {:?}, nvariants = {}", target, nvariants);
+        print!("target = {:?}, rootsort = {:?}, nvariants = {}", target, self.rootsort, nvariants);
+        panic!{"Stop right there"};
         Some(exec_state.prims().get::<()>(()))
     }
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,4 +1,5 @@
 use crate::ast::Symbol;
+use crate::sort::I64Sort;
 use crate::termdag::{Term, TermDag};
 use crate::util::HashMap;
 use crate::{ArcSort, EGraph, Error, Function, HEntry, Id, Value};
@@ -43,9 +44,9 @@ impl EGraph {
         termdag: &mut TermDag,
         arcsort: &ArcSort,
     ) -> Result<(Cost, Term), Error> {
-        if true {
-            todo!("extraction")
-        }
+        //if true {
+        //    todo!("extraction")
+        //}
 
         let extractor = Extractor::new(self, termdag);
         extractor.find_best(value, termdag, arcsort).ok_or_else(|| {
@@ -212,5 +213,27 @@ impl<'a> Extractor<'a> {
                 }
             }
         }
+    }
+}
+
+#[derive(Clone)]
+pub struct ExtractorAlter {
+    
+}
+
+impl Default for ExtractorAlter {
+    fn default() -> Self {
+        ExtractorAlter {}
+    }
+}
+
+use core_relations::{ExecutionState, ExternalFunction};
+impl ExternalFunction for ExtractorAlter {
+    fn invoke(&self, exec_state: &mut ExecutionState, args: &[core_relations::Value]) -> Option<core_relations::Value> {
+        assert!(args.len() == 2);
+        let target = args[0];
+        let nvariants = exec_state.prims().unwrap::<i64>(args[1]);
+        print!("target = {:?}, nvariants = {}", target, nvariants);
+        Some(exec_state.prims().get::<()>(()))
     }
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -471,7 +471,7 @@ impl ExtractorAlter {
         costs : &HashMap<Symbol, IndexMap<core_relations::Value, Cost>>
     ) -> Option<Cost> {
         if sort.is_container_sort() {
-            let elements = sort.inner_values(exec_state, value);
+            let elements = sort.inner_values(exec_state.containers(), value);
             let mut ch_costs: Vec<Cost> = Vec::new();
             for ch in elements.iter() {
                 if let Some (c) = self.compute_cost_node(exec_state,&ch.1, &ch.0, costs) {
@@ -524,10 +524,10 @@ impl ExtractorAlter {
         parent_edge : &HashMap<Symbol, HashMap<core_relations::Value, (Symbol, Vec<core_relations::Value>)>>
     ) -> Term {
         if sort.is_container_sort() {
-            let elements = sort.inner_values_and_sorts(exec_state, value);
+            let elements = sort.inner_values(exec_state.containers(), value);
             let mut ch_terms: Vec<Term> = Vec::new();
             for ch in elements.iter() {
-                ch_terms.push(self.reconstruct_termdag_node(exec_state, termdag, &ch.0, &ch.1, filtered_func, parent_edge));
+                ch_terms.push(self.reconstruct_termdag_node(exec_state, termdag, &ch.1, &ch.0, filtered_func, parent_edge));
             }
             sort.reconstruct_termdag_container(exec_state, value, termdag, ch_terms)
         } else if sort.is_eq_sort() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,8 @@ pub struct EGraph {
     /// Used for building the extract action
     extractor_view : Arc<ArcSwap<ExtractorView>>,
     extract_report: Option<ExtractReport>,
+    /// For testing the extractor
+    new_extract_report: Arc<Mutex<Option<ExtractReport>>>,
     /// The run report for the most recent run of a schedule.
     recent_run_report: Option<RunReport>,
     /// The run report unioned over all runs so far.
@@ -440,6 +442,7 @@ impl Default for EGraph {
             fact_directory: None,
             seminaive: true,
             extract_report: None,
+            new_extract_report: Arc::new(Mutex::new(None)),
             recent_run_report: None,
             overall_run_report: Default::default(),
             msgs: Arc::new(Mutex::new(Some(vec![]))),
@@ -1118,6 +1121,7 @@ impl EGraph {
                 &self.type_info,
                 &self.extractor_view,
                 &self.msgs,
+                &self.new_extract_report,
             );
             translator.query(&query, false);
             translator.actions(&actions)?;
@@ -1163,6 +1167,7 @@ impl EGraph {
                 &self.type_info,
                 &self.extractor_view,
                 &self.msgs,
+                &self.new_extract_report,
             );
             translator.actions(&actions)?;
             let id = translator.build();
@@ -1263,6 +1268,7 @@ impl EGraph {
                 &self.type_info,
                 &self.extractor_view,
                 &self.msgs,
+                &self.new_extract_report,
             );
             translator.query(&query, true);
             translator.rb.call_external_func(
@@ -1370,6 +1376,7 @@ impl EGraph {
                     // Update extractor_view before the top level extract command
                     self.extractor_view.store(Arc::new(ExtractorView::new(&self.functions, &self.backend)));
                     self.eval_actions(&ResolvedActions::new(vec![action.clone()]))?;
+                    self.check_extract_report_consistency();
                 }
                 _ => {
                     self.eval_actions(&ResolvedActions::new(vec![action.clone()]))?;
@@ -1695,8 +1702,30 @@ impl EGraph {
         self.type_info.get_sorts_by(f)
     }
 
+    pub fn check_extract_report_consistency(&self) {
+        let old_report = self.extract_report.clone();
+        let new_report = self.new_extract_report.lock().unwrap().clone();
+        if old_report.is_none() && new_report.is_none() {
+        } else if old_report.is_none() && !new_report.is_none() {
+            panic!("No old report found but found new report");
+        } else if !old_report.is_none() && new_report.is_none() {
+            panic!("No new report found but found old report");
+        } else {
+            let old_report = old_report.expect("Impossible");
+            let new_report = new_report.expect("Impossible");
+            match (old_report, new_report) {
+                (ExtractReport::Best { termdag: _old_termdag, cost: old_cost, term: _old_term },
+                 ExtractReport::Best { termdag: _new_termdag, cost: new_cost, term: _new_term }) => {
+                    debug_assert_eq!(old_cost, new_cost);
+                 }
+                _ => {}
+            }
+        }
+    }
+
     /// Gets the last extract report and returns it, if the last command saved it.
     pub fn get_extract_report(&self) -> &Option<ExtractReport> {
+        self.check_extract_report_consistency();
         &self.extract_report
     }
 
@@ -1736,6 +1765,7 @@ struct BackendRule<'a> {
     functions: &'a IndexMap<Symbol, Function>,
     type_info: &'a TypeInfo,
     msgs: &'a Arc<Mutex<Option<Vec<String>>>>,
+    report: &'a Arc<Mutex<Option<ExtractReport>>>,
     extractor_view: &'a Arc<ArcSwap<ExtractorView>>,
 }
 
@@ -1746,6 +1776,7 @@ impl<'a> BackendRule<'a> {
         type_info: &'a TypeInfo,
         extractor_view: &'a Arc<ArcSwap<ExtractorView>>,
         msgs: &'a Arc<Mutex<Option<Vec<String>>>>,
+        report: &'a Arc<Mutex<Option<ExtractReport>>>,
     ) -> BackendRule<'a> {
         BackendRule {
             rb,
@@ -1753,6 +1784,7 @@ impl<'a> BackendRule<'a> {
             type_info,
             extractor_view,
             msgs,
+            report,
             entries: Default::default(),
         }
     }
@@ -1949,7 +1981,7 @@ impl<'a> BackendRule<'a> {
                                 xsort,
                                 Arc::clone(self.extractor_view),
                                 extract::TreeAdditiveCostModel::default(),
-                                extract::EgraphMsgWriter::new(self.msgs.clone()),
+                                extract::EgraphMsgWriter::new(self.msgs.clone(), self.report.clone()),
                             );
                             let extract_func_id = self.rb.register_external_func(extractor);
                             self.rb.call_external_func(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,7 @@ pub struct EGraph {
     pub parser: Parser,
     egraphs: Vec<Self>,
     unionfind: UnionFind,
-    pub functions: IndexMap<Symbol, Function>,
+    pub functions: Arc<Mutex<IndexMap<Symbol, Function>>>,
     rulesets: IndexMap<Symbol, Ruleset>,
     rule_last_run_timestamp: HashMap<Symbol, u32>,
     interactive_mode: bool,
@@ -412,7 +412,6 @@ pub struct EGraph {
     pub fact_directory: Option<PathBuf>,
     pub seminaive: bool,
     type_info: TypeInfo,
-    extract_func_id: Option<ExternalFunctionId>,
     /// Used for building the extract action
     extract_report: Option<ExtractReport>,
     /// The run report for the most recent run of a schedule.
@@ -430,7 +429,7 @@ impl Default for EGraph {
             parser: Default::default(),
             egraphs: vec![],
             unionfind: Default::default(),
-            functions: Default::default(),
+            functions: Rc::new(RefCell::new(Default::default())),
             rulesets: Default::default(),
             rule_last_run_timestamp: Default::default(),
             timestamp: 0,
@@ -438,15 +437,12 @@ impl Default for EGraph {
             interactive_mode: false,
             fact_directory: None,
             seminaive: true,
-            extract_func_id: None,
             extract_report: None,
             recent_run_report: None,
             overall_run_report: Default::default(),
             msgs: Some(vec![]),
             type_info: Default::default(),
         };
-
-        eg.extract_func_id = Some (eg.backend.register_external_func(extract::ExtractorAlter::default()));
 
         eg.add_sort(UnitSort, span!()).unwrap();
         eg.add_sort(StringSort, span!()).unwrap();
@@ -554,7 +550,7 @@ impl EGraph {
     #[track_caller]
     fn debug_assert_invariants(&self) {
         #[cfg(debug_assertions)]
-        for (name, function) in self.functions.iter() {
+        for (name, function) in (*self.functions).borrow_mut().iter() {
             function.nodes.assert_sorted();
             for (i, inputs, output) in function.nodes.iter_range(0..function.nodes.len(), true) {
                 assert_eq!(inputs.len(), function.schema.input.len());
@@ -651,7 +647,7 @@ impl EGraph {
     fn rebuild_one(&mut self) -> Result<usize, Error> {
         let mut new_unions = 0;
         let mut deferred_merges = Vec::new();
-        for function in self.functions.values_mut() {
+        for function in (*self.functions).borrow_mut().values_mut() {
             let (unions, merges) = function.rebuild(&mut self.unionfind, self.timestamp)?;
             if !merges.is_empty() {
                 deferred_merges.push((function.decl.name, merges));
@@ -667,7 +663,9 @@ impl EGraph {
 
     fn apply_merges(&mut self, func: Symbol, merges: &[DeferredMerge]) -> usize {
         let mut stack = Vec::new();
-        let mut function = self.functions.get_mut(&func).unwrap();
+        let functions_clone = self.functions.clone();
+        let mut functions_borrow_mut = (*functions_clone).borrow_mut();
+        let mut function = functions_borrow_mut.get_mut(&func).unwrap();
         let n_unions = self.unionfind.n_unions();
         let merge_prog = match &function.merge {
             MergeFn::Expr(e) => Some(e.clone()),
@@ -680,7 +678,7 @@ impl EGraph {
                 self.run_actions(&mut stack, &[*old, *new], prog).unwrap();
                 let merged = stack.pop().expect("merges should produce a value");
                 stack.clear();
-                function = self.functions.get_mut(&func).unwrap();
+                function = functions_borrow_mut.get_mut(&func).unwrap();
                 function.insert(inputs, merged, self.timestamp);
             }
         }
@@ -1110,13 +1108,11 @@ impl EGraph {
             rule.to_canonicalized_core_rule(&self.type_info, &mut self.parser.symbol_gen)?;
         let (query, actions) = (core_rule.body, core_rule.head);
 
-        let extract_func_id = self.get_extract_func_id();
         let rule_id = {
             let mut translator = BackendRule::new(
                 self.backend.new_rule(name.into(), self.seminaive),
                 &self.functions,
                 &self.type_info,
-                extract_func_id,
             );
             translator.query(&query, false);
             translator.actions(&actions)?;
@@ -1155,13 +1151,11 @@ impl EGraph {
             &mut self.parser.symbol_gen,
         )?;
 
-        let extract_func_id = self.get_extract_func_id();
         let new_result = {
             let mut translator = BackendRule::new(
                 self.backend.new_rule("eval_actions", false),
                 &self.functions,
                 &self.type_info,
-                extract_func_id,
             );
             translator.actions(&actions)?;
             let id = translator.build();
@@ -1256,12 +1250,10 @@ impl EGraph {
                     Some(core_relations::Value::new_const(0))
                 }));
 
-            let extract_func_id = self.get_extract_func_id();
             let mut translator = BackendRule::new(
                 self.backend.new_rule("check_facts", false),
                 &self.functions,
                 &self.type_info,
-                extract_func_id,
             );
             translator.query(&query, true);
             translator.rb.call_external_func(
@@ -1687,10 +1679,6 @@ impl EGraph {
         self.type_info.get_sorts_by(f)
     }
 
-    pub fn get_extract_func_id(&self) -> ExternalFunctionId {
-        self.extract_func_id.expect("Uninitialized extract_func_id")
-    }
-
     /// Gets the last extract report and returns it, if the last command saved it.
     pub fn get_extract_report(&self) -> &Option<ExtractReport> {
         &self.extract_report
@@ -1725,25 +1713,21 @@ impl EGraph {
 struct BackendRule<'a> {
     pub rb: egglog_bridge::RuleBuilder<'a>,
     entries: HashMap<core::ResolvedAtomTerm, QueryEntry>,
-    functions: &'a IndexMap<Symbol, Function>,
+    functions: Rc<RefCell<IndexMap<Symbol, Function>>>,
     type_info: &'a TypeInfo,
-    // Can and should be in the backend egraph struct
-    extract_func_id: ExternalFunctionId,
 }
 
 impl<'a> BackendRule<'a> {
     fn new(
         rb: egglog_bridge::RuleBuilder<'a>,
-        functions: &'a IndexMap<Symbol, Function>,
+        functions: Rc<RefCell<IndexMap<Symbol, Function>>>,
         type_info: &'a TypeInfo,
-        extract_func_id: ExternalFunctionId,
     ) -> BackendRule<'a> {
         BackendRule {
             rb,
             functions,
             type_info,
             entries: Default::default(),
-            extract_func_id,
         }
     }
 
@@ -1920,10 +1904,27 @@ impl<'a> BackendRule<'a> {
                     match *n {
                         core::GenericAtomTerm::Literal(_, Literal::Int(variants)) => {
                             log::debug!("x = {:?} n = {:?}", x, variants);
+                            // Resolve the sort of the extract root and pass that to the extractor 
+                            let xsort = match x {
+                                core::GenericAtomTerm::Var(_, leaf) => leaf.sort.clone(),
+                                core::GenericAtomTerm::Global(_, leaf) => leaf.sort.clone(),
+                                core::GenericAtomTerm::Literal(_, literal) =>
+                                    match literal {
+                                        Literal::Bool(_) => self.type_info.get_sort::<BoolSort>() as Arc<dyn Sort>,
+                                        Literal::Int(_) => self.type_info.get_sort::<I64Sort>(),
+                                        Literal::Float(_) => self.type_info.get_sort::<F64Sort>(),
+                                        Literal::String(_) => self.type_info.get_sort::<StringSort>(),
+                                        Literal::Unit => self.type_info.get_sort::<UnitSort>(),
+                                    }
+                            };
                             let x = self.entry(x);
                             let n = self.entry(n);
+                            let extractor = extract::ExtractorAlter::new(
+                                xsort
+                            );
+                            let extract_func_id = self.rb.register_external_func(extractor);
                             self.rb.call_external_func(
-                                self.extract_func_id, 
+                                extract_func_id, 
                                 &vec![x, n], 
                                 ColumnTy::Primitive(self.rb.egraph().primitives().get_ty::<()>()), 
                                 format!("{span}: call of extract failed").as_str(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1716,7 +1716,9 @@ impl EGraph {
             match (old_report, new_report) {
                 (ExtractReport::Best { termdag: _old_termdag, cost: old_cost, term: _old_term },
                  ExtractReport::Best { termdag: _new_termdag, cost: new_cost, term: _new_term }) => {
-                    debug_assert_eq!(old_cost, new_cost);
+                    if old_cost != new_cost {
+                        panic!("Derived different extraction costs: {:?}, {:?}", old_cost, new_cost);
+                    }
                  }
                 _ => {}
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,6 +412,8 @@ pub struct EGraph {
     pub fact_directory: Option<PathBuf>,
     pub seminaive: bool,
     type_info: TypeInfo,
+    extract_func_id: Option<ExternalFunctionId>,
+    /// Used for building the extract action
     extract_report: Option<ExtractReport>,
     /// The run report for the most recent run of a schedule.
     recent_run_report: Option<RunReport>,
@@ -436,12 +438,15 @@ impl Default for EGraph {
             interactive_mode: false,
             fact_directory: None,
             seminaive: true,
+            extract_func_id: None,
             extract_report: None,
             recent_run_report: None,
             overall_run_report: Default::default(),
             msgs: Some(vec![]),
             type_info: Default::default(),
         };
+
+        eg.extract_func_id = Some (eg.backend.register_external_func(extract::ExtractorAlter::default()));
 
         eg.add_sort(UnitSort, span!()).unwrap();
         eg.add_sort(StringSort, span!()).unwrap();
@@ -1105,11 +1110,13 @@ impl EGraph {
             rule.to_canonicalized_core_rule(&self.type_info, &mut self.parser.symbol_gen)?;
         let (query, actions) = (core_rule.body, core_rule.head);
 
+        let extract_func_id = self.get_extract_func_id();
         let rule_id = {
             let mut translator = BackendRule::new(
                 self.backend.new_rule(name.into(), self.seminaive),
                 &self.functions,
                 &self.type_info,
+                extract_func_id,
             );
             translator.query(&query, false);
             translator.actions(&actions)?;
@@ -1148,11 +1155,13 @@ impl EGraph {
             &mut self.parser.symbol_gen,
         )?;
 
+        let extract_func_id = self.get_extract_func_id();
         let new_result = {
             let mut translator = BackendRule::new(
                 self.backend.new_rule("eval_actions", false),
                 &self.functions,
                 &self.type_info,
+                extract_func_id,
             );
             translator.actions(&actions)?;
             let id = translator.build();
@@ -1247,10 +1256,12 @@ impl EGraph {
                     Some(core_relations::Value::new_const(0))
                 }));
 
+            let extract_func_id = self.get_extract_func_id();
             let mut translator = BackendRule::new(
                 self.backend.new_rule("check_facts", false),
                 &self.functions,
                 &self.type_info,
+                extract_func_id,
             );
             translator.query(&query, true);
             translator.rb.call_external_func(
@@ -1676,6 +1687,10 @@ impl EGraph {
         self.type_info.get_sorts_by(f)
     }
 
+    pub fn get_extract_func_id(&self) -> ExternalFunctionId {
+        self.extract_func_id.expect("Uninitialized extract_func_id")
+    }
+
     /// Gets the last extract report and returns it, if the last command saved it.
     pub fn get_extract_report(&self) -> &Option<ExtractReport> {
         &self.extract_report
@@ -1712,6 +1727,8 @@ struct BackendRule<'a> {
     entries: HashMap<core::ResolvedAtomTerm, QueryEntry>,
     functions: &'a IndexMap<Symbol, Function>,
     type_info: &'a TypeInfo,
+    // Can and should be in the backend egraph struct
+    extract_func_id: ExternalFunctionId,
 }
 
 impl<'a> BackendRule<'a> {
@@ -1719,12 +1736,14 @@ impl<'a> BackendRule<'a> {
         rb: egglog_bridge::RuleBuilder<'a>,
         functions: &'a IndexMap<Symbol, Function>,
         type_info: &'a TypeInfo,
+        extract_func_id: ExternalFunctionId,
     ) -> BackendRule<'a> {
         BackendRule {
             rb,
             functions,
             type_info,
             entries: Default::default(),
+            extract_func_id,
         }
     }
 
@@ -1895,9 +1914,24 @@ impl<'a> BackendRule<'a> {
                     let x = self.entry(x);
                     let y = self.entry(y);
                     self.rb.union(x, y)
-                }
+                },
                 core::GenericCoreAction::Panic(_, message) => self.rb.panic(message.clone()),
-                core::GenericCoreAction::Extract(_, _x, _n) => todo!("no extraction yet"),
+                core::GenericCoreAction::Extract(span, x, n) => {
+                    match *n {
+                        core::GenericAtomTerm::Literal(_, Literal::Int(variants)) => {
+                            log::debug!("x = {:?} n = {:?}", x, variants);
+                            let x = self.entry(x);
+                            let n = self.entry(n);
+                            self.rb.call_external_func(
+                                self.extract_func_id, 
+                                &vec![x, n], 
+                                ColumnTy::Primitive(self.rb.egraph().primitives().get_ty::<()>()), 
+                                format!("{span}: call of extract failed").as_str(),
+                            );
+                        },
+                        _ => panic!("The number of variants to extract must be an i64"),
+                    }
+                },
             }
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1461,6 +1461,9 @@ impl EGraph {
                     self.backend.new_rule("outputs", false),
                     &self.functions,
                     &self.type_info,
+                    &self.extractor_view,
+                    &self.msgs,
+                    &self.new_extract_report,
                 );
                 let expr_types = exprs.iter().map(|e| e.output_type()).collect::<Vec<_>>();
                 for expr in exprs {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1344,7 +1344,7 @@ impl EGraph {
             }
             ResolvedNCommand::RunSchedule(sched) => {
                 // Update extractor_view before every rule run
-                self.extractor_view.store(Arc::new(ExtractorView::new(&self.functions)));
+                self.extractor_view.store(Arc::new(ExtractorView::new(&self.functions, &self.backend)));
                 let report = self.run_schedule(&sched);
                 log::info!("Ran schedule {}.", sched);
                 log::info!("Report: {}", report);
@@ -1365,7 +1365,7 @@ impl EGraph {
                 }
                 ResolvedAction::Extract(_, _, _) => {
                     // Update extractor_view before the top level extract command
-                    self.extractor_view.store(Arc::new(ExtractorView::new(&self.functions)));
+                    self.extractor_view.store(Arc::new(ExtractorView::new(&self.functions, &self.backend)));
                     self.eval_actions(&ResolvedActions::new(vec![action.clone()]))?;
                 }
                 _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1862,7 +1862,7 @@ impl<'a> BackendRule<'a> {
             qe_args[0] = self
                 .rb
                 .egraph()
-                .primitive_constant(ResolvedFunction { id, do_rebuild });
+                .primitive_constant(ResolvedFunction { id, do_rebuild, name });
         }
 
         (

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -310,7 +310,7 @@ impl EGraph {
             {
                 // Children will be empty unless this is a container sort
                 let children: Vec<egraph_serialize::NodeId> = sort
-                    .inner_values(self, value)
+                    .inner_values(self.backend.containers(), value)
                     .into_iter()
                     .map(|(s, v)| {
                         self.serialize_value(serializer, &s, &v, &self.value_to_class_id(&s, &v))

--- a/src/sort/bigint.rs
+++ b/src/sort/bigint.rs
@@ -81,7 +81,7 @@ impl Sort for BigIntSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<Z>())
     }
-    
+
     fn reconstruct_termdag_leaf(
         &self,
         exec_state: &core_relations::ExecutionState,

--- a/src/sort/bigint.rs
+++ b/src/sort/bigint.rs
@@ -81,6 +81,18 @@ impl Sort for BigIntSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<Z>())
     }
+    
+    fn reconstruct_termdag_leaf(
+        &self,
+        exec_state: &core_relations::ExecutionState,
+        value: &core_relations::Value,
+        termdag: &mut TermDag,
+    ) -> Term {
+        let bigint = exec_state.prims().unwrap_ref::<BigInt>(*value);
+
+        let as_string = termdag.lit(Literal::String(bigint.to_string().into()));
+        termdag.app("from_string".into(), vec![as_string])
+    }
 }
 
 impl FromSort for Z {

--- a/src/sort/bigrat.rs
+++ b/src/sort/bigrat.rs
@@ -149,7 +149,7 @@ impl Sort for BigRatSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<Q>())
     }
-    
+
     fn reconstruct_termdag_leaf(
         &self,
         exec_state: &core_relations::ExecutionState,
@@ -168,7 +168,6 @@ impl Sort for BigRatSort {
 
         termdag.app("bigrat".into(), vec![numer_term, denom_term])
     }
-
 }
 
 impl FromSort for Q {

--- a/src/sort/bigrat.rs
+++ b/src/sort/bigrat.rs
@@ -149,6 +149,26 @@ impl Sort for BigRatSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<Q>())
     }
+    
+    fn reconstruct_termdag_leaf(
+        &self,
+        exec_state: &core_relations::ExecutionState,
+        value: &core_relations::Value,
+        termdag: &mut TermDag,
+    ) -> Term {
+        let rat = exec_state.prims().unwrap_ref::<BigRational>(*value);
+        let numer = rat.numer();
+        let denom = rat.denom();
+
+        let numer_as_string = termdag.lit(Literal::String(numer.to_string().into()));
+        let denom_as_string = termdag.lit(Literal::String(denom.to_string().into()));
+
+        let numer_term = termdag.app("from_string".into(), vec![numer_as_string]);
+        let denom_term = termdag.app("from_string".into(), vec![denom_as_string]);
+
+        termdag.app("bigrat".into(), vec![numer_term, denom_term])
+    }
+
 }
 
 impl FromSort for Q {

--- a/src/sort/bool.rs
+++ b/src/sort/bool.rs
@@ -49,7 +49,7 @@ impl Sort for BoolSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<bool>())
     }
-    
+
     fn reconstruct_termdag_leaf(
         &self,
         exec_state: &core_relations::ExecutionState,
@@ -60,7 +60,6 @@ impl Sort for BoolSort {
 
         termdag.lit(Literal::Bool(*b))
     }
-    
 }
 
 impl IntoSort for bool {

--- a/src/sort/bool.rs
+++ b/src/sort/bool.rs
@@ -49,6 +49,18 @@ impl Sort for BoolSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<bool>())
     }
+    
+    fn reconstruct_termdag_leaf(
+        &self,
+        exec_state: &core_relations::ExecutionState,
+        value: &core_relations::Value,
+        termdag: &mut TermDag,
+    ) -> Term {
+        let b = exec_state.prims().unwrap_ref::<bool>(*value);
+
+        termdag.lit(Literal::Bool(*b))
+    }
+    
 }
 
 impl IntoSort for bool {

--- a/src/sort/f64.rs
+++ b/src/sort/f64.rs
@@ -76,7 +76,7 @@ impl Sort for F64Sort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<F>())
     }
-    
+
     fn reconstruct_termdag_leaf(
         &self,
         exec_state: &core_relations::ExecutionState,
@@ -87,7 +87,6 @@ impl Sort for F64Sort {
 
         termdag.lit(Literal::Float(*f))
     }
-
 }
 
 impl IntoSort for F {

--- a/src/sort/f64.rs
+++ b/src/sort/f64.rs
@@ -76,6 +76,18 @@ impl Sort for F64Sort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<F>())
     }
+    
+    fn reconstruct_termdag_leaf(
+        &self,
+        exec_state: &core_relations::ExecutionState,
+        value: &core_relations::Value,
+        termdag: &mut TermDag,
+    ) -> Term {
+        let f = exec_state.prims().unwrap_ref::<F>(*value);
+
+        termdag.lit(Literal::Float(*f))
+    }
+
 }
 
 impl IntoSort for F {

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -231,6 +231,8 @@ impl Sort for FunctionSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<NewFunctionContainer>())
     }
+    
+    //TODO: does not support extraction
 }
 
 impl IntoSort for OldFunctionContainer {

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -177,13 +177,10 @@ impl Sort for FunctionSort {
 
     fn inner_values(
         &self,
-        egraph: &EGraph,
+        containers: &core_relations::Containers,
         value: &core_relations::Value,
     ) -> Vec<(ArcSort, core_relations::Value)> {
-        let val = egraph
-            .backend
-            .containers()
-            .get_val::<NewFunctionContainer>(*value)
+        let val = containers.get_val::<NewFunctionContainer>(*value)
             .unwrap();
         self.inputs.iter().cloned().zip(val.iter()).collect()
     }

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -91,6 +91,18 @@ impl Sort for I64Sort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<i64>())
     }
+    
+    fn reconstruct_termdag_leaf(
+        &self,
+        exec_state: &core_relations::ExecutionState,
+        value: &core_relations::Value,
+        termdag: &mut TermDag,
+    ) -> Term {
+        let i = exec_state.prims().unwrap_ref::<i64>(*value);
+
+        termdag.lit(Literal::Int(*i))
+    }
+    
 }
 
 impl IntoSort for i64 {

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -91,7 +91,7 @@ impl Sort for I64Sort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<i64>())
     }
-    
+
     fn reconstruct_termdag_leaf(
         &self,
         exec_state: &core_relations::ExecutionState,
@@ -102,7 +102,6 @@ impl Sort for I64Sort {
 
         termdag.lit(Literal::Int(*i))
     }
-    
 }
 
 impl IntoSort for i64 {

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -104,7 +104,7 @@ impl Presort for MapSort {
             if v.is_container_sort() {
                 return Err(TypeError::DisallowedSort(
                     name,
-                    "Maps nested with other EqSort containers are not allowed".into(),
+                    "Maps nested with other containers are not allowed".into(),
                     v_span.clone(),
                 ));
             }
@@ -232,6 +232,23 @@ impl Sort for MapSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<MapContainer<core_relations::Value>>())
     }
+    
+    fn reconstruct_termdag_container(
+        &self,
+        _exec_state: &core_relations::ExecutionState,
+        _value: &core_relations::Value,
+        termdag: &mut TermDag,
+        element_terms: Vec<Term>,
+    ) -> Term {
+        let mut term = termdag.app("map-empty".into(), vec![]);
+
+        for x in element_terms.chunks(2) {
+            term = termdag.app("map-insert".into(), vec![term, x[0].clone(), x[1].clone()])
+        }
+
+        term
+    }
+
 }
 
 impl IntoSort for MapContainer<Value> {

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -164,9 +164,10 @@ impl Sort for MapSort {
     fn inner_values(
         &self,
         containers: &core_relations::Containers,
-        value: &core_relations::Value
+        value: &core_relations::Value,
     ) -> Vec<(ArcSort, core_relations::Value)> {
-        let val = containers.get_val::<MapContainer<core_relations::Value>>(*value)
+        let val = containers
+            .get_val::<MapContainer<core_relations::Value>>(*value)
             .unwrap()
             .clone();
         val.data
@@ -232,7 +233,7 @@ impl Sort for MapSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<MapContainer<core_relations::Value>>())
     }
-    
+
     fn reconstruct_termdag_container(
         &self,
         _exec_state: &core_relations::ExecutionState,
@@ -248,7 +249,6 @@ impl Sort for MapSort {
 
         term
     }
-
 }
 
 impl IntoSort for MapContainer<Value> {

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -138,6 +138,10 @@ impl Sort for MapSort {
         self
     }
 
+    fn inner_sorts(&self) -> Vec<&Arc<dyn Sort>> {
+        vec![&self.key, &self.value]
+    }
+
     fn is_container_sort(&self) -> bool {
         true
     }
@@ -159,13 +163,10 @@ impl Sort for MapSort {
 
     fn inner_values(
         &self,
-        egraph: &EGraph,
-        value: &core_relations::Value,
+        containers: &core_relations::Containers,
+        value: &core_relations::Value
     ) -> Vec<(ArcSort, core_relations::Value)> {
-        let val = egraph
-            .backend
-            .containers()
-            .get_val::<MapContainer<core_relations::Value>>(*value)
+        let val = containers.get_val::<MapContainer<core_relations::Value>>(*value)
             .unwrap()
             .clone();
         val.data

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -51,6 +51,13 @@ pub trait Sort: Any + Send + Sync + Debug {
 
     fn column_ty(&self, backend: &egglog_bridge::EGraph) -> ColumnTy;
 
+    // return the inner sorts if a container sort
+    // remember that containers can contain containers
+    // and this only unfold one level
+    fn inner_sorts(&self) -> Vec<&Arc<dyn Sort>> {
+        vec![]
+    }
+
     fn register_type(&self, backend: &mut egglog_bridge::EGraph);
 
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static>;
@@ -107,7 +114,7 @@ pub trait Sort: Any + Send + Sync + Debug {
     /// Only container sort need to implement this method,
     fn inner_values(
         &self,
-        egraph: &EGraph,
+        containers: &core_relations::Containers,
         value: &core_relations::Value,
     ) -> Vec<(ArcSort, core_relations::Value)> {
         debug_assert!(!self.is_container_sort());

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -146,6 +146,54 @@ pub trait Sort: Any + Send + Sync + Debug {
         _extractor: &Extractor,
         _termdag: &mut TermDag,
     ) -> Option<(Cost, Term)>;
+
+    /// Default cost for containers when the cost model does not specify the cost
+    fn default_container_cost(
+        &self,
+        _exec_state: &core_relations::ExecutionState,
+        _value: &core_relations::Value,
+        element_costs: &Vec<Cost>,
+    ) -> Cost {
+        element_costs.iter().fold(0, |s, c| { s.saturating_add(*c) })
+    }
+
+    /// Default cost for leaf primitives when the cost model does not specify the cost
+    fn default_leaf_cost(
+        &self,
+        _exec_state: &core_relations::ExecutionState,
+        _value: &core_relations::Value,
+    ) -> Cost {
+        1
+    }
+    
+    /// Reconstruct a container value in a TermDag
+    fn reconstruct_termdag_container(
+        &self,
+        exec_state: &core_relations::ExecutionState,
+        value: &core_relations::Value,
+        termdag: &mut TermDag,
+        element_terms: Vec<Term>,
+    ) -> Term {
+        let _exec_state = exec_state;
+        let _value = value;
+        let _termdag = termdag;
+        let _element_terms = element_terms;
+        panic!("Not Implemented");
+    }
+
+    /// Reconstruct a leaf primitive value in a TermDag
+    fn reconstruct_termdag_leaf(
+        &self,
+        exec_state: &core_relations::ExecutionState,
+        value: &core_relations::Value,
+        termdag: &mut TermDag,
+    ) -> Term {
+        let _exec_state = exec_state;
+        let _value = value;
+        let _termdag = termdag;
+        panic!("Not Implemented");
+    }
+
 }
 
 // Note: this trait is currently intended to be implemented on the

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -119,7 +119,7 @@ pub trait Sort: Any + Send + Sync + Debug {
     ) -> Vec<(ArcSort, core_relations::Value)> {
         debug_assert!(!self.is_container_sort());
         let _ = value;
-        let _ = egraph;
+        let _ = containers;
         vec![]
     }
 
@@ -178,7 +178,7 @@ pub trait Sort: Any + Send + Sync + Debug {
         let _value = value;
         let _termdag = termdag;
         let _element_terms = element_terms;
-        todo!("reconstruct_termdag_container");
+        todo!("reconstruct_termdag_container : {}", self.name());
     }
 
     /// Reconstruct a leaf primitive value in a TermDag
@@ -191,7 +191,7 @@ pub trait Sort: Any + Send + Sync + Debug {
         let _exec_state = exec_state;
         let _value = value;
         let _termdag = termdag;
-        todo!("reconstruct_termdag_leaf");
+        todo!("reconstruct_termdag_leaf : {}", self.name());
     }
 
 }

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -178,7 +178,7 @@ pub trait Sort: Any + Send + Sync + Debug {
         let _value = value;
         let _termdag = termdag;
         let _element_terms = element_terms;
-        panic!("Not Implemented");
+        todo!("reconstruct_termdag_container");
     }
 
     /// Reconstruct a leaf primitive value in a TermDag
@@ -191,7 +191,7 @@ pub trait Sort: Any + Send + Sync + Debug {
         let _exec_state = exec_state;
         let _value = value;
         let _termdag = termdag;
-        panic!("Not Implemented");
+        todo!("reconstruct_termdag_leaf");
     }
 
 }

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -151,21 +151,21 @@ pub trait Sort: Any + Send + Sync + Debug {
     fn default_container_cost(
         &self,
         _exec_state: &core_relations::ExecutionState,
-        _value: &core_relations::Value,
-        element_costs: &Vec<Cost>,
+        _value: core_relations::Value,
+        element_costs: &[Cost],
     ) -> Cost {
-        element_costs.iter().fold(0, |s, c| { s.saturating_add(*c) })
+        element_costs.iter().fold(0, |s, c| s.saturating_add(*c))
     }
 
     /// Default cost for leaf primitives when the cost model does not specify the cost
     fn default_leaf_cost(
         &self,
         _exec_state: &core_relations::ExecutionState,
-        _value: &core_relations::Value,
+        _value: core_relations::Value,
     ) -> Cost {
         1
     }
-    
+
     /// Reconstruct a container value in a TermDag
     fn reconstruct_termdag_container(
         &self,
@@ -193,7 +193,6 @@ pub trait Sort: Any + Send + Sync + Debug {
         let _termdag = termdag;
         todo!("reconstruct_termdag_leaf : {}", self.name());
     }
-
 }
 
 // Note: this trait is currently intended to be implemented on the

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -204,6 +204,15 @@ impl Sort for MultiSetSort {
         }
         Some((cost, termdag.app("multiset-of".into(), children)))
     }
+    fn reconstruct_termdag_container(
+        &self,
+        _exec_state: &core_relations::ExecutionState,
+        _value: &core_relations::Value,
+        termdag: &mut TermDag,
+        element_terms: Vec<Term>,
+    ) -> Term {
+        termdag.app("multiset-of".into(), element_terms)
+    }
 
     fn serialized_name(&self, _value: &core_relations::Value) -> Symbol {
         "multiset-of".into()

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -117,7 +117,8 @@ impl Sort for MultiSetSort {
         containers: &core_relations::Containers,
         value: &core_relations::Value,
     ) -> Vec<(ArcSort, core_relations::Value)> {
-        let val = containers.get_val::<MultiSetContainer<core_relations::Value>>(*value)
+        let val = containers
+            .get_val::<MultiSetContainer<core_relations::Value>>(*value)
             .unwrap()
             .clone();
         val.data

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -96,6 +96,10 @@ impl Sort for MultiSetSort {
         backend.register_container_ty::<MultiSetContainer<core_relations::Value>>();
     }
 
+    fn inner_sorts(&self) -> Vec<&Arc<dyn Sort>> {
+        vec![&self.element]
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
         self
     }
@@ -110,13 +114,10 @@ impl Sort for MultiSetSort {
 
     fn inner_values(
         &self,
-        egraph: &EGraph,
+        containers: &core_relations::Containers,
         value: &core_relations::Value,
     ) -> Vec<(ArcSort, core_relations::Value)> {
-        let val = egraph
-            .backend
-            .containers()
-            .get_val::<MultiSetContainer<core_relations::Value>>(*value)
+        let val = containers.get_val::<MultiSetContainer<core_relations::Value>>(*value)
             .unwrap()
             .clone();
         val.data

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -103,6 +103,10 @@ impl Sort for SetSort {
         self
     }
 
+    fn inner_sorts(&self) -> Vec<&Arc<dyn Sort>> {
+        vec![&self.element]
+    }    
+
     fn is_container_sort(&self) -> bool {
         true
     }
@@ -113,13 +117,10 @@ impl Sort for SetSort {
 
     fn inner_values(
         &self,
-        egraph: &EGraph,
+        containers: &core_relations::Containers,
         value: &core_relations::Value,
     ) -> Vec<(ArcSort, core_relations::Value)> {
-        let val = egraph
-            .backend
-            .containers()
-            .get_val::<SetContainer<core_relations::Value>>(*value)
+        let val = containers.get_val::<SetContainer<core_relations::Value>>(*value)
             .unwrap()
             .clone();
         val.data
@@ -138,6 +139,7 @@ impl Sort for SetSort {
         }
         result
     }
+
     fn canonicalize(&self, value: &mut Value, unionfind: &UnionFind) -> bool {
         let sets = self.sets.lock().unwrap();
         let set = sets.get_index(value.bits as usize).unwrap();

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -105,7 +105,7 @@ impl Sort for SetSort {
 
     fn inner_sorts(&self) -> Vec<&Arc<dyn Sort>> {
         vec![&self.element]
-    }    
+    }
 
     fn is_container_sort(&self) -> bool {
         true
@@ -120,7 +120,8 @@ impl Sort for SetSort {
         containers: &core_relations::Containers,
         value: &core_relations::Value,
     ) -> Vec<(ArcSort, core_relations::Value)> {
-        let val = containers.get_val::<SetContainer<core_relations::Value>>(*value)
+        let val = containers
+            .get_val::<SetContainer<core_relations::Value>>(*value)
             .unwrap()
             .clone();
         val.data

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -196,6 +196,16 @@ impl Sort for SetSort {
         Some((cost, termdag.app("set-of".into(), children)))
     }
 
+    fn reconstruct_termdag_container(
+        &self,
+        _exec_state: &core_relations::ExecutionState,
+        _value: &core_relations::Value,
+        termdag: &mut TermDag,
+        element_terms: Vec<Term>,
+    ) -> Term {
+        termdag.app("set-of".into(), element_terms)
+    }
+
     fn serialized_name(&self, _value: &core_relations::Value) -> Symbol {
         "set-of".into()
     }

--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -65,7 +65,6 @@ impl Sort for StringSort {
 
         termdag.lit(Literal::String(*s))
     }
-
 }
 
 // TODO could use a local symbol table

--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -55,6 +55,17 @@ impl Sort for StringSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<S>())
     }
+    fn reconstruct_termdag_leaf(
+        &self,
+        exec_state: &core_relations::ExecutionState,
+        value: &core_relations::Value,
+        termdag: &mut TermDag,
+    ) -> Term {
+        let s = exec_state.prims().unwrap_ref::<S>(*value);
+
+        termdag.lit(Literal::String(*s))
+    }
+
 }
 
 // TODO could use a local symbol table

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -37,6 +37,16 @@ impl Sort for UnitSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<()>())
     }
+    
+    fn reconstruct_termdag_leaf(
+        &self,
+        _exec_state: &core_relations::ExecutionState,
+        _value: &core_relations::Value,
+        termdag: &mut TermDag,
+    ) -> Term {
+        termdag.lit(Literal::Unit)
+    }
+
 }
 
 impl IntoSort for () {

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -37,7 +37,7 @@ impl Sort for UnitSort {
     fn value_type(&self) -> Option<TypeId> {
         Some(TypeId::of::<()>())
     }
-    
+
     fn reconstruct_termdag_leaf(
         &self,
         _exec_state: &core_relations::ExecutionState,
@@ -46,7 +46,6 @@ impl Sort for UnitSort {
     ) -> Term {
         termdag.lit(Literal::Unit)
     }
-
 }
 
 impl IntoSort for () {

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -123,7 +123,8 @@ impl Sort for VecSort {
         containers: &core_relations::Containers,
         value: &core_relations::Value,
     ) -> Vec<(ArcSort, core_relations::Value)> {
-        let val = containers.get_val::<VecContainer<core_relations::Value>>(*value)
+        let val = containers
+            .get_val::<VecContainer<core_relations::Value>>(*value)
             .unwrap()
             .clone();
         val.data

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -197,6 +197,20 @@ impl Sort for VecSort {
         }
     }
 
+    fn reconstruct_termdag_container(
+        &self,
+        _exec_state: &core_relations::ExecutionState,
+        _value: &core_relations::Value,
+        termdag: &mut TermDag,
+        element_terms: Vec<Term>,
+    ) -> Term {
+        if element_terms.is_empty() {
+            termdag.app("vec-empty".into(), vec![])
+        } else {
+            termdag.app("vec-of".into(), element_terms)
+        }
+    }
+
     fn serialized_name(&self, _value: &core_relations::Value) -> Symbol {
         "vec-of".into()
     }

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -66,7 +66,7 @@ impl Presort for VecSort {
             if e.is_eq_container_sort() {
                 return Err(TypeError::DisallowedSort(
                     name,
-                    "Sets nested with other EqSort containers are not allowed".into(),
+                    "Vec nested with other EqSort containers are not allowed".into(),
                     span.clone(),
                 ));
             }
@@ -99,6 +99,10 @@ impl Sort for VecSort {
         self
     }
 
+    fn inner_sorts(&self) -> Vec<&Arc<dyn Sort>> {
+        vec![&self.element]
+    }
+
     fn is_container_sort(&self) -> bool {
         true
     }
@@ -116,13 +120,10 @@ impl Sort for VecSort {
 
     fn inner_values(
         &self,
-        egraph: &EGraph,
+        containers: &core_relations::Containers,
         value: &core_relations::Value,
     ) -> Vec<(ArcSort, core_relations::Value)> {
-        let val = egraph
-            .backend
-            .containers()
-            .get_val::<VecContainer<core_relations::Value>>(*value)
+        let val = containers.get_val::<VecContainer<core_relations::Value>>(*value)
             .unwrap()
             .clone();
         val.data

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,18 +3,17 @@ use symbol_table::GlobalSymbol;
 
 #[test]
 fn test_simple_extract1() {
-
     let _ = env_logger::builder().is_test(true).try_init();
 
     let mut egraph = EGraph::default();
 
-    let result =
-    egraph.parse_and_run_program(
-        None,
-        r#"
+    let result = egraph
+        .parse_and_run_program(
+            None,
+            r#"
              (datatype Op (Add i64 i64))
              (let expr (Add 1 1))
-             (extract expr)"#
+             (extract expr)"#,
         )
         .unwrap();
 
@@ -23,14 +22,14 @@ fn test_simple_extract1() {
 
 #[test]
 fn test_simple_extract2() {
-
     let _ = env_logger::builder().is_test(true).try_init();
 
     let mut egraph = EGraph::default();
 
-    egraph.parse_and_run_program(
-        None,
-        r#"
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
              (datatype Term
                (Origin :cost 0) 
                (BigStep Term :cost 10)
@@ -46,7 +45,7 @@ fn test_simple_extract2() {
              (let tssss (SmallStep tsss))
              (union tssss tb)
              (extract tb)
-             "#
+             "#,
         )
         .unwrap();
 
@@ -61,14 +60,14 @@ fn test_simple_extract2() {
 
 #[test]
 fn test_simple_extract3() {
-
     let _ = env_logger::builder().is_test(true).try_init();
 
     let mut egraph = EGraph::default();
 
-    egraph.parse_and_run_program(
-        None,
-        r#"
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
              (datatype Fruit
                (Apple i64 :cost 1) 
                (Orange f64 :cost 2)
@@ -82,10 +81,9 @@ fn test_simple_extract3() {
              (let b (Broccoli true))
              (let c (Carrot a))
              (extract a)
-             "#
+             "#,
         )
         .unwrap();
-
 }
 
 /*
@@ -99,15 +97,15 @@ fn test_simple_extract4() {
     egraph.parse_and_run_program(
         None,
         r#"
-             (datatype Foo 
+             (datatype Foo
                 (Foobar i64)
-             ) 
+             )
              (let foobar (Foobar 42))
              (datatype Bar
                 (Barfoo i64)
              )
              (let barfoo (Barfoo 24))
-             (datatype Baz 
+             (datatype Baz
                 (Bazfoo i64)
              )
              (sort QuaMap (Map Foo Bar))
@@ -125,14 +123,14 @@ fn test_simple_extract4() {
 
 #[test]
 fn test_simple_extract5() {
-
     let _ = env_logger::builder().is_test(true).try_init();
 
     let mut egraph = EGraph::default();
 
-    egraph.parse_and_run_program(
-        None,
-        r#"
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
              (datatype Foo 
                 (Foobar i64)
              ) 
@@ -146,44 +144,42 @@ fn test_simple_extract5() {
              (function Quaz () QuaMap :no-merge)
              (set (Quaz) (map-empty))
              (extract (Quaz))
-             "#
+             "#,
         )
         .unwrap();
-
 }
 
 #[test]
 fn test_simple_extract6() {
-
     let _ = env_logger::builder().is_test(true).try_init();
 
     let mut egraph = EGraph::default();
 
-    egraph.parse_and_run_program(
-        None,
-        r#"
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
              (datatype False)
              (sort QuaVec (Vec i64))
              (sort QuaMap (Map QuaVec False))
              (function Quaz () QuaMap :no-merge)
              (set (Quaz) (map-empty))
              (extract (Quaz))
-             "#
+             "#,
         )
         .unwrap();
-
 }
 
 #[test]
 fn test_simple_extract7() {
-
     let _ = env_logger::builder().is_test(true).try_init();
 
     let mut egraph = EGraph::default();
 
-    egraph.parse_and_run_program(
-        None,
-        r#"
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
             (datatype Foo
                 (bar)
                 (baz)
@@ -211,10 +207,9 @@ fn test_simple_extract7() {
 
             ;(extract (toerr map2))
 
-             "#
+             "#,
         )
         .unwrap();
-
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,6 +2,70 @@ use egglog::{ast::Expr, *};
 use symbol_table::GlobalSymbol;
 
 #[test]
+fn test_simple_extract1() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut egraph = EGraph::default();
+
+    let result =
+    egraph.parse_and_run_program(
+        None,
+        r#"
+             (datatype Op (Add i64 i64))
+             (let expr (Add 1 1))
+             (extract expr)"#
+        )
+        .unwrap();
+
+    log::debug!("{}", result.join("\n"));
+    /* 
+    let mut termdag = TermDag::default();
+    let (sort, value) = egraph.eval_expr(&egglog::var!("expr")).unwrap();
+    let (_, extracted) = egraph.extract(value, &mut termdag, &sort).unwrap();
+    assert_eq!(termdag.to_string(&extracted), "(Add 1 1)");
+    */
+}
+
+#[test]
+fn test_simple_extract2() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut egraph = EGraph::default();
+
+    egraph.parse_and_run_program(
+        None,
+        r#"
+             (datatype Term
+               (Origin :cost 0) 
+               (BigStep Term :cost 10)
+               (SmallStep Term :cost 1)
+             )
+             (let t (Origin))
+             (let tb (BigStep t))
+             (let tbs (SmallStep tb))
+             (let ts (SmallStep t))
+             (let tss (SmallStep ts))
+             (let tsss (SmallStep tss))
+             (union tbs tsss)
+             (let tssss (SmallStep tsss))
+             (union tssss tb)
+             "#
+        )
+        .unwrap();
+
+    /*
+    let mut termdag = TermDag::default();
+    let (sort, value) = egraph.eval_expr(&egglog::var!("tb")).unwrap();
+    let (cost, extracted) = egraph.extract(value, &mut termdag, &sort).unwrap();
+    assert_eq!(cost, 4);
+    assert_eq!(termdag.to_string(&extracted), "(SmallStep (SmallStep (SmallStep (SmallStep (Origin)))))");
+    */
+}
+
+
+#[test]
 fn test_subsumed_unextractable_action_extract() {
     // Test when an expression is subsumed, it isn't extracted, even if its the cheapest
     let mut egraph = EGraph::default();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19,12 +19,6 @@ fn test_simple_extract1() {
         .unwrap();
 
     log::debug!("{}", result.join("\n"));
-    /* 
-    let mut termdag = TermDag::default();
-    let (sort, value) = egraph.eval_expr(&egglog::var!("expr")).unwrap();
-    let (_, extracted) = egraph.extract(value, &mut termdag, &sort).unwrap();
-    assert_eq!(termdag.to_string(&extracted), "(Add 1 1)");
-    */
 }
 
 #[test]
@@ -221,7 +215,6 @@ fn test_simple_extract7() {
         )
         .unwrap();
 
-    panic!("!!");
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -48,14 +48,6 @@ fn test_simple_extract2() {
              "#,
         )
         .unwrap();
-
-    /*
-    let mut termdag = TermDag::default();
-    let (sort, value) = egraph.eval_expr(&egglog::var!("tb")).unwrap();
-    let (cost, extracted) = egraph.extract(value, &mut termdag, &sort).unwrap();
-    assert_eq!(cost, 4);
-    assert_eq!(termdag.to_string(&extracted), "(SmallStep (SmallStep (SmallStep (SmallStep (Origin)))))");
-    */
 }
 
 #[test]
@@ -210,6 +202,37 @@ fn test_simple_extract7() {
              "#,
         )
         .unwrap();
+}
+
+#[test]
+fn test_extract_variants1() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut egraph = EGraph::default();
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+             (datatype Term
+               (Origin :cost 0) 
+               (BigStep Term :cost 10)
+               (SmallStep Term :cost 1)
+             )
+             (let t (Origin))
+             (let tb (BigStep t))
+             (let tbs (SmallStep tb))
+             (let ts (SmallStep t))
+             (let tss (SmallStep ts))
+             (let tsss (SmallStep tss))
+             (union tbs tsss)
+             (let tssss (SmallStep tsss))
+             (union tssss tb)
+             (extract tb 3)
+             "#,
+        )
+        .unwrap();
+    panic!("!!");
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -181,6 +181,50 @@ fn test_simple_extract6() {
 }
 
 #[test]
+fn test_simple_extract7() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut egraph = EGraph::default();
+
+    egraph.parse_and_run_program(
+        None,
+        r#"
+            (datatype Foo
+                (bar)
+                (baz)
+            )
+            (sort Mapsrt1 (Map i64 Foo))
+            (let map1 (map-insert (map-empty) 0 (bar)))
+            
+            (sort Mapsrt2 (Map bool Foo))
+            (let map2 (map-insert (map-empty) false (baz)))
+            ;(let map2b (map-insert (map-empty) false (bar)))
+            ;(union map2 map2b)
+
+            ;(extract map1)
+            ;(extract map2)
+            
+            ;(function toerr (Mapsrt2) Foo :no-merge)
+
+            ;(set (toerr map2) (bar))
+
+            (union (bar) (baz))
+            ; Also unions map1 and map2!?
+
+            (extract map1)
+            (extract map2)
+
+            ;(extract (toerr map2))
+
+             "#
+        )
+        .unwrap();
+
+    panic!("!!");
+}
+
+#[test]
 fn test_subsumed_unextractable_action_extract() {
     // Test when an expression is subsumed, it isn't extracted, even if its the cheapest
     let mut egraph = EGraph::default();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -78,40 +78,29 @@ fn test_simple_extract3() {
         .unwrap();
 }
 
-/*
 #[test]
 fn test_simple_extract4() {
-
     let _ = env_logger::builder().is_test(true).try_init();
 
     let mut egraph = EGraph::default();
 
-    egraph.parse_and_run_program(
-        None,
-        r#"
-             (datatype Foo
-                (Foobar i64)
-             )
-             (let foobar (Foobar 42))
-             (datatype Bar
-                (Barfoo i64)
-             )
-             (let barfoo (Barfoo 24))
-             (datatype Baz
-                (Bazfoo i64)
-             )
-             (sort QuaMap (Map Foo Bar))
-             (sort QuaVecMap (Vec QuaMap))
-             (sort QuaVVM (Vec QuaVecMap))
-             (function Quaz () QuaVVM :no-merge)
-             (set (Quaz) (vec-empty))
-             (extract (Quaz))
-             "#
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+        (datatype Foo
+            (Foobar)
         )
-        .unwrap();
-
+        (subsume (Foobar))
+        (datatype Bar
+            (Barbar Foo)
+        )
+        (let x (Barbar (Foobar)))
+        (extract x)
+        "#,
+        )
+        .unwrap_err();
 }
-*/
 
 #[test]
 fn test_simple_extract5() {
@@ -232,7 +221,6 @@ fn test_extract_variants1() {
              "#,
         )
         .unwrap();
-    panic!("!!");
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -51,6 +51,7 @@ fn test_simple_extract2() {
              (union tbs tsss)
              (let tssss (SmallStep tsss))
              (union tssss tb)
+             (extract tb)
              "#
         )
         .unwrap();
@@ -64,6 +65,120 @@ fn test_simple_extract2() {
     */
 }
 
+#[test]
+fn test_simple_extract3() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut egraph = EGraph::default();
+
+    egraph.parse_and_run_program(
+        None,
+        r#"
+             (datatype Fruit
+               (Apple i64 :cost 1) 
+               (Orange f64 :cost 2)
+             )
+             (datatype Vegetable
+               (Broccoli bool :cost 3)
+               (Carrot Fruit :cost 4)
+             )
+             (let a (Apple 5))
+             (let o (Orange 3.14))
+             (let b (Broccoli true))
+             (let c (Carrot a))
+             (extract a)
+             "#
+        )
+        .unwrap();
+
+}
+
+/*
+#[test]
+fn test_simple_extract4() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut egraph = EGraph::default();
+
+    egraph.parse_and_run_program(
+        None,
+        r#"
+             (datatype Foo 
+                (Foobar i64)
+             ) 
+             (let foobar (Foobar 42))
+             (datatype Bar
+                (Barfoo i64)
+             )
+             (let barfoo (Barfoo 24))
+             (datatype Baz 
+                (Bazfoo i64)
+             )
+             (sort QuaMap (Map Foo Bar))
+             (sort QuaVecMap (Vec QuaMap))
+             (sort QuaVVM (Vec QuaVecMap))
+             (function Quaz () QuaVVM :no-merge)
+             (set (Quaz) (vec-empty))
+             (extract (Quaz))
+             "#
+        )
+        .unwrap();
+
+}
+*/
+
+#[test]
+fn test_simple_extract5() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut egraph = EGraph::default();
+
+    egraph.parse_and_run_program(
+        None,
+        r#"
+             (datatype Foo 
+                (Foobar i64)
+             ) 
+             (let foobar (Foobar 42))
+             (datatype Bar
+                (Barfoo i64)
+             )
+             (let barfoo (Barfoo 24))
+             (sort QuaVec (Vec i64))
+             (sort QuaMap (Map QuaVec Foo))
+             (function Quaz () QuaMap :no-merge)
+             (set (Quaz) (map-empty))
+             (extract (Quaz))
+             "#
+        )
+        .unwrap();
+
+}
+
+#[test]
+fn test_simple_extract6() {
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut egraph = EGraph::default();
+
+    egraph.parse_and_run_program(
+        None,
+        r#"
+             (datatype False)
+             (sort QuaVec (Vec i64))
+             (sort QuaMap (Map QuaVec False))
+             (function Quaz () QuaMap :no-merge)
+             (set (Quaz) (map-empty))
+             (extract (Quaz))
+             "#
+        )
+        .unwrap();
+
+}
 
 #[test]
 fn test_subsumed_unextractable_action_extract() {


### PR DESCRIPTION
This PR implements the extract action for the new backend. It uses the default additive tree cost model, and as an action, it supports being invoked as a top-level command and a rule action.

Implementation Overview:

- The extract action is implemented as an `ExternalFunction` in the front end. The front-end `BackendRule` creates new instances of `ExtractorAlter` for each extract action and registers it as a new `ExternalFunction`. It passes the root sort, a reference to `extractor_view`, and a reference to an `ExtractionWriter` to each instance.
- Extraction requires function schemas to compute costs. `egglog::EGraph` now has a new field `extractor_view: Arc<ArcSwap<ExtractorView>>` which is a thread-safe copy of this information. This field is updated before an extract action can happen. A reference to this field is passed to each extractor instance at creation time. Each extractor would read and copy relevant information each time its `invoke` is called.
- As an optimization, `ExtractorAlter` first performs a BFS on the sorts to filter out tables unreachable from the root sort.
- `ExtractorAlter` performs Bellman-Ford to compute the costs for the output terms of those tables. It calls `inner_sorts` and `inner_values` on the sorts to unpack containers and calls the cost model for primitive, container, and function costs.
- After Bellman-Ford finds a fixpoint, the extractor enumerates all rows again to copy information for reconstruction. Ties are broken arbitrarily.
- For extracting a single lowest-cost term, it recursively reconstructs the lowest-cost enode for each eclass used in the lowest-cost enode of the root eclass and writes into a `TermDag` struct.
- For extracting multiple "diverse" variants, it extracts the multiple enodes of the root eclass, in the order of lowest costs, using a single lowest-cost enode for other eclasses.
- Finally, it passes the `termdag`, the `term(s)`, and the `cost(s)` to the `ExtractionWriter` for output. Currently, the default `ExtractionWriter` mimics the old backend's output behaviors by writing into the `EGraph.msgs` buffer and `EGraph.new_extract_report`. The latter is used to check compatibility with the older extractor, i.e., whether an extractable term is found and, if found, whether they have the same costs.

Known Issues/Caveats:

- Same as the old backend, there's a lot of redundancy in extraction as a rule action because the costs are recomputed for each match. However, this might be hard to optimize due to the parallel nature of the new backend.
- The `ExtractorAlter` does not maintain extraction states such as costs or reconstruction hints. It recomputes from scratch every time `invoke` is called. The old extractor extracts everything when it is initialized and uses that information for all future queries.
- Extract now has a different semantics as a rule action because it cannot see the updates that has been applied by the rule so far, whereas in the old backend, it could.

