### PR TITLE
Fix value generation for relations in Change::Subsume code

### DIFF
--- a/tests/subsume-relation.egg
+++ b/tests/subsume-relation.egg
@@ -1,0 +1,9 @@
+(datatype V (A) (B) (C))
+(relation R (V V))
+
+(A) (B) (C)
+(subsume (R (A) (B)))
+(R (A) (C))
+(union (B) (C))
+
+(check (= (R (A) (B)) ()))


### PR DESCRIPTION
This PR de-duplicates code for fresh output generation, fixing a bug with relation subsumption: old code for subsume just grabbed a new value from UF, which is not the right way to generate outputs for relations.

Let me know if `NewOutputGen` stuff is too much - I can do a simpler version going directly to a new fresh `Value` (it would be less code, but it would require an extra unwrap() call).