### PR TITLE
Include more literals in prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,6 +26,22 @@ pub mod exprs {
         Expr::Lit(span!(), Literal::Int(value))
     }
 
+    pub fn float(value: f64) -> Expr {
+        Expr::Lit(span!(), Literal::Float(value.into()))
+    }
+
+    pub fn string(value: &str) -> Expr {
+        Expr::Lit(span!(), Literal::String(value.to_owned()))
+    }
+
+    pub fn unit() -> Expr {
+        Expr::Lit(span!(), Literal::Unit)
+    }
+
+    pub fn bool(value: bool) -> Expr {
+        Expr::Lit(span!(), Literal::Bool(value))
+    }
+
     pub fn call(f: &str, xs: Vec<Expr>) -> Expr {
         Expr::Call(span!(), f.to_owned(), xs)
     }


### PR DESCRIPTION
Question: Should they be macros? I think macros will allow us to expand and inject the correct line information with `span!` instead of being in `prelude.rs`