### PR TITLE
Rebuild after running commands instead of before

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1200,17 +1200,6 @@ impl EGraph {
     }
 
     fn run_command(&mut self, command: ResolvedNCommand) -> Result<(), Error> {
-        let pre_rebuild = Instant::now();
-        let rebuild_num = self.rebuild()?;
-        if rebuild_num > 0 {
-            log::info!(
-                "Rebuild before command: {:10}ms",
-                pre_rebuild.elapsed().as_millis()
-            );
-        }
-
-        self.debug_assert_invariants();
-
         match command {
             ResolvedNCommand::SetOption { name, value } => {
                 let str = format!("Set option {} to {}", name, value);
@@ -1335,6 +1324,17 @@ impl EGraph {
                 log::info!("Output to '{filename:?}'.")
             }
         };
+
+        let post_rebuild = Instant::now();
+        let rebuild_num = self.rebuild()?;
+        if rebuild_num > 0 {
+            log::info!(
+                "Rebuild after command: {:10}ms",
+                post_rebuild.elapsed().as_millis()
+            );
+        }
+
+        self.debug_assert_invariants();
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,8 +548,10 @@ impl EGraph {
         }
     }
 
-    pub fn union(&mut self, id1: Id, id2: Id, sort: Symbol) -> Id {
-        self.unionfind.union(id1, id2, sort)
+    pub fn union(&mut self, id1: Id, id2: Id, sort: Symbol) -> Result<Id, Error> {
+        self.unionfind.union(id1, id2, sort);
+        self.rebuild()?;
+        Ok(self.unionfind.find(id1))
     }
 
     #[track_caller]


### PR DESCRIPTION
Running rebuilding before running the commands means that the results from the Rust API would be wrong after running e.g. a top level `union`.

This is an old backend/v0.5 kind of fix.