### PR TITLE
Performance related changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +503,7 @@ dependencies = [
  "lazy_static",
  "libtest-mimic",
  "log",
+ "mimalloc",
  "num",
  "numeric-id",
  "ordered-float",
@@ -808,6 +818,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libtest-mimic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +871,15 @@ name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "num"
@@ -1290,6 +1319,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sized-chunks"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=38c2c0e#38c2c0e80e24258d551ee5517edb684752c168db"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=896dacc#896dacc2274bc41e6c5557b93f1a950fdcaf6d0a"
 dependencies = [
  "arc-swap",
  "rayon",
@@ -312,7 +312,7 @@ dependencies = [
 [[package]]
 name = "core-relations"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=38c2c0e#38c2c0e80e24258d551ee5517edb684752c168db"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=896dacc#896dacc2274bc41e6c5557b93f1a950fdcaf6d0a"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -325,6 +325,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "log",
+ "num",
  "numeric-id",
  "once_cell",
  "petgraph",
@@ -505,7 +506,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=38c2c0e#38c2c0e80e24258d551ee5517edb684752c168db"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=896dacc#896dacc2274bc41e6c5557b93f1a950fdcaf6d0a"
 dependencies = [
  "anyhow",
  "core-relations",
@@ -515,6 +516,7 @@ dependencies = [
  "log",
  "num-rational",
  "numeric-id",
+ "once_cell",
  "petgraph",
  "rayon",
  "smallvec",
@@ -936,7 +938,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=38c2c0e#38c2c0e80e24258d551ee5517edb684752c168db"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=896dacc#896dacc2274bc41e6c5557b93f1a950fdcaf6d0a"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1446,7 +1448,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=38c2c0e#38c2c0e80e24258d551ee5517edb684752c168db"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=896dacc#896dacc2274bc41e6c5557b93f1a950fdcaf6d0a"
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,9 @@ web-time = "1.1"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "38c2c0e" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "38c2c0e" }
-numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "38c2c0e" }
+core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "896dacc" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "896dacc" }
+numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "896dacc" }
 
 # Need to add "js" feature for "graphviz-rust" to work in wasm
 getrandom = { version = "0.2.10", optional = true, features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ chrono = { version = "0.4", default-features = false, features = ["now"], option
 codspeed-criterion-compat = "2.7.2"
 glob = "0.3.1"
 libtest-mimic = "0.6.1"
+mimalloc = "0.1.46"
 
 [profile.release]
 incremental = true

--- a/benches/example_benchmarks.rs
+++ b/benches/example_benchmarks.rs
@@ -1,6 +1,9 @@
 use codspeed_criterion_compat::{criterion_group, criterion_main, Criterion};
 use egglog::EGraph;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn run_example(filename: &str, program: &str, no_messages: bool) {
     let mut egraph = EGraph::default();
     if no_messages {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -911,7 +911,7 @@ impl EGraph {
             ext_id,
             &[arg],
             egglog_bridge::ColumnTy::Primitive(unit_id),
-            "this function will never panic",
+            || "this function will never panic".to_string(),
         );
 
         let id = translator.build();
@@ -975,12 +975,11 @@ impl EGraph {
             &self.type_info,
         );
         translator.query(&query, true);
-        translator.rb.call_external_func(
-            ext_id,
-            &[],
-            egglog_bridge::ColumnTy::Id,
-            "this function will never panic",
-        );
+        translator
+            .rb
+            .call_external_func(ext_id, &[], egglog_bridge::ColumnTy::Id, || {
+                "this function will never panic".to_string()
+            });
         let id = translator.build();
         let _ = self.backend.run_rules(&[id]).unwrap();
         self.backend.free_rule(id);
@@ -1451,7 +1450,7 @@ impl<'a> BackendRule<'a> {
                 panic!("expected string literal after `unstable-fn`")
             };
             let id = if let Some(f) = self.type_info.get_func_type(&name) {
-                ResolvedFunctionId::Lookup(egglog_bridge::Lookup::new(
+                ResolvedFunctionId::Lookup(egglog_bridge::TableAction::new(
                     self.rb.egraph(),
                     self.func(f),
                 ))
@@ -1545,13 +1544,11 @@ impl<'a> BackendRule<'a> {
                         ResolvedCall::Primitive(p) => {
                             let name = p.primitive.0.name();
                             let (p, args, ty) = self.prim(p, args);
+                            let span = span.clone();
                             self.rb
-                                .call_external_func(
-                                    p,
-                                    &args,
-                                    ty,
-                                    format!("{span}: call of primitive {name} failed").as_str(),
-                                )
+                                .call_external_func(p, &args, ty, move || {
+                                    format!("{span}: call of primitive {name} failed")
+                                })
                                 .into()
                         }
                     };
@@ -1603,8 +1600,8 @@ impl<'a> BackendRule<'a> {
 fn literal_to_entry(egraph: &egglog_bridge::EGraph, l: &Literal) -> QueryEntry {
     match l {
         Literal::Int(x) => egraph.primitive_constant::<i64>(*x),
-        Literal::Float(x) => egraph.primitive_constant::<sort::F>(*x),
-        Literal::String(x) => egraph.primitive_constant::<sort::S>(*x),
+        Literal::Float(x) => egraph.primitive_constant::<sort::F>(x.into()),
+        Literal::String(x) => egraph.primitive_constant::<sort::S>(x.into()),
         Literal::Bool(x) => egraph.primitive_constant::<bool>(*x),
         Literal::Unit => egraph.primitive_constant::<()>(()),
     }
@@ -1613,8 +1610,8 @@ fn literal_to_entry(egraph: &egglog_bridge::EGraph, l: &Literal) -> QueryEntry {
 fn literal_to_value(egraph: &egglog_bridge::EGraph, l: &Literal) -> Value {
     match l {
         Literal::Int(x) => egraph.primitives().get::<i64>(*x),
-        Literal::Float(x) => egraph.primitives().get::<sort::F>(*x),
-        Literal::String(x) => egraph.primitives().get::<sort::S>(*x),
+        Literal::Float(x) => egraph.primitives().get::<sort::F>(x.into()),
+        Literal::String(x) => egraph.primitives().get::<sort::S>(x.into()),
         Literal::Bool(x) => egraph.primitives().get::<bool>(*x),
         Literal::Unit => egraph.primitives().get::<()>(()),
     }

--- a/src/sort/bigrat.rs
+++ b/src/sort/bigrat.rs
@@ -34,23 +34,23 @@ impl Sort for BigRatSort {
 
     #[rustfmt::skip]
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        add_primitive!(eg, "+" = |a: Q, b: Q| -?> Q { a.checked_add(&b) });
-        add_primitive!(eg, "-" = |a: Q, b: Q| -?> Q { a.checked_sub(&b) });
-        add_primitive!(eg, "*" = |a: Q, b: Q| -?> Q { a.checked_mul(&b) });
-        add_primitive!(eg, "/" = |a: Q, b: Q| -?> Q { a.checked_div(&b) });
+        add_primitive!(eg, "+" = |a: Q, b: Q| -?> Q { (&*a).checked_add(&b).map(Q::new) });
+        add_primitive!(eg, "-" = |a: Q, b: Q| -?> Q { (&*a).checked_sub(&b).map(Q::new) });
+        add_primitive!(eg, "*" = |a: Q, b: Q| -?> Q { (&*a).checked_mul(&b).map(Q::new) });
+        add_primitive!(eg, "/" = |a: Q, b: Q| -?> Q { (&*a).checked_div(&b).map(Q::new) });
 
         add_primitive!(eg, "min" = |a: Q, b: Q| -> Q { a.min(b) });
         add_primitive!(eg, "max" = |a: Q, b: Q| -> Q { a.max(b) });
-        add_primitive!(eg, "neg" = |a: Q| -> Q { -a });
-        add_primitive!(eg, "abs" = |a: Q| -> Q { a.abs() });
-        add_primitive!(eg, "floor" = |a: Q| -> Q { a.floor() });
-        add_primitive!(eg, "ceil" = |a: Q| -> Q { a.ceil() });
-        add_primitive!(eg, "round" = |a: Q| -> Q { a.round() });
+        add_primitive!(eg, "neg" = |a: Q| -> Q { Q::new(-a.0) });
+        add_primitive!(eg, "abs" = |a: Q| -> Q { Q::new(a.0.abs()) });
+        add_primitive!(eg, "floor" = |a: Q| -> Q { Q::new(a.0.floor()) });
+        add_primitive!(eg, "ceil" = |a: Q| -> Q { Q::new(a.0.ceil()) });
+        add_primitive!(eg, "round" = |a: Q| -> Q { Q::new((&*a).round()) });
 
-        add_primitive!(eg, "bigrat" = |a: Z, b: Z| -> Q { Q::new(a, b) });
-        add_primitive!(eg, "numer" = |a: Q| -> Z { a.numer().clone() });
-        add_primitive!(eg, "denom" = |a: Q| -> Z { a.denom().clone() });
-        add_primitive!(eg, "to-f64" = |a: Q| -> F { OrderedFloat(a.to_f64().unwrap()) });
+        add_primitive!(eg, "bigrat" = |a: Z, b: Z| -> Q { Q::new(BigRational::new(a.0, b.0)) });
+        add_primitive!(eg, "numer" = |a: Q| -> Z { Z::new((&*a).numer().clone()) });
+        add_primitive!(eg, "denom" = |a: Q| -> Z { Z::new((&*a).denom().clone()) });
+        add_primitive!(eg, "to-f64" = |a: Q| -> F { F::new(OrderedFloat(a.to_f64().unwrap())) });
 
         add_primitive!(eg, "pow" = |a: Q, b: Q| -?> Q {
             if !b.is_integer() {
@@ -62,10 +62,10 @@ impl Sort for BigRatSort {
                 // so that multiplicative inverse is always safe
                 if b.is_zero() {
                     // 0^0 = 1 by common convention
-                    Some(Q::one())
+                    Some(BigRational::one().into())
                 } else if b.is_positive() {
                     // 0^n = 0 where (n > 0)
-                    Some(Q::zero())
+                    Some(BigRational::zero().into())
                 } else {
                     // 0^n => (1/0)^(abs n) where (n < 0)
                     None
@@ -73,7 +73,7 @@ impl Sort for BigRatSort {
             } else {
                 let is_neg_pow = b.is_negative();
                 let (adj_base, adj_exp) = if is_neg_pow {
-                    (a.recip(), b.abs())
+                    (Q::new(a.recip()), Q::new(b.abs()))
                 } else {
                     (a, b)
                 };
@@ -82,12 +82,12 @@ impl Sort for BigRatSort {
                 let adj_exp_int = adj_exp.to_i64()?;
                 let adj_exp_usize = usize::try_from(adj_exp_int).ok()?;
 
-                num::traits::checked_pow(adj_base, adj_exp_usize)
+                num::traits::checked_pow(adj_base.into_inner(), adj_exp_usize).map(Q::new)
             }
         });
         add_primitive!(eg, "log" = |a: Q| -?> Q {
             if a.is_one() {
-                Some(Q::zero())
+                Some(Q::new(BigRational::zero()))
             } else {
                 todo!("log of bigrat")
             }
@@ -98,7 +98,7 @@ impl Sort for BigRatSort {
                 let s2 = a.denom().sqrt();
                 let is_perfect = &(s1.clone() * s1.clone()) == a.numer() && &(s2.clone() * s2.clone()) == a.denom();
                 if is_perfect {
-                    Some(Q::new(s1, s2))
+                    Some(Q::new(BigRational::new(s1, s2)))
                 } else {
                     None
                 }
@@ -108,7 +108,7 @@ impl Sort for BigRatSort {
         });
         add_primitive!(eg, "cbrt" = |a: Q| -?> Q {
             if a.is_one() {
-                Some(Q::one())
+                Some(Q::new(BigRational::one()))
             } else {
                 todo!("cbrt of bigrat")
             }
@@ -130,7 +130,7 @@ impl Sort for BigRatSort {
         value: Value,
         termdag: &mut TermDag,
     ) -> Term {
-        let rat = primitives.unwrap_ref::<BigRational>(value);
+        let rat = primitives.unwrap::<Q>(value);
         let numer = rat.numer();
         let denom = rat.denom();
 

--- a/src/sort/bool.rs
+++ b/src/sort/bool.rs
@@ -43,9 +43,9 @@ impl Sort for BoolSort {
         value: Value,
         termdag: &mut TermDag,
     ) -> Term {
-        let b = primitives.unwrap_ref::<bool>(value);
+        let b = primitives.unwrap::<bool>(value);
 
-        termdag.lit(Literal::Bool(*b))
+        termdag.lit(Literal::Bool(b))
     }
 }
 

--- a/src/sort/f64.rs
+++ b/src/sort/f64.rs
@@ -36,9 +36,9 @@ impl Sort for F64Sort {
         add_primitive!(eg, "+" = |a: F, b: F| -> F { a + b });
         add_primitive!(eg, "-" = |a: F, b: F| -> F { a - b });
         add_primitive!(eg, "*" = |a: F, b: F| -> F { a * b });
-        add_primitive!(eg, "/" = |a: F, b: F| -?> F { (b != 0.0).then(|| a / b) });
-        add_primitive!(eg, "%" = |a: F, b: F| -?> F { (b != 0.0).then(|| a % b) });
-        add_primitive!(eg, "^" = |a: F, b: F| -> F { OrderedFloat(a.powf(*b)) });
+        add_primitive!(eg, "/" = |a: F, b: F| -?> F { (*b != 0.0).then(|| a / b) });
+        add_primitive!(eg, "%" = |a: F, b: F| -?> F { (*b != 0.0).then(|| a % b) });
+        add_primitive!(eg, "^" = |a: F, b: F| -> F { F::from(OrderedFloat((&*a).powf(**b))) });
         add_primitive!(eg, "neg" = |a: F| -> F { -a });
 
         add_primitive!(eg, "<" = |a: F, b: F| -?> () { (a < b).then(|| ()) });
@@ -48,13 +48,13 @@ impl Sort for F64Sort {
 
         add_primitive!(eg, "min" = |a: F, b: F| -> F { a.min(b) });
         add_primitive!(eg, "max" = |a: F, b: F| -> F { a.max(b) });
-        add_primitive!(eg, "abs" = |a: F| -> F { a.abs() });
+        add_primitive!(eg, "abs" = |a: F| -> F { F::from((&*a).abs()) });
 
         // `to-f64` should be in `i64.rs`, but `F64Sort` wouldn't exist yet
-        add_primitive!(eg, "to-f64" = |a: i64| -> F { OrderedFloat(a as f64) });
-        add_primitive!(eg, "to-i64" = |a: F| -> i64 { a.0 as i64 });
+        add_primitive!(eg, "to-f64" = |a: i64| -> F { F::from(OrderedFloat(a as f64)) });
+        add_primitive!(eg, "to-i64" = |a: F| -> i64 { a.0.0 as i64 });
         // Use debug instead of to_string so that decimal place is always printed
-        add_primitive!(eg, "to-string" = |a: F| -> S { format!("{:?}", a.0).into() });
+        add_primitive!(eg, "to-string" = |a: F| -> S { S::new(format!("{:?}", a.0.0).into()) });
     }
 
     fn value_type(&self) -> Option<TypeId> {
@@ -67,9 +67,9 @@ impl Sort for F64Sort {
         value: Value,
         termdag: &mut TermDag,
     ) -> Term {
-        let f = primitives.unwrap_ref::<F>(value);
+        let f = primitives.unwrap::<F>(value);
 
-        termdag.lit(Literal::Float(*f))
+        termdag.lit(Literal::Float(f.0))
     }
 }
 

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -327,9 +327,11 @@ pub struct ResolvedFunction {
     pub name: Symbol,
 }
 
+impl core_relations::Primitive for ResolvedFunction {}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ResolvedFunctionId {
-    Lookup(egglog_bridge::Lookup),
+    Lookup(egglog_bridge::TableAction),
     Prim(ExternalFunctionId),
 }
 
@@ -370,7 +372,7 @@ impl FunctionContainer {
     pub fn apply(&self, exec_state: &mut ExecutionState, args: &[Value]) -> Option<Value> {
         let args: Vec<_> = self.1.iter().map(|(_, x)| x).chain(args).copied().collect();
         match &self.0 {
-            ResolvedFunctionId::Lookup(lookup) => lookup.run(exec_state, &args),
+            ResolvedFunctionId::Lookup(action) => action.lookup(exec_state, &args),
             ResolvedFunctionId::Prim(prim) => exec_state.call_external_func(*prim, &args),
         }
     }

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -69,7 +69,7 @@ impl Sort for I64Sort {
         add_primitive!(eg, "min" = |a: i64, b: i64| -> i64 { a.min(b) });
         add_primitive!(eg, "max" = |a: i64, b: i64| -> i64 { a.max(b) });
 
-        add_primitive!(eg, "to-string" = |a: i64| -> Symbol { a.to_string().into() });
+        add_primitive!(eg, "to-string" = |a: i64| -> S { S::new(a.to_string().into()) });
 
         // Must be in the i64 sort register function because
         // the string sort is registered before the i64 sort.
@@ -88,9 +88,9 @@ impl Sort for I64Sort {
         value: Value,
         termdag: &mut TermDag,
     ) -> Term {
-        let i = primitives.unwrap_ref::<i64>(value);
+        let i = primitives.unwrap::<i64>(value);
 
-        termdag.lit(Literal::Int(*i))
+        termdag.lit(Literal::Int(i))
     }
 }
 

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -16,10 +16,127 @@ use crate::extract::Cost;
 use crate::util::IndexSet;
 use crate::*;
 
-pub type Z = BigInt;
-pub type Q = BigRational;
-pub type F = OrderedFloat<f64>;
-pub type S = Symbol;
+/// A newtype wrapper used to implement the [`core_relations::Primitive`] trait on types not
+/// defined in this crate.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BaseTypeWrapper<T>(pub T);
+
+impl<T> BaseTypeWrapper<T> {
+    pub fn new(value: T) -> Self {
+        BaseTypeWrapper(value)
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> std::ops::Deref for BaseTypeWrapper<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for BaseTypeWrapper<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<T> for BaseTypeWrapper<T> {
+    fn from(value: T) -> Self {
+        BaseTypeWrapper(value)
+    }
+}
+
+impl<T: Copy> From<&T> for BaseTypeWrapper<T> {
+    fn from(value: &T) -> Self {
+        BaseTypeWrapper(*value)
+    }
+}
+
+impl<T: std::ops::Add<Output = T>> std::ops::Add for BaseTypeWrapper<T> {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self::Output {
+        BaseTypeWrapper(self.0 + other.0)
+    }
+}
+
+impl<T: std::ops::Sub<Output = T>> std::ops::Sub for BaseTypeWrapper<T> {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        BaseTypeWrapper(self.0 - other.0)
+    }
+}
+
+impl<T: std::ops::Mul<Output = T>> std::ops::Mul for BaseTypeWrapper<T> {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self::Output {
+        BaseTypeWrapper(self.0 * other.0)
+    }
+}
+
+impl<T: std::ops::Div<Output = T>> std::ops::Div for BaseTypeWrapper<T> {
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self::Output {
+        BaseTypeWrapper(self.0 / other.0)
+    }
+}
+
+impl<T: std::ops::Rem<Output = T>> std::ops::Rem for BaseTypeWrapper<T> {
+    type Output = Self;
+
+    fn rem(self, other: Self) -> Self::Output {
+        BaseTypeWrapper(self.0 % other.0)
+    }
+}
+
+impl<T: std::ops::Neg<Output = T>> std::ops::Neg for BaseTypeWrapper<T> {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        BaseTypeWrapper(-self.0)
+    }
+}
+
+impl<T: std::ops::BitAnd<Output = T>> std::ops::BitAnd for BaseTypeWrapper<T> {
+    type Output = Self;
+
+    fn bitand(self, other: Self) -> Self::Output {
+        BaseTypeWrapper(self.0 & other.0)
+    }
+}
+
+impl<T: std::ops::BitOr<Output = T>> std::ops::BitOr for BaseTypeWrapper<T> {
+    type Output = Self;
+
+    fn bitor(self, other: Self) -> Self::Output {
+        BaseTypeWrapper(self.0 | other.0)
+    }
+}
+
+impl<T: std::ops::BitXor<Output = T>> std::ops::BitXor for BaseTypeWrapper<T> {
+    type Output = Self;
+
+    fn bitxor(self, other: Self) -> Self::Output {
+        BaseTypeWrapper(self.0 ^ other.0)
+    }
+}
+
+impl core_relations::Primitive for BaseTypeWrapper<BigInt> {}
+impl core_relations::Primitive for BaseTypeWrapper<BigRational> {}
+impl core_relations::Primitive for BaseTypeWrapper<OrderedFloat<f64>> {}
+
+pub type Z = BaseTypeWrapper<BigInt>;
+pub type Q = BaseTypeWrapper<BigRational>;
+pub type F = BaseTypeWrapper<OrderedFloat<f64>>;
+pub type S = BaseTypeWrapper<Symbol>;
 
 mod bigint;
 pub use bigint::*;

--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -1,3 +1,6 @@
+use numeric_id::NumericId;
+use std::num::NonZeroU32;
+
 use super::*;
 
 #[derive(Debug)]
@@ -28,12 +31,14 @@ impl Sort for StringSort {
         add_primitive!(eg, "+" = [xs: S] -> S {{
             let mut y = String::new();
             xs.for_each(|x| y.push_str(x.as_str()));
-            y.into()
+            let x: Symbol = y.into();
+            BaseTypeWrapper(x)
         }});
         add_primitive!(
             eg,
-            "replace" =
-                |a: S, b: S, c: S| -> S { a.as_str().replace(b.as_str(), c.as_str()).into() }
+            "replace" = |a: S, b: S, c: S| -> S {
+                BaseTypeWrapper(a.as_str().replace(b.as_str(), c.as_str()).into())
+            }
         );
     }
 
@@ -46,12 +51,23 @@ impl Sort for StringSort {
         value: Value,
         termdag: &mut TermDag,
     ) -> Term {
-        let s = primitives.unwrap_ref::<S>(value);
+        let s = primitives.unwrap::<S>(value);
 
-        termdag.lit(Literal::String(*s))
+        termdag.lit(Literal::String(s.0))
     }
 }
 
-impl IntoSort for Symbol {
+impl IntoSort for S {
     type Sort = StringSort;
+}
+
+impl core_relations::Primitive for BaseTypeWrapper<Symbol> {
+    const MAY_UNBOX: bool = true;
+    fn try_box(&self) -> Option<core_relations::Value> {
+        let x: NonZeroU32 = self.0.into();
+        Some(core_relations::Value::new_const(x.get()))
+    }
+    fn try_unbox(val: core_relations::Value) -> Option<Self> {
+        Some(BaseTypeWrapper(NonZeroU32::new(val.rep()).unwrap().into()))
+    }
 }


### PR DESCRIPTION
This brings this branch up to date with the latest version of the backend, and makes changes related to `TableAction` and  the primitive trait.

It also adds `mimalloc` to the benchmark suite. Open to removing it. I'd like to see a codspeed benchmark with both.