### PR TITLE
no action extraction in progress

### DIFF
--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -151,59 +151,13 @@ pub(crate) fn desugar_command(
         Command::PrintOverallStatistics => {
             vec![NCommand::PrintOverallStatistics]
         }
+        Command::Extract(span, expr, variants) => vec![NCommand::Extract(span, expr, variants)],
         Command::QueryExtract {
             span,
             variants,
             expr,
         } => {
-            let variants = Expr::Lit(span.clone(), Literal::Int(variants.try_into().unwrap()));
-            if let Expr::Var(..) = expr {
-                // (extract {v} {variants})
-                vec![NCommand::CoreAction(Action::Extract(
-                    span.clone(),
-                    expr,
-                    variants,
-                ))]
-            } else {
-                // (check {expr})
-                // (ruleset {fresh_ruleset})
-                // (rule ((= {fresh} {expr}))
-                //       ((extract {fresh} {variants}))
-                //       :ruleset {fresh_ruleset})
-                // (run {fresh_ruleset} 1)
-                let fresh = parser.symbol_gen.fresh(&"desugar_qextract_var".into());
-                let fresh_ruleset = parser.symbol_gen.fresh(&"desugar_qextract_ruleset".into());
-                let fresh_rulename = parser.symbol_gen.fresh(&"desugar_qextract_rulename".into());
-                let rule = Rule {
-                    span: span.clone(),
-                    body: vec![Fact::Eq(
-                        span.clone(),
-                        Expr::Var(span.clone(), fresh),
-                        expr.clone(),
-                    )],
-                    head: Actions::singleton(Action::Extract(
-                        span.clone(),
-                        Expr::Var(span.clone(), fresh),
-                        variants,
-                    )),
-                };
-                vec![
-                    NCommand::Check(span.clone(), vec![Fact::Fact(expr.clone())]),
-                    NCommand::AddRuleset(fresh_ruleset),
-                    NCommand::NormRule {
-                        name: fresh_rulename,
-                        ruleset: fresh_ruleset,
-                        rule,
-                    },
-                    NCommand::RunSchedule(Schedule::Run(
-                        span.clone(),
-                        RunConfig {
-                            ruleset: fresh_ruleset,
-                            until: None,
-                        },
-                    )),
-                ]
-            }
+            vec![NCommand::QueryExtract(span, expr, variants)]
         }
         Command::Check(span, facts) => vec![NCommand::Check(span, facts)],
         Command::PrintFunction(span, symbol, size) => {
@@ -326,29 +280,18 @@ fn desugar_simplify(
     span: Span,
     parser: &mut Parser,
 ) -> Vec<NCommand> {
-    let mut res = vec![NCommand::Push(1)];
     let lhs = parser.symbol_gen.fresh(&"desugar_simplify".into());
-    res.push(NCommand::CoreAction(Action::Let(
-        span.clone(),
-        lhs,
-        expr.clone(),
-    )));
-    res.push(NCommand::RunSchedule(schedule.clone()));
-    res.extend(
-        desugar_command(
-            Command::QueryExtract {
-                span: span.clone(),
-                variants: 0,
-                expr: Expr::Var(span.clone(), lhs),
-            },
-            parser,
-            false,
-        )
-        .unwrap(),
-    );
-
-    res.push(NCommand::Pop(span, 1));
-    res
+    vec![
+        NCommand::Push(1),
+        NCommand::CoreAction(Action::Let(span.clone(), lhs, expr.clone())),
+        NCommand::RunSchedule(schedule.clone()),
+        NCommand::QueryExtract(
+            span.clone(),
+            Expr::Var(span.clone(), lhs),
+            Expr::Lit(span.clone(), Literal::Int(0)),
+        ),
+        NCommand::Pop(span, 1),
+    ]
 }
 
 pub fn rule_name<Head, Leaf>(command: &GenericCommand<Head, Leaf>) -> Symbol

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -562,11 +562,24 @@ impl Parser {
                 }],
                 _ => return error!(span, "usage: (simplify <schedule> <expr>)"),
             },
+            "extract" => match tail {
+                [e] => vec![Command::Extract(
+                    span.clone(),
+                    self.parse_expr(e)?,
+                    Expr::Lit(span, Literal::Int(0)),
+                )],
+                [e, v] => vec![Command::Extract(
+                    span,
+                    self.parse_expr(e)?,
+                    self.parse_expr(v)?,
+                )],
+                _ => return error!(span, "usage: (extract <expr> <number of variants>?)"),
+            },
             "query-extract" => match tail {
                 [rest @ .., e] => {
                     let variants = match self.parse_options(rest)?.as_slice() {
-                        [] => 0,
-                        [(":variants", [v])] => v.expect_uint("number of variants")?,
+                        [] => Expr::Lit(span.clone(), Literal::Int(0)),
+                        [(":variants", [v])] => self.parse_expr(v)?,
                         _ => return error!(span, "could not parse query-extract options"),
                     };
                     vec![Command::QueryExtract {
@@ -765,19 +778,6 @@ impl Parser {
             "panic" => match tail {
                 [message] => vec![Action::Panic(span, message.expect_string("error message")?)],
                 _ => return error!(span, "usage: (panic <string>)"),
-            },
-            "extract" => match tail {
-                [e] => vec![Action::Extract(
-                    span.clone(),
-                    self.parse_expr(e)?,
-                    Expr::Lit(span, Literal::Int(0)),
-                )],
-                [e, v] => vec![Action::Extract(
-                    span,
-                    self.parse_expr(e)?,
-                    self.parse_expr(v)?,
-                )],
-                _ => return error!(span, "usage: (extract <expr> <number of variants>?)"),
             },
             _ => vec![Action::Expr(span, self.parse_expr(sexp)?)],
         })

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -521,11 +521,6 @@ impl Assignment<AtomTerm, ArcSort> {
                 self.annotate_expr(lhs, typeinfo),
                 self.annotate_expr(rhs, typeinfo),
             )),
-            GenericAction::Extract(span, lhs, rhs) => Ok(ResolvedAction::Extract(
-                span.clone(),
-                self.annotate_expr(lhs, typeinfo),
-                self.annotate_expr(rhs, typeinfo),
-            )),
             GenericAction::Panic(span, msg) => Ok(ResolvedAction::Panic(span.clone(), msg.clone())),
             GenericAction::Expr(span, expr) => Ok(ResolvedAction::Expr(
                 span.clone(),
@@ -685,17 +680,6 @@ impl CoreAction {
             )
             .chain(once(constraint::eq(lhs.clone(), rhs.clone())))
             .collect()),
-            CoreAction::Extract(_ann, e, n) => {
-                // e can be anything
-                Ok(
-                    get_literal_and_global_constraints(&[e.clone(), n.clone()], typeinfo)
-                        .chain(once(constraint::assign(
-                            n.clone(),
-                            std::sync::Arc::new(I64Sort) as ArcSort,
-                        )))
-                        .collect(),
-                )
-            }
             CoreAction::Panic(_ann, _) => Ok(vec![]),
             CoreAction::LetAtomTerm(span, v, at) => {
                 Ok(get_literal_and_global_constraints(&[at.clone()], typeinfo)

--- a/src/core.rs
+++ b/src/core.rs
@@ -371,7 +371,6 @@ impl<Leaf: Clone> Query<ResolvedCall, Leaf> {
 pub enum GenericCoreAction<Head, Leaf> {
     Let(Span, Leaf, Head, Vec<GenericAtomTerm<Leaf>>),
     LetAtomTerm(Span, Leaf, GenericAtomTerm<Leaf>),
-    Extract(Span, GenericAtomTerm<Leaf>, GenericAtomTerm<Leaf>),
     Set(
         Span,
         Head,
@@ -524,20 +523,6 @@ where
                     mapped_actions
                         .0
                         .push(GenericAction::Union(span.clone(), mapped_e1, mapped_e2));
-                }
-                GenericAction::Extract(span, e, n) => {
-                    let (actions, mapped_e) = e.to_core_actions(typeinfo, binding, fresh_gen)?;
-                    norm_actions.extend(actions.0);
-                    let (actions, mapped_n) = n.to_core_actions(typeinfo, binding, fresh_gen)?;
-                    norm_actions.extend(actions.0);
-                    norm_actions.push(GenericCoreAction::Extract(
-                        span.clone(),
-                        mapped_e.get_corresponding_var_or_lit(typeinfo),
-                        mapped_n.get_corresponding_var_or_lit(typeinfo),
-                    ));
-                    mapped_actions
-                        .0
-                        .push(GenericAction::Extract(span.clone(), mapped_e, mapped_n));
                 }
                 GenericAction::Panic(span, string) => {
                     norm_actions.push(GenericCoreAction::Panic(span.clone(), string.clone()));

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -49,10 +49,6 @@ impl EGraph {
         termdag: &mut TermDag,
         arcsort: &ArcSort,
     ) -> Result<(Cost, Term), Error> {
-        //if true {
-        //    todo!("extraction")
-        //}
-
         let extractor = Extractor::new(self, termdag);
         extractor.find_best(value, termdag, arcsort).ok_or_else(|| {
             log::error!("No cost for {:?}", value);

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -136,6 +136,46 @@ impl EGraph {
                 self.type_info
                     .typecheck_action(symbol_gen, action, &Default::default())?,
             ),
+            NCommand::Extract(span, expr, variants) => {
+                let res_expr =
+                    self.type_info
+                        .typecheck_expr(symbol_gen, expr, &Default::default())?;
+
+                let res_variants =
+                    self.type_info
+                        .typecheck_expr(symbol_gen, variants, &Default::default())?;
+                if res_variants.output_type().name() != I64Sort.name() {
+                    return Err(TypeError::Mismatch {
+                        expr: variants.clone(),
+                        expected: Arc::new(I64Sort),
+                        actual: res_variants.output_type(),
+                    });
+                }
+
+                ResolvedNCommand::Extract(span.clone(), res_expr, res_variants)
+            }
+            NCommand::QueryExtract(span, expr, variants) => {
+                let res_expr = self
+                    .type_info
+                    .typecheck_facts(symbol_gen, &[Fact::Fact(expr.clone())])?;
+                assert_eq!(res_expr.len(), 1);
+                let GenericFact::Fact(res_expr) = res_expr.into_iter().next().unwrap() else {
+                    unreachable!()
+                };
+
+                let res_variants =
+                    self.type_info
+                        .typecheck_expr(symbol_gen, variants, &Default::default())?;
+                if res_variants.output_type().name() != I64Sort.name() {
+                    return Err(TypeError::Mismatch {
+                        expr: variants.clone(),
+                        expected: Arc::new(I64Sort),
+                        actual: res_variants.output_type(),
+                    });
+                }
+
+                ResolvedNCommand::QueryExtract(span.clone(), res_expr, res_variants)
+            }
             NCommand::Check(span, facts) => ResolvedNCommand::Check(
                 span.clone(),
                 self.type_info.typecheck_facts(symbol_gen, facts)?,
@@ -441,10 +481,6 @@ impl TypeInfo {
                         Self::check_lookup_expr(arg)?
                     }
                     Ok(())
-                }
-                GenericAction::Extract(_, expr, variants) => {
-                    Self::check_lookup_expr(expr)?;
-                    Self::check_lookup_expr(variants)
                 }
                 GenericAction::Panic(..) => Ok(()),
                 GenericAction::Expr(_, expr) => Self::check_lookup_expr(expr),


### PR DESCRIPTION
- changed the asts
  + had to make `query-extract` a first-class command instead of desugaring it away, but it should be a combination of `check` and regular `extract`
- fixed desugaring
- fixed typechecking
- factored out eval_resolved_expr_new from the output command so that the extract command can use it

still todo:
- implement the extractor
- implement query-extract
- implement eval_resolved_expr_old (or you can implement the old extractor some other way)