### PR TITLE
Tweaking `CostModel` Trait

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -41,6 +41,25 @@ pub trait CostModel {
 #[derive(Default, Clone)]
 pub struct TreeAdditiveCostModel {}
 
+impl TreeAdditiveCostModel {
+
+    /// Default cost for containers is just the sum of all the elements inside
+    fn default_container_cost(
+        &self,
+        _egraph: &EGraph,
+        _value: Value,
+        element_costs: &[Cost],
+    ) -> Cost {
+        element_costs.iter().fold(0, |s, c| s.saturating_add(*c))
+    }
+
+    /// Default cost for leaf primitives is the constant one
+    fn default_leaf_cost(&self, _egraph: &EGraph, _value: Value) -> Cost {
+        1
+    }
+
+}
+
 impl CostModel for TreeAdditiveCostModel {
     fn fold(&self, _head: Symbol, children_cost: &[Cost], head_cost: Cost) -> Cost {
         children_cost
@@ -60,15 +79,15 @@ impl CostModel for TreeAdditiveCostModel {
     fn container_primitive(
         &self,
         egraph: &EGraph,
-        sort: &ArcSort,
+        _sort: &ArcSort,
         value: Value,
         element_costs: &[Cost],
     ) -> Cost {
-        sort.default_container_cost(egraph.backend.containers(), value, element_costs)
+        self.default_container_cost(egraph, value, element_costs)
     }
 
-    fn leaf_primitive(&self, egraph: &EGraph, sort: &ArcSort, value: Value) -> Cost {
-        sort.default_leaf_cost(egraph.backend.primitives(), value)
+    fn leaf_primitive(&self, egraph: &EGraph, _sort: &ArcSort, value: Value) -> Cost {
+        self.default_leaf_cost(egraph, value)
     }
 }
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -5,9 +5,10 @@ use crate::*;
 use std::collections::VecDeque;
 
 /// An interface for custom cost model
-/// For common case usage, the model should guarantee a term has a no-smaller cost
-/// than its subterms to avoid cycles in the extracted terms.
-/// For more niech usage, a term can have a cost less than its subterms.
+/// To use it with the default extractor, the cost type must be usize
+/// Additionally, the model should guarantee a term has a no-smaller cost
+/// than its subterms to avoid cycles in the extracted terms for common case usages.
+/// For more niech usages, a term can have a cost less than its subterms.
 /// As long as there is no negative cost cycle,
 /// the default extractor is guaranteed to terminate in computing the costs.
 /// However, the user needs to be careful to guarantee acyclicity in the extracted terms.

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -14,10 +14,10 @@ pub type Cost = usize;
 /// the default extractor is guaranteed to terminate in computing the costs.
 /// However, the user needs to be careful to guarantee acyclicity in the extracted terms.
 pub trait CostModel {
-    /// Compute the cost of term given the costs of the head symbol and the subterms
+    /// Compute the total cost of a term given the cost of the root enode and its immediate children's total costs
     fn fold(&self, head: Symbol, children_cost: &[Cost], head_cost: Cost) -> Cost;
 
-    /// Compute the cost of a particular enode.
+    /// Compute the cost of just a enode by itself, without taking its children into account
     fn enode_cost(
         &self,
         egraph: &EGraph,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -34,7 +34,9 @@ pub trait CostModel<C: SaturatingAdd + Zero + One> {
         let _egraph = egraph;
         let _sort = sort;
         let _value = value;
-        element_costs.iter().fold(C::zero(), |s, c| s.saturating_add(c))
+        element_costs
+            .iter()
+            .fold(C::zero(), |s, c| s.saturating_add(c))
     }
 
     /// Compute the cost of a primitive, non-container, value
@@ -54,8 +56,12 @@ pub type DefaultCost = usize;
 pub struct TreeAdditiveCostModel {}
 
 impl CostModel<DefaultCost> for TreeAdditiveCostModel {
-
-    fn fold(&self, _head: Symbol, children_cost: &[DefaultCost], head_cost: DefaultCost) -> DefaultCost {
+    fn fold(
+        &self,
+        _head: Symbol,
+        children_cost: &[DefaultCost],
+        head_cost: DefaultCost,
+    ) -> DefaultCost {
         children_cost
             .iter()
             .fold(head_cost, |s, c| s.saturating_add(*c))

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -15,7 +15,6 @@ use std::collections::VecDeque;
 /// As long as there is no negative cost cycle,
 /// the default extractor is guaranteed to terminate in computing the costs.
 /// However, the user needs to be careful to guarantee acyclicity in the extracted terms.
-
 pub trait CostModel<C: SaturatingAdd + Zero + One> {
     /// Compute the total cost of a term given the cost of the root enode and its immediate children's total costs
     fn fold(&self, head: Symbol, children_cost: &[C], head_cost: C) -> C;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ impl Display for RunReport {
 pub enum ExtractReport {
     Best {
         termdag: TermDag,
-        cost: usize,
+        cost: extract::DefaultCost,
         term: Term,
     },
     Variants {

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -163,15 +163,6 @@ impl Sort for FunctionSort {
         Some(TypeId::of::<FunctionContainer>())
     }
 
-    fn default_container_cost(
-        &self,
-        _containers: &Containers,
-        _value: Value,
-        element_costs: &[Cost],
-    ) -> Cost {
-        element_costs.iter().fold(1, |s, c| s.saturating_add(*c))
-    }
-
     fn reconstruct_termdag_container(
         &self,
         containers: &Containers,

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -10,7 +10,6 @@ pub use core_relations::{Container, Containers, ExecutionState, Primitives, Rebu
 pub use egglog_bridge::ColumnTy;
 
 use crate::ast::Literal;
-use crate::extract::Cost;
 use crate::*;
 
 pub type Z = core_relations::Boxed<BigInt>;
@@ -101,21 +100,6 @@ pub trait Sort: Any + Send + Sync + Debug {
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
         let _ = eg;
-    }
-
-    /// Default cost for containers when the cost model does not specify the cost
-    fn default_container_cost(
-        &self,
-        _containers: &Containers,
-        _value: Value,
-        element_costs: &[Cost],
-    ) -> Cost {
-        element_costs.iter().fold(0, |s, c| s.saturating_add(*c))
-    }
-
-    /// Default cost for leaf primitives when the cost model does not specify the cost
-    fn default_leaf_cost(&self, _primitives: &Primitives, _value: Value) -> Cost {
-        1
     }
 
     /// Reconstruct a container value in a TermDag

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use std::ops::{Shl, Shr};
 use std::{any::Any, sync::Arc};
 
-pub use core_relations::{Container, Containers, ExecutionState, Primitives, Rebuilder, Boxed};
+pub use core_relations::{Boxed, Container, Containers, ExecutionState, Primitives, Rebuilder};
 pub use egglog_bridge::ColumnTy;
 
 use crate::ast::Literal;


### PR DESCRIPTION
This PR:
1. Added more documentation to the trait
2. Moved default cost functions from the sorts into the default cost model
  2.1. Changed the default cost for unstable-fn from `1 + sum of children's costs` to just `sum`
3. Made the cost model interface generic
4. Made the extractor interface generic to the cost type with `Cost: SaturatingAdd + Zero + One + Ord + Eq + Copy + Debug`