### PR TITLE
Underscores, shadowing, and misc.

### DIFF
--- a/src/ast/check_shadowing.rs
+++ b/src/ast/check_shadowing.rs
@@ -1,0 +1,100 @@
+use crate::*;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Names(HashMap<Symbol, Span>);
+
+impl Names {
+    pub(crate) fn check_shadowing(&mut self, program: &[ResolvedNCommand]) -> Result<(), Error> {
+        for command in program {
+            self.check_shadowing_command(command)?;
+        }
+        Ok(())
+    }
+
+    fn check(&mut self, name: Symbol, new: Span) -> Result<(), Error> {
+        if let Some(old) = self.0.get(&name) {
+            Err(Error::Shadowing(name, old.clone(), new))
+        } else {
+            self.0.insert(name, new);
+            Ok(())
+        }
+    }
+
+    fn check_shadowing_command(&mut self, command: &ResolvedNCommand) -> Result<(), Error> {
+        match command {
+            ResolvedNCommand::Sort(span, name, _args) => self.check(*name, span.clone()),
+            ResolvedNCommand::Function(decl) => self.check(decl.name, decl.span.clone()),
+            ResolvedNCommand::AddRuleset(span, name) => self.check(*name, span.clone()),
+            ResolvedNCommand::UnstableCombinedRuleset(span, name, _args) => {
+                self.check(*name, span.clone())
+            }
+            ResolvedNCommand::NormRule { rule, .. } => {
+                let mut inner = self.clone();
+                inner.check_shadowing_query(&rule.body)?;
+                for action in rule.head.iter() {
+                    inner.check_shadowing_action(action)?;
+                }
+                Ok(())
+            }
+            ResolvedNCommand::CoreAction(action) => self.check_shadowing_action(action),
+            ResolvedNCommand::Check(_span, query) => {
+                let mut inner = self.clone();
+                inner.check_shadowing_query(query)
+            }
+            ResolvedNCommand::Fail(_span, command) => self.check_shadowing_command(command),
+            ResolvedNCommand::SetOption { .. } => Ok(()),
+            ResolvedNCommand::RunSchedule(..) => Ok(()),
+            ResolvedNCommand::PrintOverallStatistics => Ok(()),
+            ResolvedNCommand::PrintTable(..) => Ok(()),
+            ResolvedNCommand::PrintSize(..) => Ok(()),
+            ResolvedNCommand::Input { .. } => Ok(()),
+            ResolvedNCommand::Output { .. } => Ok(()),
+            ResolvedNCommand::Push(..) => Ok(()),
+            ResolvedNCommand::Pop(..) => Ok(()),
+        }
+    }
+
+    fn check_shadowing_query(&mut self, query: &[ResolvedFact]) -> Result<(), Error> {
+        // we want to allow names in queries to shadow each other, so we first collect
+        // all of the variable names, and then we check each of those names once
+        fn get_expr_names(expr: &ResolvedExpr, inner: &mut Names) {
+            match expr {
+                ResolvedExpr::Lit(..) => {}
+                ResolvedExpr::Var(span, name) => {
+                    if !inner.0.contains_key(&name.name) {
+                        inner.0.insert(name.name, span.clone());
+                    }
+                }
+                ResolvedExpr::Call(_span, _func, args) => {
+                    args.iter().for_each(|e| get_expr_names(e, inner))
+                }
+            };
+        }
+
+        let mut inner = Names::default();
+
+        for fact in query {
+            match fact {
+                ResolvedFact::Eq(_span, e1, e2) => {
+                    get_expr_names(e1, &mut inner);
+                    get_expr_names(e2, &mut inner);
+                }
+                ResolvedFact::Fact(e) => get_expr_names(e, &mut inner),
+            }
+        }
+
+        for (name, span) in inner.0 {
+            self.check(name, span.clone())?;
+        }
+
+        Ok(())
+    }
+
+    fn check_shadowing_action(&mut self, action: &ResolvedAction) -> Result<(), Error> {
+        if let ResolvedAction::Let(span, name, _args) = action {
+            self.check(name.name, span.clone())
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/src/ast/check_shadowing.rs
+++ b/src/ast/check_shadowing.rs
@@ -4,13 +4,6 @@ use crate::*;
 pub(crate) struct Names(HashMap<Symbol, Span>);
 
 impl Names {
-    pub(crate) fn check_shadowing(&mut self, program: &[ResolvedNCommand]) -> Result<(), Error> {
-        for command in program {
-            self.check_shadowing_command(command)?;
-        }
-        Ok(())
-    }
-
     fn check(&mut self, name: Symbol, new: Span) -> Result<(), Error> {
         if let Some(old) = self.0.get(&name) {
             Err(Error::Shadowing(name, old.clone(), new))
@@ -20,7 +13,12 @@ impl Names {
         }
     }
 
-    fn check_shadowing_command(&mut self, command: &ResolvedNCommand) -> Result<(), Error> {
+    /// WARNING: this function does not handle `push` and `pop`.
+    /// Because `Names` is contained on the `EGraph`, this will
+    /// work correctly when executed from `process_command`, but
+    /// a unit test that called this function multiple times without
+    /// changing the `EGraph` will be wrong.
+    pub(crate) fn check_shadowing(&mut self, command: &ResolvedNCommand) -> Result<(), Error> {
         match command {
             ResolvedNCommand::Sort(span, name, _args) => self.check(*name, span.clone()),
             ResolvedNCommand::Function(decl) => self.check(decl.name, decl.span.clone()),
@@ -43,7 +41,7 @@ impl Names {
             }
             ResolvedNCommand::Fail(_span, command) => {
                 let mut inner = self.clone();
-                inner.check_shadowing_command(command)
+                inner.check_shadowing(command)
             }
             ResolvedNCommand::SetOption { .. } => Ok(()),
             ResolvedNCommand::RunSchedule(..) => Ok(()),

--- a/src/ast/check_shadowing.rs
+++ b/src/ast/check_shadowing.rs
@@ -41,7 +41,10 @@ impl Names {
                 let mut inner = self.clone();
                 inner.check_shadowing_query(query)
             }
-            ResolvedNCommand::Fail(_span, command) => self.check_shadowing_command(command),
+            ResolvedNCommand::Fail(_span, command) => {
+                let mut inner = self.clone();
+                inner.check_shadowing_command(command)
+            }
             ResolvedNCommand::SetOption { .. } => Ok(()),
             ResolvedNCommand::RunSchedule(..) => Ok(()),
             ResolvedNCommand::PrintOverallStatistics => Ok(()),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,12 +1,10 @@
 pub mod desugar;
 mod expr;
-pub mod parse;
-pub(crate) mod remove_globals;
+mod parse;
+pub mod remove_globals;
 
-use crate::{
-    core::{GenericAtom, GenericAtomTerm, HeadOrEq, Query, ResolvedCall},
-    *,
-};
+use crate::core::{GenericAtom, GenericAtomTerm, HeadOrEq, Query, ResolvedCall};
+use crate::*;
 pub use expr::*;
 pub use parse::*;
 pub use symbol_table::GlobalSymbol as Symbol;

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -405,11 +405,12 @@ impl Parser {
                 _ => return error!(span, "usage: (relation <name> (<input sort>*))"),
             },
             "ruleset" => match tail {
-                [name] => vec![Command::AddRuleset(name.expect_atom("ruleset name")?)],
+                [name] => vec![Command::AddRuleset(span, name.expect_atom("ruleset name")?)],
                 _ => return error!(span, "usage: (ruleset <name>)"),
             },
             "unstable-combined-ruleset" => match tail {
                 [name, subrulesets @ ..] => vec![Command::UnstableCombinedRuleset(
+                    span,
                     name.expect_atom("combined ruleset name")?,
                     map_fallible(subrulesets, self, |_, sexp| {
                         sexp.expect_atom("subruleset name")

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -797,7 +797,14 @@ impl Parser {
     pub fn parse_expr(&mut self, sexp: &Sexp) -> Result<Expr, ParseError> {
         Ok(match sexp {
             Sexp::Literal(literal, span) => Expr::Lit(span.clone(), literal.clone()),
-            Sexp::Atom(symbol, span) => Expr::Var(span.clone(), *symbol),
+            Sexp::Atom(symbol, span) => Expr::Var(
+                span.clone(),
+                if *symbol == "_".into() {
+                    self.symbol_gen.fresh(symbol)
+                } else {
+                    *symbol
+                },
+            ),
             Sexp::List(list, span) => match list.as_slice() {
                 [] => Expr::Lit(span.clone(), Literal::Unit),
                 _ => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,11 +19,6 @@ pub mod bin {
         /// Prints extra information, which can be useful for debugging
         #[clap(long, default_value_t = RunMode::Normal)]
         show: RunMode,
-        /// Changes the prefix of the generated symbols
-        // TODO why do we support this?
-        // TODO remove this evil hack
-        #[clap(long, default_value = "__")]
-        reserved_symbol: String,
         /// The file names for the egglog files to run
         inputs: Vec<PathBuf>,
         /// Serializes the egraph for each egglog file as JSON
@@ -62,7 +57,6 @@ pub mod bin {
             .init();
 
         let args = Args::parse();
-        egraph.set_reserved_symbol(args.reserved_symbol.clone().into());
         egraph.fact_directory.clone_from(&args.fact_directory);
         egraph.seminaive = !args.naive;
         egraph.run_mode = args.show;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@ use crate::constraint::Problem;
 use crate::core::{AtomTerm, ResolvedCall};
 use crate::typechecking::TypeError;
 use actions::Program;
-use ast::remove_globals::remove_globals;
 use ast::*;
 #[cfg(feature = "bin")]
 pub use cli::bin::*;
@@ -1432,7 +1431,7 @@ impl EGraph {
             .type_info
             .typecheck_program(&mut self.parser.symbol_gen, &program)?;
 
-        let program = remove_globals(program, &mut self.parser.symbol_gen);
+        let program = remove_globals::remove_globals(program, &mut self.parser.symbol_gen);
 
         Ok(program)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1427,7 +1427,9 @@ impl EGraph {
 
         let program = remove_globals::remove_globals(program, &mut self.parser.symbol_gen);
 
-        self.names.check_shadowing(&program)?;
+        for command in &program {
+            self.names.check_shadowing(command)?;
+        }
 
         Ok(program)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,6 +428,7 @@ impl FromStr for RunMode {
 #[derive(Clone)]
 pub struct EGraph {
     pub parser: Parser,
+    names: check_shadowing::Names,
     egraphs: Vec<Self>,
     unionfind: UnionFind,
     pub functions: IndexMap<Symbol, Function>,
@@ -452,6 +453,7 @@ impl Default for EGraph {
     fn default() -> Self {
         let mut egraph = Self {
             parser: Default::default(),
+            names: Default::default(),
             egraphs: vec![],
             unionfind: Default::default(),
             functions: Default::default(),
@@ -1218,11 +1220,11 @@ impl EGraph {
                 self.declare_function(&fdecl)?;
                 log::info!("Declared function {}.", fdecl.name)
             }
-            ResolvedNCommand::AddRuleset(name) => {
+            ResolvedNCommand::AddRuleset(_span, name) => {
                 self.add_ruleset(name);
                 log::info!("Declared ruleset {name}.");
             }
-            ResolvedNCommand::UnstableCombinedRuleset(name, others) => {
+            ResolvedNCommand::UnstableCombinedRuleset(_span, name, others) => {
                 self.add_combined_ruleset(name, others);
                 log::info!("Declared ruleset {name}.");
             }
@@ -1416,14 +1418,6 @@ impl EGraph {
         }
     }
 
-    pub fn set_reserved_symbol(&mut self, sym: Symbol) {
-        assert!(
-            !self.parser.symbol_gen.has_been_used(),
-            "Reserved symbol must be set before any symbols are generated"
-        );
-        self.parser.symbol_gen = SymbolGen::new(sym.to_string());
-    }
-
     fn process_command(&mut self, command: Command) -> Result<Vec<ResolvedNCommand>, Error> {
         let program = desugar::desugar_program(vec![command], &mut self.parser, self.seminaive)?;
 
@@ -1432,6 +1426,8 @@ impl EGraph {
             .typecheck_program(&mut self.parser.symbol_gen, &program)?;
 
         let program = remove_globals::remove_globals(program, &mut self.parser.symbol_gen);
+
+        self.names.check_shadowing(&program)?;
 
         Ok(program)
     }
@@ -1580,6 +1576,8 @@ pub enum Error {
     SubsumeMergeError(Symbol),
     #[error("extraction failure: {:?}", .0)]
     ExtractError(Value),
+    #[error("{1}\n{2}\nShadowing is not allowed, but found {0}")]
+    Shadowing(Symbol, Span, Span),
 }
 
 #[cfg(test)]

--- a/tests/eggcc-extraction.egg
+++ b/tests/eggcc-extraction.egg
@@ -1393,7 +1393,7 @@
 ;;			B
 ;;	else:
 ;;		B
-(rule ((= gamma (Gamma (Node (PureOp (band BoolT a b))) (VO inputs) (VVO outputs)))
+(rule ((= gamma (Gamma (Node (PureOp (band (BoolT) a b))) (VO inputs) (VVO outputs)))
        (= (vec-length outputs) 2)
        (= (vec-get outputs 1) (VO A))
        (= (vec-get outputs 0) (VO B))
@@ -1420,7 +1420,7 @@
 ;;			A
 ;;		else:
 ;;			B
-(rule ((= gamma (Gamma (Node (PureOp (bor BoolT a b))) (VO inputs) (VVO outputs)))
+(rule ((= gamma (Gamma (Node (PureOp (bor (BoolT) a b))) (VO inputs) (VVO outputs)))
        (= (vec-length outputs) 2)
        (= (vec-get outputs 1) (VO A))
        (= (vec-get outputs 0) (VO B))

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -24,7 +24,6 @@ impl Run {
         } else {
             let mut egraph = EGraph::default();
             egraph.run_mode = RunMode::ShowDesugaredEgglog;
-            egraph.set_reserved_symbol("__".into());
             let desugared_str = egraph
                 .parse_and_run_program(self.path.to_str().map(String::from), &program)
                 .unwrap()
@@ -40,7 +39,6 @@ impl Run {
 
     fn test_program(&self, filename: Option<String>, program: &str, message: &str) {
         let mut egraph = EGraph::default();
-        egraph.set_reserved_symbol("___".into());
         match egraph.parse_and_run_program(filename, program) {
             Ok(msgs) => {
                 if self.should_fail() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -469,3 +469,12 @@ fn test_serialize_subsume_status() {
     assert!(serialized.nodes[&a_id].subsumed);
     assert!(!serialized.nodes[&b_id].subsumed);
 }
+
+#[test]
+fn test_shadowing() {
+    let s = "(function f () i64 :no-merge) (set (f) 2) (check (= (f) f) (= f 2))";
+    let e = EGraph::default()
+        .parse_and_run_program(None, s)
+        .unwrap_err();
+    assert!(matches!(e, Error::Shadowing(_, _, _)));
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -471,10 +471,16 @@ fn test_serialize_subsume_status() {
 }
 
 #[test]
-fn test_shadowing() {
+fn test_shadowing_query() {
     let s = "(function f () i64 :no-merge) (set (f) 2) (check (= (f) f) (= f 2))";
     let e = EGraph::default()
         .parse_and_run_program(None, s)
         .unwrap_err();
     assert!(matches!(e, Error::Shadowing(_, _, _)));
+}
+
+#[test]
+fn test_shadowing_push() {
+    let s = "(push) (let x 1) (pop) (let x 1)";
+    EGraph::default().parse_and_run_program(None, s).unwrap();
 }

--- a/tests/list.egg
+++ b/tests/list.egg
@@ -2,23 +2,23 @@
 	(Nil)
 	(Cons i64 List))
 
-(ruleset list)
+(ruleset list-ruleset)
 
 (function list-length (List) i64 :no-merge)
 (relation list-length-demand (List))
 (rule
 	((list-length-demand (Nil)))
 	((set (list-length (Nil)) 0))
-	:ruleset list)
+	:ruleset list-ruleset)
 (rule
 	((list-length-demand (Cons head tail)))
 	((list-length-demand tail))
-	:ruleset list)
+	:ruleset list-ruleset)
 (rule
 	(	(list-length-demand (Cons head tail))
 		(= (list-length tail) tail-length))
 	((set (list-length (Cons head tail)) (+ tail-length 1)))
-	:ruleset list)
+	:ruleset list-ruleset)
 
 (function list-get (List i64) i64 :no-merge)
 (relation list-get-demand (List i64))
@@ -26,22 +26,22 @@
 	(	(list-get-demand list 0)
 		(= list (Cons head tail)))
 	((set (list-get list 0) head))
-	:ruleset list)
+	:ruleset list-ruleset)
 (rule
 	(	(list-get-demand list n) (> n 0)
 		(= list (Cons head tail)))
 	((list-get-demand tail (- n 1)))
-	:ruleset list)
+	:ruleset list-ruleset)
 (rule
 	(	(list-get-demand list n)
 		(= list (Cons head tail))
 		(= item (list-get tail (- n 1))))
 	((set (list-get list n) item))
-	:ruleset list)
+	:ruleset list-ruleset)
 
 (constructor list-append (List List) List)
-(rewrite (list-append (Nil) list) list :ruleset list)
-(rewrite (list-append (Cons head tail) list) (Cons head (list-append tail list)) :ruleset list)
+(rewrite (list-append (Nil) list) list :ruleset list-ruleset)
+(rewrite (list-append (Cons head tail) list) (Cons head (list-append tail list)) :ruleset list-ruleset)
 
 ; list-contains Nil _ => false
 ; list-contains (Cons item tail) item => true
@@ -49,8 +49,8 @@
 ; list-contains needs inequality
 
 (constructor list-set (List i64 i64) List)
-(rewrite (list-set (Cons head tail) 0 item) (Cons item tail) :ruleset list)
-(rewrite (list-set (Cons head tail) i item) (Cons head (list-set tail (- i 1) item)) :when ((> i 0)) :ruleset list)
+(rewrite (list-set (Cons head tail) 0 item) (Cons item tail) :ruleset list-ruleset)
+(rewrite (list-set (Cons head tail) i item) (Cons head (list-set tail (- i 1) item)) :when ((> i 0)) :ruleset list-ruleset)
 
 ; Tests
 (let a (Cons 1 (Cons 2 (Nil))))
@@ -64,7 +64,7 @@
 (list-get-demand b 0)
 (list-get-demand a 1)
 
-(run-schedule (saturate (run list)))
+(run-schedule (saturate (run list-ruleset)))
 
 (check (= e c))
 (check (= (list-length c) 3))


### PR DESCRIPTION
1. Makes variables named `_` wildcards in `parse.rs`.
2. Adds a check to forbid shadowing. Fixes one benign case (in `list.egg`) and one bug (in `eggcc_extraction.egg`).
3. Adds span info to the ruleset commands.
4. Made the rewrite desugaring use the symbol gen.
5. Deleted the "reserved symbol" command line argument, and the `EGraph::set_reserved_symbol` method.

Fixes #329, #556, #409.