### PR TITLE
Rust API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -48,36 +48,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
@@ -101,9 +101,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitmaps"
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "cast"
@@ -137,9 +137,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "shlex",
 ]
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -577,9 +577,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys",
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -698,12 +698,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -770,7 +764,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.1",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
@@ -847,9 +841,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -957,11 +951,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -979,6 +973,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oorandom"
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1339,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -1384,12 +1384,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1499,11 +1499,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -274,7 +274,7 @@ impl Parser {
         filename: Option<String>,
         input: &str,
     ) -> Result<Vec<Command>, ParseError> {
-        let sexps = all_sexps(Context::new(filename, input))?;
+        let sexps = all_sexps(SexpParser::new(filename, input))?;
         let nested: Vec<Vec<_>> = map_fallible(&sexps, self, Self::parse_command)?;
         Ok(nested.into_iter().flatten().collect())
     }
@@ -285,7 +285,7 @@ impl Parser {
         filename: Option<String>,
         input: &str,
     ) -> Result<Expr, ParseError> {
-        let sexp = sexp(&mut Context::new(filename, input))?;
+        let sexp = sexp(&mut SexpParser::new(filename, input))?;
         self.parse_expr(&sexp)
     }
 
@@ -892,14 +892,14 @@ impl Parser {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct Context {
+pub(crate) struct SexpParser {
     source: Arc<SrcFile>,
     index: usize,
 }
 
-impl Context {
-    pub(crate) fn new(name: Option<String>, contents: &str) -> Context {
-        Context {
+impl SexpParser {
+    pub(crate) fn new(name: Option<String>, contents: &str) -> SexpParser {
+        SexpParser {
             source: Arc::new(SrcFile {
                 name,
                 contents: contents.to_string(),
@@ -1018,7 +1018,7 @@ enum Token {
     Other,
 }
 
-fn sexp(ctx: &mut Context) -> Result<Sexp, ParseError> {
+fn sexp(ctx: &mut SexpParser) -> Result<Sexp, ParseError> {
     let mut stack: Vec<(EgglogSpan, Vec<Sexp>)> = vec![];
 
     loop {
@@ -1074,7 +1074,7 @@ fn sexp(ctx: &mut Context) -> Result<Sexp, ParseError> {
     }
 }
 
-pub(crate) fn all_sexps(mut ctx: Context) -> Result<Vec<Sexp>, ParseError> {
+pub(crate) fn all_sexps(mut ctx: SexpParser) -> Result<Vec<Sexp>, ParseError> {
     let mut sexps = Vec::new();
     ctx.advance_past_whitespace();
     while !ctx.is_at_end() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -175,7 +175,7 @@ impl EGraph {
 }
 
 fn should_eval(curr_cmd: &str) -> bool {
-    all_sexps(Context::new(None, curr_cmd)).is_ok()
+    all_sexps(SexpParser::new(None, curr_cmd)).is_ok()
 }
 
 fn run_command_in_scripting<W>(egraph: &mut EGraph, command: &str, mut output: W) -> io::Result<()>

--- a/src/core.rs
+++ b/src/core.rs
@@ -823,7 +823,7 @@ impl ResolvedRule {
             ResolvedCall::Primitive(SpecializedPrimitive {
                 primitive: value_eq.clone(),
                 input: vec![at1.output(), at2.output()],
-                output: Arc::new(UnitSort),
+                output: UnitSort.to_arcsort(),
             })
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1350,23 +1350,33 @@ impl EGraph {
     }
 
     /// Returns a sort based on the type.
-    pub fn get_sort<S: Sort + Send + Sync>(&self) -> Arc<S> {
+    pub fn get_sort<S: Sort>(&self) -> Arc<S> {
         self.type_info.get_sort()
     }
 
     /// Returns a sort that satisfies the type and predicate.
-    pub fn get_sort_by<S: Sort + Send + Sync>(&self, f: impl Fn(&Arc<S>) -> bool) -> Arc<S> {
+    pub fn get_sort_by<S: Sort>(&self, f: impl Fn(&Arc<S>) -> bool) -> Arc<S> {
         self.type_info.get_sort_by(f)
     }
 
     /// Returns all sorts based on the type.
-    pub fn get_sorts<S: Sort + Send + Sync>(&self) -> Vec<Arc<S>> {
+    pub fn get_sorts<S: Sort>(&self) -> Vec<Arc<S>> {
         self.type_info.get_sorts()
     }
 
     /// Returns all sorts that satisfy the type and predicate.
-    pub fn get_sorts_by<S: Sort + Send + Sync>(&self, f: impl Fn(&Arc<S>) -> bool) -> Vec<Arc<S>> {
+    pub fn get_sorts_by<S: Sort>(&self, f: impl Fn(&Arc<S>) -> bool) -> Vec<Arc<S>> {
         self.type_info.get_sorts_by(f)
+    }
+
+    /// Returns a sort based on the predicate.
+    pub fn get_arcsort_by(&self, f: impl Fn(&ArcSort) -> bool) -> ArcSort {
+        self.type_info.get_arcsort_by(f)
+    }
+
+    /// Returns all sorts that satisfy the predicate.
+    pub fn get_arcsorts_by(&self, f: impl Fn(&ArcSort) -> bool) -> Vec<ArcSort> {
+        self.type_info.get_arcsorts_by(f)
     }
 
     /// Gets the last extract report and returns it, if the last command saved it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,7 +329,7 @@ impl Default for EGraph {
         eg.add_sort(UnitSort, span!()).unwrap();
         eg.add_sort(StringSort, span!()).unwrap();
         eg.add_sort(BoolSort, span!()).unwrap();
-        eg.add_sort(I64Sort, span!()).unwrap();
+        prelude::add_leaf_sort(&mut eg, I64Sort).unwrap();
         eg.add_sort(F64Sort, span!()).unwrap();
         eg.add_sort(BigIntSort, span!()).unwrap();
         eg.add_sort(BigRatSort, span!()).unwrap();
@@ -1678,7 +1678,6 @@ mod tests {
 
     #[derive(Clone)]
     struct InnerProduct {
-        ele: Arc<I64Sort>,
         vec: Arc<VecSort>,
     }
 
@@ -1690,7 +1689,7 @@ mod tests {
         fn get_type_constraints(&self, span: &Span) -> Box<dyn crate::constraint::TypeConstraint> {
             SimpleTypeConstraint::new(
                 self.name(),
-                vec![self.vec.clone(), self.vec.clone(), self.ele.clone()],
+                vec![self.vec.clone(), self.vec.clone(), I64Sort.to_arcsort()],
                 span.clone(),
             )
             .into_box()
@@ -1724,12 +1723,9 @@ mod tests {
             .unwrap();
 
         let int_vec_sort =
-            egraph.get_sort_by(|s: &Arc<VecSort>| s.element().name() == I64Sort.name());
+            egraph.get_sort_by(|s: &Arc<VecSort>| s.element().name() == I64Sort.name().into());
 
-        egraph.add_primitive(InnerProduct {
-            ele: I64Sort.into(),
-            vec: int_vec_sort,
-        });
+        egraph.add_primitive(InnerProduct { vec: int_vec_sort });
 
         egraph
             .parse_and_run_program(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1379,6 +1379,11 @@ impl EGraph {
         self.type_info.get_arcsorts_by(f)
     }
 
+    /// Returns the sort with the given name if it exists.
+    pub fn get_sort_by_name(&self, sym: &Symbol) -> Option<&ArcSort> {
+        self.type_info.get_sort_by_name(sym)
+    }
+
     /// Gets the last extract report and returns it, if the last command saved it.
     pub fn get_extract_report(&self) -> &Option<ExtractReport> {
         &self.extract_report
@@ -1668,9 +1673,8 @@ pub enum Error {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
-
     use lazy_static::lazy_static;
+    use std::sync::Mutex;
 
     use crate::constraint::SimpleTypeConstraint;
     use crate::sort::*;
@@ -1678,7 +1682,7 @@ mod tests {
 
     #[derive(Clone)]
     struct InnerProduct {
-        vec: Arc<VecSort>,
+        vec: ArcSort,
     }
 
     impl Primitive for InnerProduct {
@@ -1722,8 +1726,10 @@ mod tests {
             .parse_and_run_program(None, "(sort IntVec (Vec i64))")
             .unwrap();
 
-        let int_vec_sort =
-            egraph.get_sort_by(|s: &Arc<VecSort>| s.element().name() == I64Sort.name().into());
+        let int_vec_sort = egraph.get_arcsort_by(|s| {
+            s.value_type() == Some(std::any::TypeId::of::<VecContainer>())
+                && s.inner_sorts()[0].name() == I64Sort.name().into()
+        });
 
         egraph.add_primitive(InnerProduct { vec: int_vec_sort });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod cli;
 pub mod constraint;
 mod core;
 pub mod extract;
+pub mod prelude;
 mod serialize;
 pub mod sort;
 mod termdag;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,23 +28,27 @@ pub mod util;
 extern crate self as egglog;
 pub use add_primitive::add_primitive;
 
-use crate::constraint::Problem;
-use crate::core::{AtomTerm, ResolvedAtomTerm, ResolvedCall};
-pub use crate::prelude::*;
-use crate::typechecking::TypeError;
 use ast::*;
 #[cfg(feature = "bin")]
 pub use cli::bin::*;
-use constraint::{Constraint, SimpleTypeConstraint, TypeConstraint};
-pub use core_relations::Value;
+use constraint::{Constraint, Problem, SimpleTypeConstraint, TypeConstraint};
+use core::{AtomTerm, ResolvedAtomTerm, ResolvedCall};
 use core_relations::{make_external_func, ExternalFunctionId};
+pub use core_relations::{ExecutionState, Value};
 use egglog_bridge::{ColumnTy, IterationReport, QueryEntry};
 use extract::{Extractor, TreeAdditiveCostModel};
-use indexmap::map::Entry;
+use prelude::*;
 pub use serialize::{SerializeConfig, SerializedNode};
 use sort::*;
-use std::fmt::Debug;
-use std::fmt::{Display, Formatter};
+pub use termdag::{Term, TermDag, TermId};
+use typechecking::{TypeError, TypeInfo};
+use util::*;
+
+use indexmap::map::Entry;
+use thiserror::Error;
+use web_time::Duration;
+
+use std::fmt::{Debug, Display, Formatter};
 use std::fs::File;
 use std::hash::Hash;
 use std::io::Read;
@@ -52,11 +56,6 @@ use std::iter::once;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
-pub use termdag::{Term, TermDag, TermId};
-use thiserror::Error;
-pub use typechecking::TypeInfo;
-use util::*;
-use web_time::Duration;
 
 pub type ArcSort = Arc<dyn Sort>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1398,6 +1398,16 @@ impl EGraph {
         &self.overall_run_report
     }
 
+    /// Convert from an egglog value to a Rust type.
+    pub fn value_to_rust<T: core_relations::Primitive>(&self, x: Value) -> T {
+        self.backend.primitives().unwrap::<T>(x)
+    }
+
+    /// Convert from a Rust type to an egglog value.
+    pub fn rust_to_value<T: core_relations::Primitive>(&self, x: T) -> Value {
+        self.backend.primitives().get::<T>(x)
+    }
+
     pub(crate) fn print_msg(&mut self, msg: String) {
         if let Some(ref mut msgs) = self.msgs {
             msgs.push(msg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub use add_primitive::add_primitive;
 
 use crate::constraint::Problem;
 use crate::core::{AtomTerm, ResolvedAtomTerm, ResolvedCall};
+pub use crate::prelude::*;
 use crate::typechecking::TypeError;
 use ast::*;
 #[cfg(feature = "bin")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,13 +326,13 @@ impl Default for EGraph {
             type_info: Default::default(),
         };
 
-        eg.add_sort(UnitSort, span!()).unwrap();
-        eg.add_sort(StringSort, span!()).unwrap();
-        eg.add_sort(BoolSort, span!()).unwrap();
-        prelude::add_leaf_sort(&mut eg, I64Sort).unwrap();
-        eg.add_sort(F64Sort, span!()).unwrap();
-        eg.add_sort(BigIntSort, span!()).unwrap();
-        eg.add_sort(BigRatSort, span!()).unwrap();
+        add_leaf_sort(&mut eg, UnitSort, span!()).unwrap();
+        add_leaf_sort(&mut eg, StringSort, span!()).unwrap();
+        add_leaf_sort(&mut eg, BoolSort, span!()).unwrap();
+        add_leaf_sort(&mut eg, I64Sort, span!()).unwrap();
+        add_leaf_sort(&mut eg, F64Sort, span!()).unwrap();
+        add_leaf_sort(&mut eg, BigIntSort, span!()).unwrap();
+        add_leaf_sort(&mut eg, BigRatSort, span!()).unwrap();
         eg.type_info.add_presort::<MapSort>(span!()).unwrap();
         eg.type_info.add_presort::<SetSort>(span!()).unwrap();
         eg.type_info.add_presort::<VecSort>(span!()).unwrap();
@@ -592,7 +592,7 @@ impl EGraph {
             .get(&sym)
             // function_to_dag should have checked this
             .unwrap();
-        let out_is_unit = f.schema.output.name() == UnitSort.name();
+        let out_is_unit = f.schema.output.name() == UnitSort.name().into();
 
         let mut buf = String::new();
         let s = &mut buf;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -33,21 +33,19 @@ pub mod sort {
 }
 
 /// Create a new ruleset.
-pub fn add_ruleset(egraph: &mut EGraph, ruleset: Symbol) -> Result<(), Error> {
-    egraph.run_program(vec![Command::AddRuleset(span!(), ruleset)])?;
-    Ok(())
+pub fn add_ruleset(egraph: &mut EGraph, ruleset: Symbol) -> Result<Vec<String>, Error> {
+    egraph.run_program(vec![Command::AddRuleset(span!(), ruleset)])
 }
 
 /// Run one iteration of a ruleset.
-pub fn run_ruleset(egraph: &mut EGraph, ruleset: Symbol) -> Result<(), Error> {
+pub fn run_ruleset(egraph: &mut EGraph, ruleset: Symbol) -> Result<Vec<String>, Error> {
     egraph.run_program(vec![Command::RunSchedule(Schedule::Run(
         span!(),
         RunConfig {
             ruleset,
             until: None,
         },
-    ))])?;
-    Ok(())
+    ))])
 }
 
 #[macro_export]
@@ -112,7 +110,7 @@ pub fn rule(
     ruleset: Symbol,
     facts: Facts<Symbol, Symbol>,
     actions: Actions,
-) -> Result<(), Error> {
+) -> Result<Vec<String>, Error> {
     let rule = Rule {
         span: span!(),
         head: actions,
@@ -124,9 +122,7 @@ pub fn rule(
         name: rule_name,
         ruleset,
         rule,
-    }])?;
-
-    Ok(())
+    }])
 }
 
 /// A wrapper around an `ExecutionState` for rules that are written in Rust.
@@ -236,7 +232,7 @@ pub fn rust_rule(
     vars: &[(&str, ArcSort)],
     facts: Facts<Symbol, Symbol>,
     func: impl Fn(&mut Context, &[Value]) -> Option<()> + Clone + Send + Sync + 'static,
-) -> Result<(), Error> {
+) -> Result<Vec<String>, Error> {
     let rule_name = egraph.parser.symbol_gen.fresh(&"prelude::rust_rule".into());
     let prim_name = egraph.parser.symbol_gen.fresh(&"rust_rule_prim".into());
 
@@ -275,9 +271,7 @@ pub fn rust_rule(
         name: rule_name,
         ruleset,
         rule,
-    }])?;
-
-    Ok(())
+    }])
 }
 
 /// The result of a query.
@@ -370,9 +364,8 @@ pub fn query(
 }
 
 /// Declare a new sort.
-pub fn add_sort(egraph: &mut EGraph, name: Symbol) -> Result<(), Error> {
-    egraph.run_program(vec![Command::Sort(span!(), name, None)])?;
-    Ok(())
+pub fn add_sort(egraph: &mut EGraph, name: Symbol) -> Result<Vec<String>, Error> {
+    egraph.run_program(vec![Command::Sort(span!(), name, None)])
 }
 
 /// Declare a new function table.
@@ -381,14 +374,13 @@ pub fn add_function(
     name: Symbol,
     schema: Schema,
     merge: Option<GenericExpr<Symbol, Symbol>>,
-) -> Result<(), Error> {
+) -> Result<Vec<String>, Error> {
     egraph.run_program(vec![Command::Function {
         span: span!(),
         name,
         schema,
         merge,
-    }])?;
-    Ok(())
+    }])
 }
 
 /// Declare a new constructor table.
@@ -398,15 +390,14 @@ pub fn add_constructor(
     schema: Schema,
     cost: Option<usize>,
     unextractable: bool,
-) -> Result<(), Error> {
+) -> Result<Vec<String>, Error> {
     egraph.run_program(vec![Command::Constructor {
         span: span!(),
         name,
         schema,
         cost,
         unextractable,
-    }])?;
-    Ok(())
+    }])
 }
 
 /// Declare a new relation table.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -369,6 +369,59 @@ pub fn query(
     })
 }
 
+/// Declare a new sort.
+pub fn add_sort(egraph: &mut EGraph, name: Symbol) -> Result<(), Error> {
+    egraph.run_program(vec![Command::Sort(span!(), name, None)])?;
+    Ok(())
+}
+
+/// Declare a new function table.
+pub fn add_function(
+    egraph: &mut EGraph,
+    name: Symbol,
+    schema: Schema,
+    merge: Option<GenericExpr<Symbol, Symbol>>,
+) -> Result<(), Error> {
+    egraph.run_program(vec![Command::Function {
+        span: span!(),
+        name,
+        schema,
+        merge,
+    }])?;
+    Ok(())
+}
+
+/// Declare a new constructor table.
+pub fn add_constructor(
+    egraph: &mut EGraph,
+    name: Symbol,
+    schema: Schema,
+    cost: Option<usize>,
+    unextractable: bool,
+) -> Result<(), Error> {
+    egraph.run_program(vec![Command::Constructor {
+        span: span!(),
+        name,
+        schema,
+        cost,
+        unextractable,
+    }])?;
+    Ok(())
+}
+
+/// Declare a new relation table.
+pub fn add_relation(
+    egraph: &mut EGraph,
+    name: Symbol,
+    inputs: Vec<Symbol>,
+) -> Result<Vec<String>, Error> {
+    egraph.run_program(vec![Command::Relation {
+        span: span!(),
+        name,
+        inputs,
+    }])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,9 @@
+//! This module makes it easier to use `egglog` from Rust.
+//! It is intended to be imported fully.
+//! ```
+//! use egglog::prelude::*;
+//! ```
+
 use crate::*;
 use std::any::{Any, TypeId};
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -154,7 +154,7 @@ macro_rules! actions {
 ///
 /// let big_number = 20;
 ///
-/// // check that `fib` does not contain `20`
+/// // check that `(fib 20)` is not in the e-graph
 /// let results = query(
 ///     &mut egraph,
 ///     vars![f: i64],
@@ -184,7 +184,7 @@ macro_rules! actions {
 ///     run_ruleset(&mut egraph, ruleset)?;
 /// }
 ///
-/// // check that `fib` now contains `20`
+/// // check that `(fib 20)` is now in the e-graph
 /// let results = query(
 ///     &mut egraph,
 ///     vars![f: i64],
@@ -340,7 +340,7 @@ impl<F: Fn(&mut RustRuleContext, &[Value]) -> Option<()>> Primitive for RustRule
 ///
 /// let big_number = 20;
 ///
-/// // check that `fib` does not contain `20`
+/// // check that `(fib 20)` is not in the e-graph
 /// let results = query(
 ///     &mut egraph,
 ///     vars![f: i64],
@@ -380,7 +380,7 @@ impl<F: Fn(&mut RustRuleContext, &[Value]) -> Option<()>> Primitive for RustRule
 ///     run_ruleset(&mut egraph, ruleset)?;
 /// }
 ///
-/// // check that `fib` now contains `20`
+/// // check that `(fib 20)` is now in the e-graph
 /// let results = query(
 ///     &mut egraph,
 ///     vars![f: i64],
@@ -821,7 +821,7 @@ mod tests {
 
         let big_number = 20;
 
-        // check that `fib` does not contain `20`
+        // check that `(fib 20)` is not in the e-graph
         let results = query(
             &mut egraph,
             vars![f: i64],
@@ -851,7 +851,7 @@ mod tests {
             run_ruleset(&mut egraph, ruleset)?;
         }
 
-        // check that `fib` now contains `20`
+        // check that `(fib 20)` is now in the e-graph
         let results = query(
             &mut egraph,
             vars![f: i64],
@@ -901,7 +901,7 @@ mod tests {
 
         let big_number = 20;
 
-        // check that `fib` does not contain `20`
+        // check that `(fib 20)` is not in the e-graph
         let results = query(
             &mut egraph,
             vars![f: i64],
@@ -941,7 +941,7 @@ mod tests {
             run_ruleset(&mut egraph, ruleset)?;
         }
 
-        // check that `fib` now contains `20`
+        // check that `(fib 20)` is now in the e-graph
         let results = query(
             &mut egraph,
             vars![f: i64],

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -491,7 +491,7 @@ pub trait ContainerSort: Any + Send + Sync + Debug {
     fn is_eq_container_sort(&self) -> bool;
     fn inner_sorts(&self) -> Vec<ArcSort>;
     fn inner_values(&self, _: &Containers, _: Value) -> Vec<(ArcSort, Value)>;
-    fn register_primitives(&self, _eg: &mut EGraph, _: ArcSort) {}
+    fn register_primitives(&self, _eg: &mut EGraph) {}
     fn reconstruct_termdag(&self, _: &Containers, _: Value, _: &mut TermDag, _: Vec<Term>) -> Term;
     fn serialized_name(&self, _: Value) -> &str;
 
@@ -548,7 +548,7 @@ impl<T: ContainerSort> Sort for ContainerSortImpl<T> {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        self.0.register_primitives(eg, self.clone() as ArcSort);
+        self.0.register_primitives(eg);
     }
 
     fn reconstruct_termdag_container(

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -415,7 +415,7 @@ pub fn add_relation(
 
 /// Adds sorts and constructor tables to the database.
 #[macro_export]
-macro_rules! define_language {
+macro_rules! datatype {
     ($egraph:expr, (datatype $sort:ident $(($name:ident $($args:ident)* $(:cost $cost:expr)?))*)) => {
         add_sort($egraph, stringify!($sort))?;
         $(add_constructor(
@@ -528,7 +528,7 @@ mod tests {
     fn rust_api_macros() -> Result<(), Error> {
         let mut egraph = build_test_database()?;
 
-        define_language!(&mut egraph, (datatype Expr (One) (Two Expr Expr :cost 10)));
+        datatype!(&mut egraph, (datatype Expr (One) (Two Expr Expr :cost 10)));
 
         let ruleset = "custom_ruleset";
         add_ruleset(&mut egraph, ruleset)?;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,26 +32,22 @@ pub mod sort {
     }
 }
 
-pub mod ruleset {
-    use super::*;
+/// Create a new ruleset.
+pub fn add_ruleset(egraph: &mut EGraph, ruleset: Symbol) -> Result<(), Error> {
+    egraph.run_program(vec![Command::AddRuleset(span!(), ruleset)])?;
+    Ok(())
+}
 
-    /// Create a new ruleset.
-    pub fn add(egraph: &mut EGraph, ruleset: Symbol) -> Result<(), Error> {
-        egraph.run_program(vec![Command::AddRuleset(span!(), ruleset)])?;
-        Ok(())
-    }
-
-    /// Run one iteration of a ruleset.
-    pub fn run(egraph: &mut EGraph, ruleset: Symbol) -> Result<(), Error> {
-        egraph.run_program(vec![Command::RunSchedule(Schedule::Run(
-            span!(),
-            RunConfig {
-                ruleset,
-                until: None,
-            },
-        ))])?;
-        Ok(())
-    }
+/// Run one iteration of a ruleset.
+pub fn run_ruleset(egraph: &mut EGraph, ruleset: Symbol) -> Result<(), Error> {
+    egraph.run_program(vec![Command::RunSchedule(Schedule::Run(
+        span!(),
+        RunConfig {
+            ruleset,
+            until: None,
+        },
+    ))])?;
+    Ok(())
 }
 
 #[macro_export]
@@ -336,7 +332,7 @@ pub fn query(
         .parser
         .symbol_gen
         .fresh(&Symbol::from("query_ruleset"));
-    ruleset::add(egraph, ruleset)?;
+    add_ruleset(egraph, ruleset)?;
 
     rust_rule(
         egraph,
@@ -352,7 +348,7 @@ pub fn query(
         },
     )?;
 
-    ruleset::run(egraph, ruleset)?;
+    run_ruleset(egraph, ruleset)?;
 
     let ruleset = egraph.rulesets.swap_remove(&ruleset).unwrap();
 
@@ -433,7 +429,7 @@ mod tests {
         assert!(results.data.is_empty());
 
         let ruleset = Symbol::from("custom_ruleset");
-        ruleset::add(&mut egraph, ruleset)?;
+        add_ruleset(&mut egraph, ruleset)?;
 
         // add the rule from `build_test_database` to the egraph
         rule(
@@ -450,7 +446,7 @@ mod tests {
 
         // run that rule 10 times
         for _ in 0..10 {
-            ruleset::run(&mut egraph, ruleset)?;
+            run_ruleset(&mut egraph, ruleset)?;
         }
 
         // check that `fib` now contains `20`
@@ -473,7 +469,7 @@ mod tests {
         egraph.parse_and_run_program(None, "(datatype Unionable (One) (Two))")?;
 
         let ruleset = Symbol::from("custom_ruleset");
-        ruleset::add(&mut egraph, ruleset)?;
+        add_ruleset(&mut egraph, ruleset)?;
 
         rule(
             &mut egraph,
@@ -513,7 +509,7 @@ mod tests {
         assert!(results.data.is_empty());
 
         let ruleset = Symbol::from("custom_ruleset");
-        ruleset::add(&mut egraph, ruleset)?;
+        add_ruleset(&mut egraph, ruleset)?;
 
         // add the rule from `build_test_database` to the egraph
         rust_rule(
@@ -540,7 +536,7 @@ mod tests {
 
         // run that rule 10 times
         for _ in 0..10 {
-            ruleset::run(&mut egraph, ruleset)?;
+            run_ruleset(&mut egraph, ruleset)?;
         }
 
         // check that `fib` now contains `20`

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,15 +4,15 @@ pub mod expr {
     use super::*;
 
     pub fn var(name: &str) -> Expr {
-        Expr::Var(DUMMY_SPAN.clone(), name.into())
+        Expr::Var(span!(), name.into())
     }
 
     pub fn int(value: i64) -> Expr {
-        Expr::Lit(DUMMY_SPAN.clone(), Literal::Int(value))
+        Expr::Lit(span!(), Literal::Int(value))
     }
 
     pub fn call(f: &str, xs: Vec<Expr>) -> Expr {
-        Expr::Call(DUMMY_SPAN.clone(), f.into(), xs)
+        Expr::Call(span!(), f.into(), xs)
     }
 }
 
@@ -20,7 +20,7 @@ pub mod fact {
     use super::*;
 
     pub fn equals(args: Vec<Expr>) -> Fact {
-        Fact::Eq(DUMMY_SPAN.clone(), args)
+        Fact::Eq(span!(), args)
     }
 }
 
@@ -99,9 +99,9 @@ pub fn rule(
     });
 
     let rule = Rule {
-        span: DUMMY_SPAN.clone(),
+        span: span!(),
         head: GenericActions(vec![GenericAction::Expr(
-            DUMMY_SPAN.clone(),
+            span!(),
             expr::call(
                 prim_name.into(),
                 vars.iter().map(|(v, _)| expr::var(v)).collect(),
@@ -126,7 +126,7 @@ pub fn rule(
 
 pub fn run_ruleset(egraph: &mut EGraph, ruleset: Symbol) -> Result<(), Error> {
     egraph.run_program(vec![Command::RunSchedule(Schedule::Run(
-        DUMMY_SPAN.clone(),
+        span!(),
         RunConfig {
             ruleset,
             until: None,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -437,6 +437,13 @@ pub trait LeafSort: Any + Send + Sync + Debug {
     fn name(&self) -> &str;
     fn register_primitives(&self, eg: &mut EGraph);
     fn reconstruct_termdag(&self, _: &Primitives, _: Value, _: &mut TermDag) -> Term;
+
+    fn to_arcsort(self) -> ArcSort
+    where
+        Self: Sized,
+    {
+        Arc::new(LeafSortImpl(self))
+    }
 }
 
 #[derive(Debug)]
@@ -487,6 +494,13 @@ pub trait ContainerSort: Any + Send + Sync + Debug {
     fn register_primitives(&self, eg: &mut EGraph);
     fn reconstruct_termdag(&self, _: &Containers, _: Value, _: &mut TermDag, _: Vec<Term>) -> Term;
     fn serialized_name(&self, _: Value) -> &str;
+
+    fn to_arcsort(self) -> ArcSort
+    where
+        Self: Sized,
+    {
+        Arc::new(ContainerSortImpl(self))
+    }
 }
 
 #[derive(Debug)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -122,6 +122,7 @@ pub fn rule(
 }
 
 /// A wrapper around an `ExecutionState` for rules that are written in Rust.
+/// See the [`rust_rule`] documentation for an example of how to use this.
 pub struct RustRuleContext<'a, 'b> {
     exec_state: &'a mut ExecutionState<'b>,
     union_action: egglog_bridge::UnionAction,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -411,6 +411,12 @@ macro_rules! datatype {
     };
 }
 
+/// A "default" implementation of [`Sort`] for simple types
+/// which just want to put some data in the e-graph. If you
+/// implement this trait, do not implement `Sort` or
+/// `ContainerSort. Use `add_leaf_sort` to register leaf
+/// sorts with the `EGraph`. See `Sort` for documentation
+/// of the methods. Do not override `to_arcsort`.
 pub trait LeafSort: Any + Send + Sync + Debug {
     type Leaf: core_relations::Primitive;
     fn name(&self) -> &str;
@@ -464,6 +470,12 @@ impl<T: LeafSort> Sort for LeafSortImpl<T> {
     }
 }
 
+/// A "default" implementation of [`Sort`] for types which
+/// just want to store a pure data structure in the e-graph.
+/// If you implement this trait, do not implement `Sort` or
+/// `LeafSort`. Use `add_container_sort` to register container
+/// sorts with the `EGraph`. See `Sort` for documentation
+/// of the methods. Do not override `to_arcsort`.
 pub trait ContainerSort: Any + Send + Sync + Debug {
     type Container: core_relations::Container;
     fn name(&self) -> Symbol;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,253 @@
+use crate::*;
+
+pub mod expr {
+    use super::*;
+
+    pub fn var(name: &str) -> Expr {
+        Expr::Var(DUMMY_SPAN.clone(), name.into())
+    }
+
+    pub fn int(value: i64) -> Expr {
+        Expr::Lit(DUMMY_SPAN.clone(), Literal::Int(value))
+    }
+
+    pub fn call(f: &str, xs: Vec<Expr>) -> Expr {
+        Expr::Call(DUMMY_SPAN.clone(), f.into(), xs)
+    }
+}
+
+pub mod fact {
+    use super::*;
+
+    pub fn equals(args: Vec<Expr>) -> Fact {
+        Fact::Eq(DUMMY_SPAN.clone(), args)
+    }
+}
+
+pub mod sort {
+    use super::*;
+
+    pub fn int() -> ArcSort {
+        Arc::new(I64Sort)
+    }
+}
+
+#[macro_export]
+macro_rules! expr {
+    ((unquote $unquoted:expr)) => { $unquoted };
+    (($func:tt $($arg:tt)*)) => { expr::call(stringify!($func), vec![$(expr!($arg)),*]) };
+    // TODO: this matches ALL literals as ints
+    ($value:literal) => { expr::int($value) };
+    ($quoted:tt) => { expr::var(stringify!($quoted)) };
+}
+
+#[macro_export]
+macro_rules! fact {
+    ((= $($arg:tt)*)) => { fact::equals(vec![$(expr!($arg)),*]) };
+    ($a:tt) => { Fact::Fact(expr!($a)) };
+}
+
+#[macro_export]
+macro_rules! facts {
+    ($($tree:tt)*) => { Facts(vec![$(fact!($tree)),*]) };
+}
+
+struct RustRuleRhs<F: Fn(&[Value], (&[ArcSort], &ArcSort), &mut EGraph)> {
+    name: Symbol,
+    input: Vec<ArcSort>,
+    func: F,
+}
+
+impl<F: Fn(&[Value], (&[ArcSort], &ArcSort), &mut EGraph)> PrimitiveLike for RustRuleRhs<F> {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn get_type_constraints(&self, span: &Span) -> Box<dyn TypeConstraint> {
+        let sorts: Vec<_> = self
+            .input
+            .iter()
+            .chain(once(&(Arc::new(UnitSort) as Arc<dyn Sort>)))
+            .cloned()
+            .collect();
+        SimpleTypeConstraint::new(self.name(), sorts, span.clone()).into_box()
+    }
+    fn apply(
+        &self,
+        values: &[Value],
+        sorts: (&[ArcSort], &ArcSort),
+        egraph: Option<&mut EGraph>,
+    ) -> Option<Value> {
+        let egraph = egraph.expect("RustRuleRhs should not be used in a query");
+        (self.func)(values, sorts, egraph);
+        Some(Value::unit())
+    }
+}
+
+/// Add a rule to the e-graph. Returns the ruleset name.
+pub fn rule(
+    egraph: &mut EGraph,
+    vars: &[(&str, ArcSort)],
+    facts: Facts<Symbol, Symbol>,
+    func: impl Fn(&[Value], (&[ArcSort], &ArcSort), &mut EGraph) + 'static,
+) -> Result<Symbol, Error> {
+    let prim_name = egraph.symbol_gen.fresh(&Symbol::from("rust_rule_prim"));
+    egraph.add_primitive(RustRuleRhs {
+        name: prim_name,
+        input: vars.iter().map(|(_, s)| s.clone()).collect(),
+        func,
+    });
+
+    let rule = Rule {
+        span: DUMMY_SPAN.clone(),
+        head: GenericActions(vec![GenericAction::Expr(
+            DUMMY_SPAN.clone(),
+            expr::call(
+                prim_name.into(),
+                vars.iter().map(|(v, _)| expr::var(v)).collect(),
+            ),
+        )]),
+        body: facts.0,
+    };
+
+    let rule_name = format!("{}", rule).into();
+    let ruleset = egraph.symbol_gen.fresh(&"rust_rule_ruleset".into());
+    egraph.run_program(vec![
+        Command::AddRuleset(ruleset),
+        Command::Rule {
+            name: rule_name,
+            rule,
+            ruleset,
+        },
+    ])?;
+
+    Ok(ruleset)
+}
+
+pub fn run_ruleset(egraph: &mut EGraph, ruleset: Symbol) -> Result<(), Error> {
+    egraph.run_program(vec![Command::RunSchedule(Schedule::Run(
+        DUMMY_SPAN.clone(),
+        RunConfig {
+            ruleset,
+            until: None,
+        },
+    ))])?;
+    Ok(())
+}
+
+pub fn query(
+    egraph: &mut EGraph,
+    vars: &[(&str, ArcSort)],
+    facts: Facts<Symbol, Symbol>,
+) -> Result<Vec<Vec<Value>>, Error> {
+    use std::{cell::RefCell, rc::Rc};
+
+    let results = Rc::new(RefCell::new(Vec::new()));
+    let results_weak = Rc::downgrade(&results);
+
+    let ruleset = rule(
+        egraph,
+        vars,
+        facts,
+        move |values, _, _| match results_weak.upgrade() {
+            Some(rc) => rc.borrow_mut().push(values.to_vec()),
+            None => panic!("one-shot rule was called twice"),
+        },
+    )?;
+    run_ruleset(egraph, ruleset)?;
+
+    match Rc::into_inner(results) {
+        Some(refcell) => Ok(refcell.into_inner()),
+        None => panic!("results_weak.upgrade() was not dropped"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_test_database() -> Result<EGraph, Error> {
+        let mut egraph = EGraph::default();
+        egraph.parse_and_run_program(
+            None,
+            "
+(function fib (i64) i64)
+(set (fib 0) 0)
+(set (fib 1) 1)
+(rule (
+    (= f0 (fib x))
+    (= f1 (fib (+ x 1)))
+) (
+    (set (fib (+ x 2)) (+ f0 f1))
+))
+(run 10)
+        ",
+        )?;
+        Ok(egraph)
+    }
+
+    #[test]
+    fn rust_api_query() -> Result<(), Error> {
+        let mut egraph = build_test_database()?;
+
+        let results = query(
+            &mut egraph,
+            &[("x", sort::int()), ("y", sort::int())],
+            facts![
+                (= (fib x) y)
+                (= y 13)
+            ],
+        )?;
+
+        assert_eq!(results, [[Value::from(7), Value::from(13)]]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn rust_api_rule() -> Result<(), Error> {
+        let mut egraph = build_test_database()?;
+
+        let big_number = 20;
+
+        // check that `fib` does not contain `20`
+        let results = query(
+            &mut egraph,
+            &[("f", sort::int())],
+            facts![(= (fib (unquote expr::int(big_number))) f)],
+        )?;
+
+        assert!(results.is_empty());
+
+        // add the rule from `build_test_database` to the egraph with a handle
+        let ruleset = rule(
+            &mut egraph,
+            &[("x", sort::int()), ("f0", sort::int()), ("f1", sort::int())],
+            facts![
+                (= f0 (fib x))
+                (= f1 (fib (+ x 1)))
+            ],
+            |values, _, egraph| {
+                let [x, f0, f1] = values else { unreachable!() };
+                let a = Value::from(i64::load(&I64Sort, x) + 2);
+                let b = Value::from(i64::load(&I64Sort, f0) + i64::load(&I64Sort, f1));
+                egraph.functions[&Symbol::from("fib")].insert(&[a], b, egraph.timestamp);
+            },
+        )?;
+
+        // run that rule 10 times
+        for _ in 0..10 {
+            run_ruleset(&mut egraph, ruleset)?;
+        }
+
+        // check that `fib` now contains `20`
+        let results = query(
+            &mut egraph,
+            &[("f", sort::int())],
+            facts![(= (fib (unquote expr::int(big_number))) f)],
+        )?;
+        assert_eq!(results, [[Value::from(6765)]]);
+
+        Ok(())
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -285,30 +285,9 @@ impl QueryResult {
     /// Get an iterator over the query results,
     /// where each match is a `&[Value]` in the same order
     /// as the `vars` that were passed to `query`.
-    pub fn iter(&self) -> QueryResultIterator {
-        QueryResultIterator {
-            index: 0,
-            query: self,
-        }
-    }
-}
-
-/// Immutable iterator on the result of `query`.
-pub struct QueryResultIterator<'a> {
-    index: usize,
-    query: &'a QueryResult,
-}
-
-impl<'a> Iterator for QueryResultIterator<'a> {
-    type Item = &'a [Value];
-    fn next(&mut self) -> Option<&'a [Value]> {
-        let rest = &self.query.data[self.index..];
-        if rest.is_empty() {
-            None
-        } else {
-            self.index += self.query.cols;
-            Some(&rest[..self.query.cols])
-        }
+    pub fn iter(&self) -> impl Iterator<Item = &[Value]> {
+        assert!(self.data.len() % self.cols == 0);
+        self.data.chunks_exact(self.cols)
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,7 +27,7 @@ pub mod fact {
 pub mod sort {
     use super::*;
 
-    pub fn int() -> ArcSort {
+    pub fn i64() -> ArcSort {
         Arc::new(I64Sort)
     }
 }
@@ -52,6 +52,13 @@ pub mod ruleset {
         ))])?;
         Ok(())
     }
+}
+
+#[macro_export]
+macro_rules! vars {
+    [$($x:ident : $t:ident),* $(,)?] => {
+        &[$((stringify!($x), sort::$t())),*]
+    };
 }
 
 #[macro_export]
@@ -256,7 +263,6 @@ impl<'a> Iterator for QueryResultIterator<'a> {
 }
 
 /// Run a query over the database.
-/// TODO: add vars macro
 pub fn query(
     egraph: &mut EGraph,
     vars: &[(&str, ArcSort)],
@@ -338,7 +344,7 @@ mod tests {
 
         let results = query(
             &mut egraph,
-            &[("x", sort::int()), ("y", sort::int())],
+            vars![x: i64, y: i64],
             facts![
                 (= (fib x) y)
                 (= y 13)
@@ -361,7 +367,7 @@ mod tests {
         // check that `fib` does not contain `20`
         let results = query(
             &mut egraph,
-            &[("f", sort::int())],
+            vars![f: i64],
             facts![(= (fib (unquote expr::int(big_number))) f)],
         )?;
 
@@ -374,7 +380,7 @@ mod tests {
         rule(
             &mut egraph,
             ruleset,
-            &[("x", sort::int()), ("f0", sort::int()), ("f1", sort::int())],
+            vars![x: i64, f0: i64, f1: i64],
             facts![
                 (= f0 (fib x))
                 (= f1 (fib (+ x 1)))
@@ -401,7 +407,7 @@ mod tests {
         // check that `fib` now contains `20`
         let results = query(
             &mut egraph,
-            &[("f", sort::int())],
+            vars![f: i64],
             facts![(= (fib (unquote expr::int(big_number))) f)],
         )?;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -491,7 +491,7 @@ pub trait ContainerSort: Any + Send + Sync + Debug {
     fn is_eq_container_sort(&self) -> bool;
     fn inner_sorts(&self) -> Vec<ArcSort>;
     fn inner_values(&self, _: &Containers, _: Value) -> Vec<(ArcSort, Value)>;
-    fn register_primitives(&self, _eg: &mut EGraph) {}
+    fn register_primitives(&self, _eg: &mut EGraph, _: ArcSort) {}
     fn reconstruct_termdag(&self, _: &Containers, _: Value, _: &mut TermDag, _: Vec<Term>) -> Term;
     fn serialized_name(&self, _: Value) -> &str;
 
@@ -548,7 +548,7 @@ impl<T: ContainerSort> Sort for ContainerSortImpl<T> {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        self.0.register_primitives(eg);
+        self.0.register_primitives(eg, self.clone() as ArcSort);
     }
 
     fn reconstruct_termdag_container(
@@ -567,20 +567,16 @@ pub fn add_leaf_sort(
     egraph: &mut EGraph,
     leaf_sort: impl LeafSort,
     span: Span,
-) -> Result<(), Error> {
-    egraph
-        .add_sort(LeafSortImpl(leaf_sort), span)
-        .map_err(Error::TypeError)
+) -> Result<(), TypeError> {
+    egraph.add_sort(LeafSortImpl(leaf_sort), span)
 }
 
 pub fn add_container_sort(
     egraph: &mut EGraph,
     container_sort: impl ContainerSort,
     span: Span,
-) -> Result<(), Error> {
-    egraph
-        .add_sort(ContainerSortImpl(container_sort), span)
-        .map_err(Error::TypeError)
+) -> Result<(), TypeError> {
+    egraph.add_sort(ContainerSortImpl(container_sort), span)
 }
 
 #[cfg(test)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,8 @@ use std::any::{Any, TypeId};
 
 // Re-exports in `prelude` for convenience.
 pub use egglog::ast::{Action, Fact, Facts, GenericActions, Symbol};
-pub use egglog::{action, actions, datatype, expr, fact, facts, vars};
+pub use egglog::sort::{BigIntSort, BigRatSort, BoolSort, F64Sort, I64Sort, StringSort, UnitSort};
+pub use egglog::{action, actions, datatype, expr, fact, facts, sort, vars};
 pub use egglog::{span, EGraph};
 
 pub mod exprs {
@@ -27,14 +28,6 @@ pub mod exprs {
 
     pub fn call(f: &str, xs: Vec<Expr>) -> Expr {
         Expr::Call(span!(), f.into(), xs)
-    }
-}
-
-pub mod sort {
-    use super::*;
-
-    pub fn i64() -> ArcSort {
-        I64Sort.to_arcsort()
     }
 }
 
@@ -55,9 +48,37 @@ pub fn run_ruleset(egraph: &mut EGraph, ruleset: &str) -> Result<Vec<String>, Er
 }
 
 #[macro_export]
+macro_rules! sort {
+    (BigInt) => {
+        BigIntSort.to_arcsort()
+    };
+    (BigRat) => {
+        BigRatSort.to_arcsort()
+    };
+    (bool) => {
+        BoolSort.to_arcsort()
+    };
+    (f64) => {
+        F64Sort.to_arcsort()
+    };
+    (i64) => {
+        I64Sort.to_arcsort()
+    };
+    (String) => {
+        StringSort.to_arcsort()
+    };
+    (Unit) => {
+        UnitSort.to_arcsort()
+    };
+    ($t:expr) => {
+        $t
+    };
+}
+
+#[macro_export]
 macro_rules! vars {
-    [$($x:ident : $t:ident),* $(,)?] => {
-        &[$((stringify!($x), sort::$t())),*]
+    [$($x:ident : $t:tt),* $(,)?] => {
+        &[$((stringify!($x), sort!($t))),*]
     };
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -118,9 +118,8 @@ pub fn rule(
         body: facts.0,
     };
 
-    let rule_name = egraph.parser.symbol_gen.fresh(&"prelude::rule".into());
     egraph.run_program(vec![Command::Rule {
-        name: rule_name,
+        name: format!("{rule:?}").into(),
         ruleset: ruleset.into(),
         rule,
     }])
@@ -234,10 +233,8 @@ pub fn rust_rule(
     facts: Facts<Symbol, Symbol>,
     func: impl Fn(&mut RustRuleContext, &[Value]) -> Option<()> + Clone + Send + Sync + 'static,
 ) -> Result<Vec<String>, Error> {
-    let rule_name = egraph.parser.symbol_gen.fresh(&"prelude::rust_rule".into());
     let prim_name = egraph.parser.symbol_gen.fresh(&"rust_rule_prim".into());
-
-    let panic_id = egraph.backend.new_panic(format!("{rule_name}"));
+    let panic_id = egraph.backend.new_panic(format!("{prim_name}_panic"));
     egraph.add_primitive(RustRuleRhs {
         name: prim_name,
         inputs: vars.iter().map(|(_, s)| s.clone()).collect(),
@@ -269,7 +266,7 @@ pub fn rust_rule(
     };
 
     egraph.run_program(vec![Command::Rule {
-        name: rule_name,
+        name: format!("{rule:?}").into(),
         ruleset: ruleset.into(),
         rule,
     }])

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -29,7 +29,7 @@ pub mod sort {
     use super::*;
 
     pub fn i64() -> ArcSort {
-        Arc::new(I64Sort)
+        I64Sort.to_arcsort()
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -83,7 +83,7 @@ macro_rules! facts {
 #[macro_export]
 macro_rules! action {
     ((let $name:ident $value:tt)) => {
-        Action::Let(span!(), $name, expr!(value))
+        Action::Let(span!(), Symbol::from(stringify!($name)), expr!(value))
     };
     ((set ($f:ident $($x:tt)*) $value:tt)) => {
         Action::Set(span!(), Symbol::from(stringify!($f)), vec![$(expr!($x)),*], expr!($value))
@@ -101,7 +101,7 @@ macro_rules! action {
         Action::Panic(span!(), $message)
     };
     ($x:tt) => {
-        Action::Expr(span, expr!($x))
+        Action::Expr(span!(), expr!($x))
     };
 }
 

--- a/src/sort/add_primitive/src/lib.rs
+++ b/src/sort/add_primitive/src/lib.rs
@@ -190,9 +190,8 @@ pub fn add_primitive(input: TokenStream) -> TokenStream {
 
     // This is the big `quote!` block that ties everything together.
     quote! {{
-        #[allow(unused_imports)] use ::egglog::{*, constraint::*};
-        #[allow(unused_imports)] use ::std::any::TypeId;
-        #[allow(unused_imports)] use ::std::sync::Arc;
+        #[allow(unused_imports)] use ::egglog::{*, ast::*, constraint::*};
+        #[allow(unused_imports)] use ::std::{any::TypeId, sync::Arc};
 
         #[derive(Clone)]
         #prim_def

--- a/src/sort/add_primitive/src/lib.rs
+++ b/src/sort/add_primitive/src/lib.rs
@@ -25,7 +25,9 @@ use syn::{braced, bracketed, parenthesized, parse_macro_input, Expr, Ident, LitS
 ///   This is necessary because the relationship between Rust types
 ///   and egglog sorts is not 1-to-1.
 ///
-/// - Context: putting `{x: T}` between the `=` and the argument list
+/// - Context: sometimes you want your primitive to reference
+///   information from the scope of the `add_primitive!` call.
+///   Putting `{x: T}` between the `=` and the argument list
 ///   will let you access the expression `x` of type `T` from inside
 ///   the body as `self.ctx`. `T` must be the real Rust type of `x`.
 ///   `T` must be `Clone` and `'static`.

--- a/src/sort/add_primitive/src/lib.rs
+++ b/src/sort/add_primitive/src/lib.rs
@@ -21,7 +21,7 @@ use syn::{braced, bracketed, parenthesized, parse_macro_input, Expr, Ident, LitS
 /// - Containers: you must put an `@` in front of container types.
 ///
 /// - Specialized Constraints: using `T (E)` as a type will use
-///   `E:expr` in the type constraint but `T:ty` in the body.
+///   `(E:expr).clone()` in the type constraint but `T:ty` in the body.
 ///   This is necessary because the relationship between Rust types
 ///   and egglog sorts is not 1-to-1.
 ///
@@ -62,7 +62,7 @@ pub fn add_primitive(input: TokenStream) -> TokenStream {
         .filter_map(|(x, t)| {
             t.field
                 .as_ref()
-                .map(|(d, u)| (quote!(#x: #d), quote!(#x: #u)))
+                .map(|(d, u)| (quote!(#x: #d), quote!(#x: #u.clone())))
         })
         .chain(match context.0 {
             Some((e, t)) => vec![(quote!(ctx: #t), quote!(ctx: #e))],

--- a/src/sort/bigint.rs
+++ b/src/sort/bigint.rs
@@ -80,7 +80,3 @@ impl Sort for BigIntSort {
         termdag.app("from-string".into(), vec![as_string])
     }
 }
-
-impl IntoSort for Z {
-    type Sort = BigIntSort;
-}

--- a/src/sort/bigint.rs
+++ b/src/sort/bigint.rs
@@ -1,32 +1,17 @@
 use super::*;
 
-lazy_static! {
-    static ref BIG_INT_SORT_NAME: Symbol = "BigInt".into();
-    static ref INTS: Mutex<IndexSet<Z>> = Default::default();
-}
-
 #[derive(Debug)]
 pub struct BigIntSort;
 
-impl Sort for BigIntSort {
-    fn name(&self) -> Symbol {
-        *BIG_INT_SORT_NAME
-    }
+impl LeafSort for BigIntSort {
+    type Leaf = Z;
 
-    fn column_ty(&self, backend: &egglog_bridge::EGraph) -> ColumnTy {
-        ColumnTy::Primitive(backend.primitives().get_ty::<Z>())
-    }
-
-    fn register_type(&self, backend: &mut egglog_bridge::EGraph) {
-        backend.primitives_mut().register_type::<Z>();
-    }
-
-    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
-        self
+    fn name(&self) -> &str {
+        "BigInt"
     }
 
     #[rustfmt::skip]
-    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
+    fn register_primitives(&self, eg: &mut EGraph) {
         add_primitive!(eg, "bigint" = |a: i64| -> Z { Z::new(a.into()) });
 
         add_primitive!(eg, "+" = |a: Z, b: Z| -> Z { a + b });
@@ -64,11 +49,7 @@ impl Sort for BigIntSort {
         });
     }
 
-    fn value_type(&self) -> Option<TypeId> {
-        Some(TypeId::of::<Z>())
-    }
-
-    fn reconstruct_termdag_leaf(
+    fn reconstruct_termdag(
         &self,
         primitives: &Primitives,
         value: Value,

--- a/src/sort/bigrat.rs
+++ b/src/sort/bigrat.rs
@@ -1,10 +1,5 @@
 use super::*;
 
-lazy_static! {
-    static ref BIG_RAT_SORT_NAME: Symbol = "BigRat".into();
-    static ref RATS: Mutex<IndexSet<Q>> = Default::default();
-}
-
 /// Rational numbers supporting these primitives:
 /// - Arithmetic: `+`, `-`, `*`, `/`, `neg`, `abs`
 /// - Exponential: `pow`, `log`, `sqrt`, `cbrt`
@@ -15,25 +10,15 @@ lazy_static! {
 #[derive(Debug)]
 pub struct BigRatSort;
 
-impl Sort for BigRatSort {
-    fn name(&self) -> Symbol {
-        *BIG_RAT_SORT_NAME
-    }
+impl LeafSort for BigRatSort {
+    type Leaf = Q;
 
-    fn column_ty(&self, backend: &egglog_bridge::EGraph) -> ColumnTy {
-        ColumnTy::Primitive(backend.primitives().get_ty::<Q>())
-    }
-
-    fn register_type(&self, backend: &mut egglog_bridge::EGraph) {
-        backend.primitives_mut().register_type::<Q>();
-    }
-
-    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
-        self
+    fn name(&self) -> &str {
+        "BigRat"
     }
 
     #[rustfmt::skip]
-    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
+    fn register_primitives(&self, eg: &mut EGraph) {
         add_primitive!(eg, "+" = |a: Q, b: Q| -?> Q { a.checked_add(&b).map(Q::new) });
         add_primitive!(eg, "-" = |a: Q, b: Q| -?> Q { a.checked_sub(&b).map(Q::new) });
         add_primitive!(eg, "*" = |a: Q, b: Q| -?> Q { a.checked_mul(&b).map(Q::new) });
@@ -120,11 +105,7 @@ impl Sort for BigRatSort {
         add_primitive!(eg, ">=" = |a: Q, b: Q| -?> () { if a >= b {Some(())} else {None} });
     }
 
-    fn value_type(&self) -> Option<TypeId> {
-        Some(TypeId::of::<Q>())
-    }
-
-    fn reconstruct_termdag_leaf(
+    fn reconstruct_termdag(
         &self,
         primitives: &Primitives,
         value: Value,

--- a/src/sort/bigrat.rs
+++ b/src/sort/bigrat.rs
@@ -143,7 +143,3 @@ impl Sort for BigRatSort {
         termdag.app("bigrat".into(), vec![numer_term, denom_term])
     }
 }
-
-impl IntoSort for Q {
-    type Sort = BigRatSort;
-}

--- a/src/sort/bool.rs
+++ b/src/sort/bool.rs
@@ -48,7 +48,3 @@ impl Sort for BoolSort {
         termdag.lit(Literal::Bool(b))
     }
 }
-
-impl IntoSort for bool {
-    type Sort = BoolSort;
-}

--- a/src/sort/bool.rs
+++ b/src/sort/bool.rs
@@ -3,29 +3,15 @@ use super::*;
 #[derive(Debug)]
 pub struct BoolSort;
 
-lazy_static! {
-    static ref BOOL_SORT_NAME: Symbol = "bool".into();
-}
+impl LeafSort for BoolSort {
+    type Leaf = bool;
 
-impl Sort for BoolSort {
-    fn name(&self) -> Symbol {
-        *BOOL_SORT_NAME
-    }
-
-    fn column_ty(&self, backend: &egglog_bridge::EGraph) -> ColumnTy {
-        ColumnTy::Primitive(backend.primitives().get_ty::<bool>())
-    }
-
-    fn register_type(&self, backend: &mut egglog_bridge::EGraph) {
-        backend.primitives_mut().register_type::<bool>();
-    }
-
-    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
-        self
+    fn name(&self) -> &str {
+        "bool"
     }
 
     #[rustfmt::skip]
-    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
+    fn register_primitives(&self, eg: &mut EGraph) {
         add_primitive!(eg, "not" = |a: bool| -> bool { !a });
         add_primitive!(eg, "and" = |a: bool, b: bool| -> bool { a && b });
         add_primitive!(eg, "or" = |a: bool, b: bool| -> bool { a || b });
@@ -33,11 +19,7 @@ impl Sort for BoolSort {
         add_primitive!(eg, "=>" = |a: bool, b: bool| -> bool { !a || b });
     }
 
-    fn value_type(&self) -> Option<TypeId> {
-        Some(TypeId::of::<bool>())
-    }
-
-    fn reconstruct_termdag_leaf(
+    fn reconstruct_termdag(
         &self,
         primitives: &Primitives,
         value: Value,

--- a/src/sort/f64.rs
+++ b/src/sort/f64.rs
@@ -7,32 +7,18 @@ use super::*;
 #[derive(Debug)]
 pub struct F64Sort;
 
-lazy_static! {
-    static ref F64_SORT_NAME: Symbol = "f64".into();
-}
+impl LeafSort for F64Sort {
+    type Leaf = F;
 
-impl Sort for F64Sort {
-    fn name(&self) -> Symbol {
-        *F64_SORT_NAME
-    }
-
-    fn column_ty(&self, backend: &egglog_bridge::EGraph) -> ColumnTy {
-        ColumnTy::Primitive(backend.primitives().get_ty::<F>())
-    }
-
-    fn register_type(&self, backend: &mut egglog_bridge::EGraph) {
-        backend.primitives_mut().register_type::<F>();
-    }
-
-    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
-        self
+    fn name(&self) -> &str {
+        "f64"
     }
 
     #[rustfmt::skip]
     // We need the closure for division and mod operations, as they can panic.
     // cf https://github.com/rust-lang/rust-clippy/issues/9422
     #[allow(clippy::unnecessary_lazy_evaluations)]
-    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
+    fn register_primitives(&self, eg: &mut EGraph) {
         add_primitive!(eg, "+" = |a: F, b: F| -> F { a + b });
         add_primitive!(eg, "-" = |a: F, b: F| -> F { a - b });
         add_primitive!(eg, "*" = |a: F, b: F| -> F { a * b });
@@ -57,11 +43,7 @@ impl Sort for F64Sort {
         add_primitive!(eg, "to-string" = |a: F| -> S { S::new(format!("{:?}", a.0.0).into()) });
     }
 
-    fn value_type(&self) -> Option<TypeId> {
-        Some(TypeId::of::<F>())
-    }
-
-    fn reconstruct_termdag_leaf(
+    fn reconstruct_termdag(
         &self,
         primitives: &Primitives,
         value: Value,

--- a/src/sort/f64.rs
+++ b/src/sort/f64.rs
@@ -72,7 +72,3 @@ impl Sort for F64Sort {
         termdag.lit(Literal::Float(f.0))
     }
 }
-
-impl IntoSort for F {
-    type Sort = F64Sort;
-}

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -366,7 +366,7 @@ impl Primitive for Apply {
 }
 
 impl FunctionContainer {
-    /// Call function (primitive or table) <name> with value args <args> and return the value.
+    /// Call function (primitive or table) `name` with value args `args` and return the value.
     ///
     /// Public so that other primitive sorts (external or internal) have access.
     pub fn apply(&self, exec_state: &mut ExecutionState, args: &[Value]) -> Option<Value> {

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -186,10 +186,6 @@ impl Sort for FunctionSort {
     }
 }
 
-impl IntoSort for FunctionContainer {
-    type Sort = FunctionSort;
-}
-
 /// Takes a string and any number of partially applied args of any sort and returns a function
 struct FunctionCTorTypeConstraint {
     name: Symbol,

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -277,7 +277,7 @@ impl TypeConstraint for FunctionCTorTypeConstraint {
 
         // Otherwise we just try assuming it's this function, we don't know if it is or not
         vec![
-            constraint::assign(arguments[0].clone(), Arc::new(StringSort)),
+            constraint::assign(arguments[0].clone(), StringSort.to_arcsort()),
             output_sort_constraint,
         ]
     }

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -17,29 +17,15 @@ use super::*;
 #[derive(Debug)]
 pub struct I64Sort;
 
-lazy_static! {
-    static ref I64_SORT_NAME: Symbol = "i64".into();
-}
+impl LeafSort for I64Sort {
+    type Leaf = i64;
 
-impl Sort for I64Sort {
-    fn name(&self) -> Symbol {
-        *I64_SORT_NAME
-    }
-
-    fn column_ty(&self, backend: &egglog_bridge::EGraph) -> ColumnTy {
-        ColumnTy::Primitive(backend.primitives().get_ty::<i64>())
-    }
-
-    fn register_type(&self, backend: &mut egglog_bridge::EGraph) {
-        backend.primitives_mut().register_type::<i64>();
-    }
-
-    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
-        self
+    fn name(&self) -> &str {
+        "i64"
     }
 
     #[rustfmt::skip]
-    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
+    fn register_primitives(&self, eg: &mut EGraph) {
         add_primitive!(eg, "+" = |a: i64, b: i64| -?> i64 { a.checked_add(b) });
         add_primitive!(eg, "-" = |a: i64, b: i64| -?> i64 { a.checked_sub(b) });
         add_primitive!(eg, "*" = |a: i64, b: i64| -?> i64 { a.checked_mul(b) });
@@ -78,11 +64,7 @@ impl Sort for I64Sort {
         });
     }
 
-    fn value_type(&self) -> Option<TypeId> {
-        Some(TypeId::of::<i64>())
-    }
-
-    fn reconstruct_termdag_leaf(
+    fn reconstruct_termdag(
         &self,
         primitives: &Primitives,
         value: Value,

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -93,7 +93,3 @@ impl Sort for I64Sort {
         termdag.lit(Literal::Int(i))
     }
 }
-
-impl IntoSort for i64 {
-    type Sort = I64Sort;
-}

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -147,7 +147,9 @@ impl ContainerSort for MapSort {
             .collect()
     }
 
-    fn register_primitives(&self, eg: &mut EGraph, arc: ArcSort) {
+    fn register_primitives(&self, eg: &mut EGraph) {
+        let arc = self.clone().to_arcsort();
+
         add_primitive!(eg, "map-empty" = {self.clone(): MapSort} || -> @MapContainer (arc) { MapContainer {
             do_rebuild_keys: self.ctx.key.is_eq_sort(),
             do_rebuild_vals: self.ctx.value.is_eq_sort(),

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -157,7 +157,11 @@ impl Sort for MapSort {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        add_primitive!(eg, "map-empty" = || -> @MapContainer (self.clone()) { MapContainer { do_rebuild_keys: self.__y.key.is_eq_sort(), do_rebuild_vals: self.__y.value.is_eq_sort(), data: BTreeMap::new() } });
+        add_primitive!(eg, "map-empty" = || -> @MapContainer (self.clone()) { MapContainer {
+            do_rebuild_keys: self.__y.inner_sorts()[0].is_eq_sort(),
+            do_rebuild_vals: self.__y.inner_sorts()[1].is_eq_sort(),
+            data: BTreeMap::new()
+        } });
 
         add_primitive!(eg, "map-get"    = |    xs: @MapContainer (self.clone()), x: # (self.key())                     | -?> # (self.value()) { xs.data.get(&x).copied() });
         add_primitive!(eg, "map-insert" = |mut xs: @MapContainer (self.clone()), x: # (self.key()), y: # (self.value())| -> @MapContainer (self.clone()) {{ xs.data.insert(x, y); xs }});
@@ -187,8 +191,4 @@ impl Sort for MapSort {
 
         term
     }
-}
-
-impl IntoSort for MapContainer {
-    type Sort = MapSort;
 }

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -157,9 +157,9 @@ impl Sort for MapSort {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        add_primitive!(eg, "map-empty" = || -> @MapContainer (self.clone()) { MapContainer {
-            do_rebuild_keys: self.__y.inner_sorts()[0].is_eq_sort(),
-            do_rebuild_vals: self.__y.inner_sorts()[1].is_eq_sort(),
+        add_primitive!(eg, "map-empty" = {self.clone(): Arc<MapSort>} || -> @MapContainer (self.clone()) { MapContainer {
+            do_rebuild_keys: self.ctx.key.is_eq_sort(),
+            do_rebuild_vals: self.ctx.value.is_eq_sort(),
             data: BTreeMap::new()
         } });
 

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -79,16 +79,15 @@ impl Presort for MapSort {
     }
 
     fn make_sort(
-        eg: &mut EGraph,
+        typeinfo: &mut TypeInfo,
         name: Symbol,
         args: &[Expr],
-        span: Span,
-    ) -> Result<(), TypeError> {
+    ) -> Result<ArcSort, TypeError> {
         if let [Expr::Var(k_span, k), Expr::Var(v_span, v)] = args {
-            let k = eg
+            let k = typeinfo
                 .get_sort_by_name(k)
                 .ok_or(TypeError::UndefinedSort(*k, k_span.clone()))?;
-            let v = eg
+            let v = typeinfo
                 .get_sort_by_name(v)
                 .ok_or(TypeError::UndefinedSort(*v, v_span.clone()))?;
 
@@ -100,7 +99,6 @@ impl Presort for MapSort {
                     k_span.clone(),
                 ));
             }
-
             if v.is_container_sort() {
                 return Err(TypeError::DisallowedSort(
                     name,
@@ -109,15 +107,12 @@ impl Presort for MapSort {
                 ));
             }
 
-            add_container_sort(
-                eg,
-                Self {
-                    name,
-                    key: k.clone(),
-                    value: v.clone(),
-                },
-                span,
-            )
+            let out = Self {
+                name,
+                key: k.clone(),
+                value: v.clone(),
+            };
+            Ok(out.to_arcsort())
         } else {
             panic!()
         }

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -157,19 +157,19 @@ impl Sort for MapSort {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        add_primitive!(eg, "map-empty" = {self.clone(): Arc<MapSort>} || -> @MapContainer (self.clone()) { MapContainer {
+        add_primitive!(eg, "map-empty" = {self.clone(): Arc<MapSort>} || -> @MapContainer (self) { MapContainer {
             do_rebuild_keys: self.ctx.key.is_eq_sort(),
             do_rebuild_vals: self.ctx.value.is_eq_sort(),
             data: BTreeMap::new()
         } });
 
-        add_primitive!(eg, "map-get"    = |    xs: @MapContainer (self.clone()), x: # (self.key())                     | -?> # (self.value()) { xs.data.get(&x).copied() });
-        add_primitive!(eg, "map-insert" = |mut xs: @MapContainer (self.clone()), x: # (self.key()), y: # (self.value())| -> @MapContainer (self.clone()) {{ xs.data.insert(x, y); xs }});
-        add_primitive!(eg, "map-remove" = |mut xs: @MapContainer (self.clone()), x: # (self.key())                     | -> @MapContainer (self.clone()) {{ xs.data.remove(&x);   xs }});
+        add_primitive!(eg, "map-get"    = |    xs: @MapContainer (self), x: # (self.key())                     | -?> # (self.value()) { xs.data.get(&x).copied() });
+        add_primitive!(eg, "map-insert" = |mut xs: @MapContainer (self), x: # (self.key()), y: # (self.value())| -> @MapContainer (self) {{ xs.data.insert(x, y); xs }});
+        add_primitive!(eg, "map-remove" = |mut xs: @MapContainer (self), x: # (self.key())                     | -> @MapContainer (self) {{ xs.data.remove(&x);   xs }});
 
-        add_primitive!(eg, "map-length"       = |xs: @MapContainer (self.clone())| -> i64 { xs.data.len() as i64 });
-        add_primitive!(eg, "map-contains"     = |xs: @MapContainer (self.clone()), x: # (self.key())| -?> () { ( xs.data.contains_key(&x)).then_some(()) });
-        add_primitive!(eg, "map-not-contains" = |xs: @MapContainer (self.clone()), x: # (self.key())| -?> () { (!xs.data.contains_key(&x)).then_some(()) });
+        add_primitive!(eg, "map-length"       = |xs: @MapContainer (self)| -> i64 { xs.data.len() as i64 });
+        add_primitive!(eg, "map-contains"     = |xs: @MapContainer (self), x: # (self.key())| -?> () { ( xs.data.contains_key(&x)).then_some(()) });
+        add_primitive!(eg, "map-not-contains" = |xs: @MapContainer (self), x: # (self.key())| -?> () { (!xs.data.contains_key(&x)).then_some(()) });
     }
 
     fn value_type(&self) -> Option<TypeId> {

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -1,11 +1,9 @@
-use lazy_static::lazy_static;
 use num::traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, One, Signed, ToPrimitive, Zero};
-use num::{rational::BigRational, BigInt};
+use num::{BigInt, BigRational};
 use ordered_float::OrderedFloat;
 use std::any::TypeId;
 use std::fmt::Debug;
 use std::ops::{Shl, Shr};
-use std::sync::Mutex;
 use std::{any::Any, sync::Arc};
 
 pub use core_relations::{Container, Containers, ExecutionState, Primitives, Rebuilder};
@@ -13,7 +11,6 @@ pub use egglog_bridge::ColumnTy;
 
 use crate::ast::Literal;
 use crate::extract::Cost;
-use crate::util::IndexSet;
 use crate::*;
 
 pub type Z = core_relations::Boxed<BigInt>;
@@ -199,9 +196,9 @@ pub type PreSort =
 pub fn literal_sort(lit: &Literal) -> ArcSort {
     match lit {
         Literal::Int(_) => I64Sort.to_arcsort(),
-        Literal::Float(_) => Arc::new(F64Sort) as ArcSort,
-        Literal::String(_) => Arc::new(StringSort) as ArcSort,
-        Literal::Bool(_) => Arc::new(BoolSort) as ArcSort,
-        Literal::Unit => Arc::new(UnitSort) as ArcSort,
+        Literal::Float(_) => F64Sort.to_arcsort(),
+        Literal::String(_) => StringSort.to_arcsort(),
+        Literal::Bool(_) => BoolSort.to_arcsort(),
+        Literal::Unit => UnitSort.to_arcsort(),
     }
 }

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -155,14 +155,13 @@ pub trait Presort {
     fn presort_name() -> Symbol;
     fn reserved_primitives() -> Vec<Symbol>;
     fn make_sort(
-        egraph: &mut EGraph,
+        typeinfo: &mut TypeInfo,
         name: Symbol,
         args: &[Expr],
-        span: Span,
-    ) -> Result<(), TypeError>;
+    ) -> Result<ArcSort, TypeError>;
 }
 
-pub type MkSort = fn(&mut EGraph, Symbol, &[Expr], Span) -> Result<(), TypeError>;
+pub type MkSort = fn(&mut TypeInfo, Symbol, &[Expr]) -> Result<ArcSort, TypeError>;
 
 #[derive(Debug)]
 pub struct EqSort {

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -193,12 +193,6 @@ impl Sort for EqSort {
     }
 }
 
-/// This trait is used by the `add_primitive` macro to infer the sort type
-/// that corresponds to a given type.
-pub trait IntoSort: Sized {
-    type Sort: Sort;
-}
-
 pub type PreSort =
     fn(typeinfo: &mut TypeInfo, name: Symbol, params: &[Expr]) -> Result<ArcSort, TypeError>;
 

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -155,14 +155,14 @@ pub trait Presort {
     fn presort_name() -> Symbol;
     fn reserved_primitives() -> Vec<Symbol>;
     fn make_sort(
-        typeinfo: &mut TypeInfo,
+        egraph: &mut EGraph,
         name: Symbol,
         args: &[Expr],
-    ) -> Result<ArcSort, TypeError>;
+        span: Span,
+    ) -> Result<(), TypeError>;
 }
 
-pub type MakeSort =
-    fn(typeinfo: &mut TypeInfo, name: Symbol, params: &[Expr]) -> Result<ArcSort, TypeError>;
+pub type MkSort = fn(&mut EGraph, Symbol, &[Expr], Span) -> Result<(), TypeError>;
 
 #[derive(Debug)]
 pub struct EqSort {

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -198,7 +198,7 @@ pub type PreSort =
 
 pub fn literal_sort(lit: &Literal) -> ArcSort {
     match lit {
-        Literal::Int(_) => Arc::new(I64Sort) as ArcSort,
+        Literal::Int(_) => I64Sort.to_arcsort(),
         Literal::Float(_) => Arc::new(F64Sort) as ArcSort,
         Literal::String(_) => Arc::new(StringSort) as ArcSort,
         Literal::Bool(_) => Arc::new(BoolSort) as ArcSort,

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -161,6 +161,9 @@ pub trait Presort {
     ) -> Result<ArcSort, TypeError>;
 }
 
+pub type MakeSort =
+    fn(typeinfo: &mut TypeInfo, name: Symbol, params: &[Expr]) -> Result<ArcSort, TypeError>;
+
 #[derive(Debug)]
 pub struct EqSort {
     pub name: Symbol,
@@ -189,9 +192,6 @@ impl Sort for EqSort {
         None
     }
 }
-
-pub type PreSort =
-    fn(typeinfo: &mut TypeInfo, name: Symbol, params: &[Expr]) -> Result<ArcSort, TypeError>;
 
 pub fn literal_sort(lit: &Literal) -> ArcSort {
     match lit {

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -122,20 +122,20 @@ impl Sort for MultiSetSort {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        add_primitive!(eg, "multiset-of" = {self.clone(): Arc<MultiSetSort>} [xs: # (self.element())] -> @MultiSetContainer (self.clone()) { MultiSetContainer {
+        add_primitive!(eg, "multiset-of" = {self.clone(): Arc<MultiSetSort>} [xs: # (self.element())] -> @MultiSetContainer (self) { MultiSetContainer {
             do_rebuild: self.ctx.element.is_eq_sort(),
             data: xs.collect()
         } });
 
-        add_primitive!(eg, "multiset-pick" = |xs: @MultiSetContainer (self.clone())| -> # (self.element()) { *xs.data.pick().expect("Cannot pick from an empty multiset") });
-        add_primitive!(eg, "multiset-insert" = |mut xs: @MultiSetContainer (self.clone()), x: # (self.element())| -> @MultiSetContainer (self.clone()) { MultiSetContainer { data: xs.data.insert( x) , ..xs } });
-        add_primitive!(eg, "multiset-remove" = |mut xs: @MultiSetContainer (self.clone()), x: # (self.element())| -> @MultiSetContainer (self.clone()) { MultiSetContainer { data: xs.data.remove(&x)?, ..xs } });
+        add_primitive!(eg, "multiset-pick" = |xs: @MultiSetContainer (self)| -> # (self.element()) { *xs.data.pick().expect("Cannot pick from an empty multiset") });
+        add_primitive!(eg, "multiset-insert" = |mut xs: @MultiSetContainer (self), x: # (self.element())| -> @MultiSetContainer (self) { MultiSetContainer { data: xs.data.insert( x) , ..xs } });
+        add_primitive!(eg, "multiset-remove" = |mut xs: @MultiSetContainer (self), x: # (self.element())| -> @MultiSetContainer (self) { MultiSetContainer { data: xs.data.remove(&x)?, ..xs } });
 
-        add_primitive!(eg, "multiset-length"       = |xs: @MultiSetContainer (self.clone())| -> i64 { xs.data.len() as i64 });
-        add_primitive!(eg, "multiset-contains"     = |xs: @MultiSetContainer (self.clone()), x: # (self.element())| -?> () { ( xs.data.contains(&x)).then_some(()) });
-        add_primitive!(eg, "multiset-not-contains" = |xs: @MultiSetContainer (self.clone()), x: # (self.element())| -?> () { (!xs.data.contains(&x)).then_some(()) });
+        add_primitive!(eg, "multiset-length"       = |xs: @MultiSetContainer (self)| -> i64 { xs.data.len() as i64 });
+        add_primitive!(eg, "multiset-contains"     = |xs: @MultiSetContainer (self), x: # (self.element())| -?> () { ( xs.data.contains(&x)).then_some(()) });
+        add_primitive!(eg, "multiset-not-contains" = |xs: @MultiSetContainer (self), x: # (self.element())| -?> () { (!xs.data.contains(&x)).then_some(()) });
 
-        add_primitive!(eg, "multiset-sum" = |xs: @MultiSetContainer (self.clone()), ys: @MultiSetContainer (self.clone())| -> @MultiSetContainer (self.clone()) { MultiSetContainer { data: xs.data.sum(ys.data), ..xs } });
+        add_primitive!(eg, "multiset-sum" = |xs: @MultiSetContainer (self), ys: @MultiSetContainer (self)| -> @MultiSetContainer (self) { MultiSetContainer { data: xs.data.sum(ys.data), ..xs } });
 
         // Only include map function if we already declared a function sort with the correct signature
         let fn_sorts = eg.type_info.get_sorts_by(|s: &Arc<FunctionSort>| {
@@ -147,7 +147,7 @@ impl Sort for MultiSetSort {
             0 => {}
             1 => eg.add_primitive(Map {
                 name: "unstable-multiset-map".into(),
-                multiset: self.clone(),
+                multiset: self,
                 fn_: fn_sorts.into_iter().next().unwrap(),
             }),
             _ => panic!("too many applicable function sorts"),

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -112,7 +112,9 @@ impl ContainerSort for MultiSetSort {
             .collect()
     }
 
-    fn register_primitives(&self, eg: &mut EGraph, arc: ArcSort) {
+    fn register_primitives(&self, eg: &mut EGraph) {
+        let arc = self.clone().to_arcsort();
+
         add_primitive!(eg, "multiset-of" = {self.clone(): MultiSetSort} [xs: # (self.element())] -> @MultiSetContainer (arc) { MultiSetContainer {
             do_rebuild: self.ctx.element.is_eq_sort(),
             data: xs.collect()

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -54,32 +54,28 @@ impl Presort for MultiSetSort {
     }
 
     fn make_sort(
-        eg: &mut EGraph,
+        typeinfo: &mut TypeInfo,
         name: Symbol,
         args: &[Expr],
-        span: Span,
-    ) -> Result<(), TypeError> {
-        if let [Expr::Var(arg_span, e)] = args {
-            let e = eg
+    ) -> Result<ArcSort, TypeError> {
+        if let [Expr::Var(span, e)] = args {
+            let e = typeinfo
                 .get_sort_by_name(e)
-                .ok_or(TypeError::UndefinedSort(*e, arg_span.clone()))?;
+                .ok_or(TypeError::UndefinedSort(*e, span.clone()))?;
 
             if e.is_eq_container_sort() {
                 return Err(TypeError::DisallowedSort(
                     name,
                     "Multisets nested with other EqSort containers are not allowed".into(),
-                    arg_span.clone(),
+                    span.clone(),
                 ));
             }
 
-            add_container_sort(
-                eg,
-                Self {
-                    name,
-                    element: e.clone(),
-                },
-                span,
-            )
+            let out = Self {
+                name,
+                element: e.clone(),
+            };
+            Ok(out.to_arcsort())
         } else {
             panic!()
         }

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -170,10 +170,6 @@ impl Sort for MultiSetSort {
     }
 }
 
-impl IntoSort for MultiSetContainer {
-    type Sort = MultiSetSort;
-}
-
 #[derive(Clone)]
 struct Map {
     name: Symbol,

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -122,7 +122,10 @@ impl Sort for MultiSetSort {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        add_primitive!(eg, "multiset-of" = [xs: # (self.element())] -> @MultiSetContainer (self.clone()) { MultiSetContainer { do_rebuild: self.__y.is_eq_container_sort(), data: xs.collect() } });
+        add_primitive!(eg, "multiset-of" = {self.clone(): Arc<MultiSetSort>} [xs: # (self.element())] -> @MultiSetContainer (self.clone()) { MultiSetContainer {
+            do_rebuild: self.ctx.element.is_eq_sort(),
+            data: xs.collect()
+        } });
 
         add_primitive!(eg, "multiset-pick" = |xs: @MultiSetContainer (self.clone())| -> # (self.element()) { *xs.data.pick().expect("Cannot pick from an empty multiset") });
         add_primitive!(eg, "multiset-insert" = |mut xs: @MultiSetContainer (self.clone()), x: # (self.element())| -> @MultiSetContainer (self.clone()) { MultiSetContainer { data: xs.data.insert( x) , ..xs } });

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -57,32 +57,28 @@ impl Presort for SetSort {
     }
 
     fn make_sort(
-        eg: &mut EGraph,
+        typeinfo: &mut TypeInfo,
         name: Symbol,
         args: &[Expr],
-        span: Span,
-    ) -> Result<(), TypeError> {
-        if let [Expr::Var(arg_span, e)] = args {
-            let e = eg
+    ) -> Result<ArcSort, TypeError> {
+        if let [Expr::Var(span, e)] = args {
+            let e = typeinfo
                 .get_sort_by_name(e)
-                .ok_or(TypeError::UndefinedSort(*e, arg_span.clone()))?;
+                .ok_or(TypeError::UndefinedSort(*e, span.clone()))?;
 
             if e.is_eq_container_sort() {
                 return Err(TypeError::DisallowedSort(
                     name,
                     "Sets nested with other EqSort containers are not allowed".into(),
-                    arg_span.clone(),
+                    span.clone(),
                 ));
             }
 
-            add_container_sort(
-                eg,
-                Self {
-                    name,
-                    element: e.clone(),
-                },
-                span,
-            )
+            let out = Self {
+                name,
+                element: e.clone(),
+            };
+            Ok(out.to_arcsort())
         } else {
             panic!()
         }

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -122,26 +122,26 @@ impl Sort for SetSort {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        add_primitive!(eg, "set-empty" = {self.clone(): Arc<SetSort>} |                      | -> @SetContainer (self.clone()) { SetContainer {
+        add_primitive!(eg, "set-empty" = {self.clone(): Arc<SetSort>} |                      | -> @SetContainer (self) { SetContainer {
             do_rebuild: self.ctx.element.is_eq_sort(),
             data: BTreeSet::new()
         } });
-        add_primitive!(eg, "set-of"    = {self.clone(): Arc<SetSort>} [xs: # (self.element())] -> @SetContainer (self.clone()) { SetContainer {
+        add_primitive!(eg, "set-of"    = {self.clone(): Arc<SetSort>} [xs: # (self.element())] -> @SetContainer (self) { SetContainer {
             do_rebuild: self.ctx.element.is_eq_sort(),
             data: xs.collect()
         } });
 
-        add_primitive!(eg, "set-get" = |xs: @SetContainer (self.clone()), i: i64| -?> # (self.element()) { xs.data.iter().nth(i as usize).copied() });
-        add_primitive!(eg, "set-insert" = |mut xs: @SetContainer (self.clone()), x: # (self.element())| -> @SetContainer (self.clone()) {{ xs.data.insert( x); xs }});
-        add_primitive!(eg, "set-remove" = |mut xs: @SetContainer (self.clone()), x: # (self.element())| -> @SetContainer (self.clone()) {{ xs.data.remove(&x); xs }});
+        add_primitive!(eg, "set-get" = |xs: @SetContainer (self), i: i64| -?> # (self.element()) { xs.data.iter().nth(i as usize).copied() });
+        add_primitive!(eg, "set-insert" = |mut xs: @SetContainer (self), x: # (self.element())| -> @SetContainer (self) {{ xs.data.insert( x); xs }});
+        add_primitive!(eg, "set-remove" = |mut xs: @SetContainer (self), x: # (self.element())| -> @SetContainer (self) {{ xs.data.remove(&x); xs }});
 
-        add_primitive!(eg, "set-length"       = |xs: @SetContainer (self.clone())| -> i64 { xs.data.len() as i64 });
-        add_primitive!(eg, "set-contains"     = |xs: @SetContainer (self.clone()), x: # (self.element())| -?> () { ( xs.data.contains(&x)).then_some(()) });
-        add_primitive!(eg, "set-not-contains" = |xs: @SetContainer (self.clone()), x: # (self.element())| -?> () { (!xs.data.contains(&x)).then_some(()) });
+        add_primitive!(eg, "set-length"       = |xs: @SetContainer (self)| -> i64 { xs.data.len() as i64 });
+        add_primitive!(eg, "set-contains"     = |xs: @SetContainer (self), x: # (self.element())| -?> () { ( xs.data.contains(&x)).then_some(()) });
+        add_primitive!(eg, "set-not-contains" = |xs: @SetContainer (self), x: # (self.element())| -?> () { (!xs.data.contains(&x)).then_some(()) });
 
-        add_primitive!(eg, "set-union"      = |mut xs: @SetContainer (self.clone()), ys: @SetContainer (self.clone())| -> @SetContainer (self.clone()) {{ xs.data.extend(ys.data);                  xs }});
-        add_primitive!(eg, "set-diff"       = |mut xs: @SetContainer (self.clone()), ys: @SetContainer (self.clone())| -> @SetContainer (self.clone()) {{ xs.data.retain(|k| !ys.data.contains(k)); xs }});
-        add_primitive!(eg, "set-intersect"  = |mut xs: @SetContainer (self.clone()), ys: @SetContainer (self.clone())| -> @SetContainer (self.clone()) {{ xs.data.retain(|k|  ys.data.contains(k)); xs }});
+        add_primitive!(eg, "set-union"      = |mut xs: @SetContainer (self), ys: @SetContainer (self)| -> @SetContainer (self) {{ xs.data.extend(ys.data);                  xs }});
+        add_primitive!(eg, "set-diff"       = |mut xs: @SetContainer (self), ys: @SetContainer (self)| -> @SetContainer (self) {{ xs.data.retain(|k| !ys.data.contains(k)); xs }});
+        add_primitive!(eg, "set-intersect"  = |mut xs: @SetContainer (self), ys: @SetContainer (self)| -> @SetContainer (self) {{ xs.data.retain(|k|  ys.data.contains(k)); xs }});
     }
 
     fn reconstruct_termdag_container(

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -122,8 +122,14 @@ impl Sort for SetSort {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        add_primitive!(eg, "set-empty" = |                      | -> @SetContainer (self.clone()) { SetContainer { do_rebuild: self.__y.is_eq_container_sort(), data: BTreeSet::new() } });
-        add_primitive!(eg, "set-of"    = [xs: # (self.element())] -> @SetContainer (self.clone()) { SetContainer { do_rebuild: self.__y.is_eq_container_sort(), data: xs.collect()    } });
+        add_primitive!(eg, "set-empty" = {self.clone(): Arc<SetSort>} |                      | -> @SetContainer (self.clone()) { SetContainer {
+            do_rebuild: self.ctx.element.is_eq_sort(),
+            data: BTreeSet::new()
+        } });
+        add_primitive!(eg, "set-of"    = {self.clone(): Arc<SetSort>} [xs: # (self.element())] -> @SetContainer (self.clone()) { SetContainer {
+            do_rebuild: self.ctx.element.is_eq_sort(),
+            data: xs.collect()
+        } });
 
         add_primitive!(eg, "set-get" = |xs: @SetContainer (self.clone()), i: i64| -?> # (self.element()) { xs.data.iter().nth(i as usize).copied() });
         add_primitive!(eg, "set-insert" = |mut xs: @SetContainer (self.clone()), x: # (self.element())| -> @SetContainer (self.clone()) {{ xs.data.insert( x); xs }});

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -156,7 +156,3 @@ impl Sort for SetSort {
         Some(TypeId::of::<SetContainer>())
     }
 }
-
-impl IntoSort for SetContainer {
-    type Sort = SetSort;
-}

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -112,7 +112,9 @@ impl ContainerSort for SetSort {
             .collect()
     }
 
-    fn register_primitives(&self, eg: &mut EGraph, arc: ArcSort) {
+    fn register_primitives(&self, eg: &mut EGraph) {
+        let arc = self.clone().to_arcsort();
+
         add_primitive!(eg, "set-empty" = {self.clone(): SetSort} |                      | -> @SetContainer (arc) { SetContainer {
             do_rebuild: self.ctx.element.is_eq_sort(),
             data: BTreeSet::new()

--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -57,10 +57,6 @@ impl Sort for StringSort {
     }
 }
 
-impl IntoSort for S {
-    type Sort = StringSort;
-}
-
 /// A newtype wrapper for [`Symbol`] to allow for a custom implementation of the
 /// [`core_relations::Primitive`] trait.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -6,28 +6,14 @@ use super::*;
 #[derive(Debug)]
 pub struct StringSort;
 
-lazy_static! {
-    static ref STRING_SORT_NAME: Symbol = "String".into();
-}
+impl LeafSort for StringSort {
+    type Leaf = S;
 
-impl Sort for StringSort {
-    fn name(&self) -> Symbol {
-        *STRING_SORT_NAME
+    fn name(&self) -> &str {
+        "String"
     }
 
-    fn column_ty(&self, backend: &egglog_bridge::EGraph) -> ColumnTy {
-        ColumnTy::Primitive(backend.primitives().get_ty::<S>())
-    }
-
-    fn register_type(&self, backend: &mut egglog_bridge::EGraph) {
-        backend.primitives_mut().register_type::<S>();
-    }
-
-    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
-        self
-    }
-
-    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
+    fn register_primitives(&self, eg: &mut EGraph) {
         add_primitive!(eg, "+" = [xs: S] -> S {{
             let mut y = String::new();
             xs.for_each(|x| y.push_str(x.as_str()));
@@ -42,10 +28,7 @@ impl Sort for StringSort {
         );
     }
 
-    fn value_type(&self) -> Option<TypeId> {
-        Some(TypeId::of::<S>())
-    }
-    fn reconstruct_termdag_leaf(
+    fn reconstruct_termdag(
         &self,
         primitives: &Primitives,
         value: Value,

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -3,32 +3,14 @@ use super::*;
 #[derive(Debug)]
 pub struct UnitSort;
 
-lazy_static! {
-    static ref UNIT_SORT_NAME: Symbol = "Unit".into();
-}
+impl LeafSort for UnitSort {
+    type Leaf = ();
 
-impl Sort for UnitSort {
-    fn name(&self) -> Symbol {
-        *UNIT_SORT_NAME
+    fn name(&self) -> &str {
+        "Unit"
     }
 
-    fn column_ty(&self, backend: &egglog_bridge::EGraph) -> ColumnTy {
-        ColumnTy::Primitive(backend.primitives().get_ty::<()>())
-    }
-
-    fn register_type(&self, backend: &mut egglog_bridge::EGraph) {
-        backend.primitives_mut().register_type::<()>();
-    }
-
-    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
-        self
-    }
-
-    fn value_type(&self) -> Option<TypeId> {
-        Some(TypeId::of::<()>())
-    }
-
-    fn reconstruct_termdag_leaf(
+    fn reconstruct_termdag(
         &self,
         _primitives: &Primitives,
         _value: Value,

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -37,7 +37,3 @@ impl Sort for UnitSort {
         termdag.lit(Literal::Unit)
     }
 }
-
-impl IntoSort for () {
-    type Sort = UnitSort;
-}

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -53,32 +53,28 @@ impl Presort for VecSort {
     }
 
     fn make_sort(
-        eg: &mut EGraph,
+        typeinfo: &mut TypeInfo,
         name: Symbol,
         args: &[Expr],
-        span: Span,
-    ) -> Result<(), TypeError> {
-        if let [Expr::Var(arg_span, e)] = args {
-            let e = eg
+    ) -> Result<ArcSort, TypeError> {
+        if let [Expr::Var(span, e)] = args {
+            let e = typeinfo
                 .get_sort_by_name(e)
-                .ok_or(TypeError::UndefinedSort(*e, arg_span.clone()))?;
+                .ok_or(TypeError::UndefinedSort(*e, span.clone()))?;
 
             if e.is_eq_container_sort() {
                 return Err(TypeError::DisallowedSort(
                     name,
                     "Vec nested with other EqSort containers are not allowed".into(),
-                    arg_span.clone(),
+                    span.clone(),
                 ));
             }
 
-            add_container_sort(
-                eg,
-                Self {
-                    name,
-                    element: e.clone(),
-                },
-                span,
-            )
+            let out = Self {
+                name,
+                element: e.clone(),
+            };
+            Ok(out.to_arcsort())
         } else {
             panic!("Vec sort must have sort as argument. Got {:?}", args)
         }

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -157,10 +157,6 @@ impl Sort for VecSort {
     }
 }
 
-impl IntoSort for VecContainer {
-    type Sort = VecSort;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -118,9 +118,18 @@ impl Sort for VecSort {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        add_primitive!(eg, "vec-empty"  = |                                | -> @VecContainer (self.clone()) { VecContainer { do_rebuild: self.__y.is_eq_container_sort(), data: Vec::new()                        } });
-        add_primitive!(eg, "vec-of"     = [xs: # (self.element())          ] -> @VecContainer (self.clone()) { VecContainer { do_rebuild: self.__y.is_eq_container_sort(), data: xs                     .collect() } });
-        add_primitive!(eg, "vec-append" = [xs: @VecContainer (self.clone())] -> @VecContainer (self.clone()) { VecContainer { do_rebuild: self.__y.is_eq_container_sort(), data: xs.flat_map(|x| x.data).collect() } });
+        add_primitive!(eg, "vec-empty"  = {self.clone(): Arc<VecSort>} |                                | -> @VecContainer (self.clone()) { VecContainer {
+            do_rebuild: self.ctx.element.is_eq_sort(),
+            data: Vec::new()
+        } });
+        add_primitive!(eg, "vec-of"     = {self.clone(): Arc<VecSort>} [xs: # (self.element())          ] -> @VecContainer (self.clone()) { VecContainer {
+            do_rebuild: self.ctx.element.is_eq_sort(),
+            data: xs                     .collect()
+        } });
+        add_primitive!(eg, "vec-append" = {self.clone(): Arc<VecSort>} [xs: @VecContainer (self.clone())] -> @VecContainer (self.clone()) { VecContainer {
+            do_rebuild: self.ctx.element.is_eq_sort(),
+            data: xs.flat_map(|x| x.data).collect()
+        } });
 
         add_primitive!(eg, "vec-push" = |mut xs: @VecContainer (self.clone()), x: # (self.element())| -> @VecContainer (self.clone()) {{ xs.data.push(x); xs }});
         add_primitive!(eg, "vec-pop"  = |mut xs: @VecContainer (self.clone())                       | -> @VecContainer (self.clone()) {{ xs.data.pop();   xs }});

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -108,7 +108,9 @@ impl ContainerSort for VecSort {
             .collect()
     }
 
-    fn register_primitives(&self, eg: &mut EGraph, arc: ArcSort) {
+    fn register_primitives(&self, eg: &mut EGraph) {
+        let arc = self.clone().to_arcsort();
+
         add_primitive!(eg, "vec-empty"  = {self.clone(): VecSort} |                                | -> @VecContainer (arc) { VecContainer {
             do_rebuild: self.ctx.element.is_eq_sort(),
             data: Vec::new()

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -118,29 +118,29 @@ impl Sort for VecSort {
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        add_primitive!(eg, "vec-empty"  = {self.clone(): Arc<VecSort>} |                                | -> @VecContainer (self.clone()) { VecContainer {
+        add_primitive!(eg, "vec-empty"  = {self.clone(): Arc<VecSort>} |                                | -> @VecContainer (self) { VecContainer {
             do_rebuild: self.ctx.element.is_eq_sort(),
             data: Vec::new()
         } });
-        add_primitive!(eg, "vec-of"     = {self.clone(): Arc<VecSort>} [xs: # (self.element())          ] -> @VecContainer (self.clone()) { VecContainer {
+        add_primitive!(eg, "vec-of"     = {self.clone(): Arc<VecSort>} [xs: # (self.element())          ] -> @VecContainer (self) { VecContainer {
             do_rebuild: self.ctx.element.is_eq_sort(),
             data: xs                     .collect()
         } });
-        add_primitive!(eg, "vec-append" = {self.clone(): Arc<VecSort>} [xs: @VecContainer (self.clone())] -> @VecContainer (self.clone()) { VecContainer {
+        add_primitive!(eg, "vec-append" = {self.clone(): Arc<VecSort>} [xs: @VecContainer (self)] -> @VecContainer (self) { VecContainer {
             do_rebuild: self.ctx.element.is_eq_sort(),
             data: xs.flat_map(|x| x.data).collect()
         } });
 
-        add_primitive!(eg, "vec-push" = |mut xs: @VecContainer (self.clone()), x: # (self.element())| -> @VecContainer (self.clone()) {{ xs.data.push(x); xs }});
-        add_primitive!(eg, "vec-pop"  = |mut xs: @VecContainer (self.clone())                       | -> @VecContainer (self.clone()) {{ xs.data.pop();   xs }});
+        add_primitive!(eg, "vec-push" = |mut xs: @VecContainer (self), x: # (self.element())| -> @VecContainer (self) {{ xs.data.push(x); xs }});
+        add_primitive!(eg, "vec-pop"  = |mut xs: @VecContainer (self)                       | -> @VecContainer (self) {{ xs.data.pop();   xs }});
 
-        add_primitive!(eg, "vec-length"       = |xs: @VecContainer (self.clone())| -> i64 { xs.data.len() as i64 });
-        add_primitive!(eg, "vec-contains"     = |xs: @VecContainer (self.clone()), x: # (self.element())| -?> () { ( xs.data.contains(&x)).then_some(()) });
-        add_primitive!(eg, "vec-not-contains" = |xs: @VecContainer (self.clone()), x: # (self.element())| -?> () { (!xs.data.contains(&x)).then_some(()) });
+        add_primitive!(eg, "vec-length"       = |xs: @VecContainer (self)| -> i64 { xs.data.len() as i64 });
+        add_primitive!(eg, "vec-contains"     = |xs: @VecContainer (self), x: # (self.element())| -?> () { ( xs.data.contains(&x)).then_some(()) });
+        add_primitive!(eg, "vec-not-contains" = |xs: @VecContainer (self), x: # (self.element())| -?> () { (!xs.data.contains(&x)).then_some(()) });
 
-        add_primitive!(eg, "vec-get"    = |    xs: @VecContainer (self.clone()), i: i64                       | -?> # (self.element()) { xs.data.get(i as usize).copied() });
-        add_primitive!(eg, "vec-set"    = |mut xs: @VecContainer (self.clone()), i: i64, x: # (self.element())| -> @VecContainer (self.clone()) {{ xs.data[i as usize] = x;    xs }});
-        add_primitive!(eg, "vec-remove" = |mut xs: @VecContainer (self.clone()), i: i64                       | -> @VecContainer (self.clone()) {{ xs.data.remove(i as usize); xs }});
+        add_primitive!(eg, "vec-get"    = |    xs: @VecContainer (self), i: i64                       | -?> # (self.element()) { xs.data.get(i as usize).copied() });
+        add_primitive!(eg, "vec-set"    = |mut xs: @VecContainer (self), i: i64, x: # (self.element())| -> @VecContainer (self) {{ xs.data[i as usize] = x;    xs }});
+        add_primitive!(eg, "vec-remove" = |mut xs: @VecContainer (self), i: i64                       | -> @VecContainer (self) {{ xs.data.remove(i as usize); xs }});
     }
 
     fn reconstruct_termdag_container(

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -47,7 +47,7 @@ impl Debug for PrimitiveWithId {
 #[derive(Clone, Default)]
 pub struct TypeInfo {
     // get the sort from the sorts name()
-    presorts: HashMap<Symbol, PreSort>,
+    presorts: HashMap<Symbol, MakeSort>,
     // TODO(yz): I want to get rid of this as now we have user-defined primitives and constraint based type checking
     reserved_primitives: HashSet<Symbol>,
     sorts: HashMap<Symbol, Arc<dyn Sort>>,

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -190,10 +190,10 @@ impl EGraph {
                 let res_variants =
                     self.type_info
                         .typecheck_expr(symbol_gen, variants, &Default::default())?;
-                if res_variants.output_type().name() != I64Sort.name() {
+                if res_variants.output_type().name() != I64Sort.name().into() {
                     return Err(TypeError::Mismatch {
                         expr: variants.clone(),
-                        expected: Arc::new(I64Sort),
+                        expected: I64Sort.to_arcsort(),
                         actual: res_variants.output_type(),
                     });
                 }

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -73,16 +73,18 @@ impl EGraph {
             return Err(TypeError::FunctionAlreadyBound(name, span));
         }
 
-        match presort_and_args {
-            None => self.add_arcsort(Arc::new(EqSort { name }), span),
+        let sort = match presort_and_args {
+            None => Arc::new(EqSort { name }),
             Some((presort, args)) => {
                 if let Some(mksort) = self.type_info.mksorts.get(presort) {
-                    mksort(self, name, args, span)
+                    mksort(&mut self.type_info, name, args)?
                 } else {
-                    Err(TypeError::PresortNotFound(*presort, span))
+                    return Err(TypeError::PresortNotFound(*presort, span));
                 }
             }
-        }
+        };
+
+        self.add_arcsort(sort, span)
     }
 
     /// Add a user-defined sort

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -270,6 +270,7 @@ impl TypeInfo {
         }
     }
 
+    /// Returns all sorts that satisfy the type and predicate.
     pub fn get_sorts_by<S: Sort>(&self, pred: impl Fn(&Arc<S>) -> bool) -> Vec<Arc<S>> {
         let mut results = Vec::new();
         for sort in self.sorts.values() {
@@ -283,10 +284,12 @@ impl TypeInfo {
         results
     }
 
+    /// Returns all sorts based on the type.
     pub fn get_sorts<S: Sort>(&self) -> Vec<Arc<S>> {
         self.get_sorts_by(|_| true)
     }
 
+    /// Returns a sort that satisfies the type and predicate.
     pub fn get_sort_by<S: Sort>(&self, pred: impl Fn(&Arc<S>) -> bool) -> Arc<S> {
         let results = self.get_sorts_by(pred);
         assert_eq!(
@@ -298,8 +301,26 @@ impl TypeInfo {
         results.into_iter().next().unwrap()
     }
 
+    /// Returns a sort based on the type.
     pub fn get_sort<S: Sort>(&self) -> Arc<S> {
         self.get_sort_by(|_| true)
+    }
+
+    /// Returns all sorts that satisfy the predicate.
+    pub fn get_arcsorts_by(&self, f: impl Fn(&ArcSort) -> bool) -> Vec<ArcSort> {
+        self.sorts.values().filter(|&x| f(x)).cloned().collect()
+    }
+
+    /// Returns a sort based on the predicate.
+    pub fn get_arcsort_by(&self, f: impl Fn(&ArcSort) -> bool) -> ArcSort {
+        let results = self.get_arcsorts_by(f);
+        assert_eq!(
+            results.len(),
+            1,
+            "Expected exactly one sort for type {}",
+            std::any::type_name::<S>()
+        );
+        results.into_iter().next().unwrap()
     }
 
     fn function_to_functype(&self, func: &FunctionDecl) -> Result<FuncType, TypeError> {


### PR DESCRIPTION
Adds a prelude that can be imported to expose ways to build an e-graph without using string interpolation.

I am choosing to block this on the open performance PR.