### PR TITLE
Fix Codspeed Comparisons

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
 name: Build
 
-on: [push, pull_request, workflow_dispatch]
-
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As described in the [codspeed discussion](https://discord.com/channels/1065233827569598464/1370395084251467869), the benchmarks should only be run on `main` and on PRs, not on other branches, or else the changes will get confused on the PRs:

> Hello, it seems you are running the CodSpeed action both on push and on pull_request (See the workflow file). This creates an inconsistency on our end, because we have a different logic depending on the event type.
> In particular, the push-related runs are compared to the previous commit on the same branch, whereas the pull_request runs are compared to the base branch (what you would expect in your situation).
> 
> I would advise to create a separate workflow file to run your CodSpeed benchmarks, with a config similar to what is described in our documentation.


I updated our main CI to run only in these cases. If we want tests to run on all branches, even not CI, I can make a new workflow for benchmarks as suggested in the reply.

Issues discovered in https://github.com/egraphs-good/egglog/pull/527