### PR TITLE
Much Faster Push Implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,7 +429,7 @@ impl FromStr for RunMode {
 pub struct EGraph {
     pub parser: Parser,
     names: check_shadowing::Names,
-    prev_egraph: Box<Option<Self>>,
+    prev_egraph: Option<Box<Self>>,
     unionfind: UnionFind,
     pub functions: IndexMap<Symbol, Function>,
     rulesets: IndexMap<Symbol, Ruleset>,
@@ -496,11 +496,10 @@ impl EGraph {
     }
 
     pub fn push(&mut self) {
-        let mut prev_prev: Box<Option<Self>> = Default::default();
-        std::mem::swap(&mut self.prev_egraph, &mut prev_prev);
+        let prev_prev: Option<Box<Self>> = self.prev_egraph.take();
         let mut prev = self.clone();
         prev.prev_egraph = prev_prev;
-        self.prev_egraph = Box::new(Some(prev));
+        self.prev_egraph = Some(Box::new(prev));
     }
 
     /// Disable saving messages to be printed to the user and remove any saved messages.
@@ -533,7 +532,7 @@ impl EGraph {
                 let overall_run_report = self.overall_run_report.clone();
                 let messages = self.msgs.clone();
 
-                *self = e;
+                *self = *e;
                 self.extract_report = extract_report.or(self.extract_report.clone());
                 // We union the run reports, meaning
                 // that statistics are shared across

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,7 +429,9 @@ impl FromStr for RunMode {
 pub struct EGraph {
     pub parser: Parser,
     names: check_shadowing::Names,
-    prev_egraph: Option<Box<Self>>,
+    /// pushed_egraph forms a linked list of pushed egraphs.
+    /// Pop reverts the egraph to the last pushed egraph.
+    pushed_egraph: Option<Box<Self>>,
     unionfind: UnionFind,
     pub functions: IndexMap<Symbol, Function>,
     rulesets: IndexMap<Symbol, Ruleset>,
@@ -454,7 +456,7 @@ impl Default for EGraph {
         let mut egraph = Self {
             parser: Default::default(),
             names: Default::default(),
-            prev_egraph: Default::default(),
+            pushed_egraph: Default::default(),
             unionfind: Default::default(),
             functions: Default::default(),
             rulesets: Default::default(),
@@ -496,10 +498,10 @@ impl EGraph {
     }
 
     pub fn push(&mut self) {
-        let prev_prev: Option<Box<Self>> = self.prev_egraph.take();
+        let prev_prev: Option<Box<Self>> = self.pushed_egraph.take();
         let mut prev = self.clone();
-        prev.prev_egraph = prev_prev;
-        self.prev_egraph = Some(Box::new(prev));
+        prev.pushed_egraph = prev_prev;
+        self.pushed_egraph = Some(Box::new(prev));
     }
 
     /// Disable saving messages to be printed to the user and remove any saved messages.
@@ -524,7 +526,7 @@ impl EGraph {
     /// It preserves the run report and messages from the popped
     /// egraph.
     pub fn pop(&mut self) -> Result<(), Error> {
-        match self.prev_egraph.take() {
+        match self.pushed_egraph.take() {
             Some(e) => {
                 // Copy the reports and messages from the popped egraph
                 let extract_report = self.extract_report.clone();


### PR DESCRIPTION
Previously, the push implementation cloned the entire egraph... including previously pushed egraphs

So a sequence of n pushes took `O(n^2 * size_of_initial_egraph)` space
This PR fixes that so it takes n * size_of_initial_egraph space