### PR TITLE
Improve `input_file` performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=6d74e8#6d74e8ec88812aad94067ac178095a03a30d504c"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bbb7551#bbb7551fbb1a3554548b5fde97e793392fe4a2fb"
 dependencies = [
  "arc-swap",
  "rayon",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "core-relations"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=6d74e8#6d74e8ec88812aad94067ac178095a03a30d504c"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bbb7551#bbb7551fbb1a3554548b5fde97e793392fe4a2fb"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=6d74e8#6d74e8ec88812aad94067ac178095a03a30d504c"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bbb7551#bbb7551fbb1a3554548b5fde97e793392fe4a2fb"
 dependencies = [
  "anyhow",
  "core-relations",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=6d74e8#6d74e8ec88812aad94067ac178095a03a30d504c"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bbb7551#bbb7551fbb1a3554548b5fde97e793392fe4a2fb"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1485,7 +1485,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=6d74e8#6d74e8ec88812aad94067ac178095a03a30d504c"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=bbb7551#bbb7551fbb1a3554548b5fde97e793392fe4a2fb"
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,9 @@ dyn-clone = "1.0.17"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "6d74e8" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "6d74e8" }
-numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "6d74e8" }
+core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "bbb7551" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "bbb7551" }
+numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "bbb7551" }
 
 # Need to add "js" feature for "graphviz-rust" to work in wasm
 getrandom = { version = "0.2.10", optional = true, features = ["js"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1283,7 +1283,7 @@ impl EGraph {
             let mut row: Vec<Value> = Vec::with_capacity(row_schema.len());
 
             for sort in row_schema.iter() {
-                if let Some (raw) = it.next() {
+                if let Some(raw) = it.next() {
                     let val = match sort.name().as_str() {
                         "i64" => {
                             if let Ok(i) = raw.parse::<i64>() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1265,6 +1265,7 @@ impl EGraph {
         let mut contents = String::new();
         f.read_to_string(&mut contents).unwrap();
 
+        // Can also do a row-major Vec<Value>
         let mut parsed_contents: Vec<Vec<Value>> = Vec::with_capacity(contents.lines().count());
 
         let mut row_schema = func.schema.input.clone();
@@ -1277,12 +1278,12 @@ impl EGraph {
         let unit_val = self.backend.primitives().get(());
 
         for line in contents.lines() {
-            let mut row: Vec<Value> = Vec::with_capacity(row_schema.len());
-
             let mut it = line.split('\t').map(|s| s.trim());
 
+            let mut row: Vec<Value> = Vec::with_capacity(row_schema.len());
+
             for sort in row_schema.iter() {
-                if let Some(raw) = it.next() {
+                if let Some (raw) = it.next() {
                     let val = match sort.name().as_str() {
                         "i64" => {
                             if let Ok(i) = raw.parse::<i64>() {
@@ -1331,13 +1332,13 @@ impl EGraph {
         let table_action = egglog_bridge::TableAction::new(&self.backend, func.backend_id);
 
         let unit_id = self.backend.primitives().get_ty::<()>();
-        let use_lookup = function_type.subtype != FunctionSubtype::Constructor;
+        let use_insert = function_type.subtype != FunctionSubtype::Constructor;
 
         let ext_id = self
             .backend
             .register_external_func(make_external_func(move |es, _| {
                 for row in parsed_contents.iter() {
-                    if use_lookup {
+                    if use_insert {
                         table_action.insert(es, row.to_vec());
                     } else {
                         table_action.lookup(es, row);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1280,35 +1280,35 @@ impl EGraph {
             let mut row: Vec<Value> = Vec::with_capacity(row_schema.len());
 
             for (sort, raw) in row_schema.iter().zip(line.split('\t').map(|s| s.trim())) {
-                let val = 
-                    match sort.name().as_str() {
-                        "i64" => {
-                            if let Ok(i) = raw.parse::<i64>() {
-                                self.backend.primitives().get(i)
-                            } else {
-                                return Err(Error::InputFileFormatError(file));
-                            }
-                        },
-                        "f64" => {
-                            if let Ok(f) = raw.parse::<f64>() {
-                                self.backend.primitives().get::<F>(core_relations::Boxed::new(f.into()))
-                            } else {
-                                return Err(Error::InputFileFormatError(file));
-                            }
-                        },
-                        "String" => {
-                            self.backend.primitives().get::<S>(SymbolWrapper::new(raw.to_string().into()))
-                        },
-                        "Unit" => {
-                            unit_val
+                let val = match sort.name().as_str() {
+                    "i64" => {
+                        if let Ok(i) = raw.parse::<i64>() {
+                            self.backend.primitives().get(i)
+                        } else {
+                            return Err(Error::InputFileFormatError(file));
                         }
-                        _ => panic!("Unreachable")
-                    };
+                    }
+                    "f64" => {
+                        if let Ok(f) = raw.parse::<f64>() {
+                            self.backend
+                                .primitives()
+                                .get::<F>(core_relations::Boxed::new(f.into()))
+                        } else {
+                            return Err(Error::InputFileFormatError(file));
+                        }
+                    }
+                    "String" => self
+                        .backend
+                        .primitives()
+                        .get::<S>(SymbolWrapper::new(raw.to_string().into())),
+                    "Unit" => unit_val,
+                    _ => panic!("Unreachable"),
+                };
                 row.push(val);
             }
 
-            if row.len() == 0 {
-                continue
+            if row.is_empty() {
+                continue;
             }
 
             if row.len() != row_schema.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1329,7 +1329,7 @@ impl EGraph {
                     table_action.insert(es, row.to_vec());
                 }
                 Some(unit_val)
-            }));g
+            }));
 
         let mut translator = BackendRule::new(
             self.backend.new_rule("input_file", false),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -267,7 +267,8 @@ impl RustRuleContext<'_, '_> {
     /// Subsume a row in a table.
     /// For more information, see `egglog_bridge::TableAction::subsume`.
     pub fn subsume(&mut self, table: &str, key: &[Value]) {
-        self.get_table_action(table).subsume(self.exec_state, key)
+        self.get_table_action(table)
+            .subsume(self.exec_state, key.to_vec())
     }
 
     /// Panic.

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use std::ops::{Shl, Shr};
 use std::{any::Any, sync::Arc};
 
-pub use core_relations::{Container, Containers, ExecutionState, Primitives, Rebuilder, Boxed};
+pub use core_relations::{Boxed, Container, Containers, ExecutionState, Primitives, Rebuilder};
 pub use egglog_bridge::ColumnTy;
 
 use crate::ast::Literal;


### PR DESCRIPTION
This PR optimizes `input_file` performance. Instead of creating as many top-level commands as rows in the csv file, this implementation uses a single rule with a custom callback that inserts all the rows with `TableAction`.