### PR TITLE
Union=>set desugar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=1a1f913#1a1f913e88101dbd6f98cc2468be0f0d1b87960b"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
 dependencies = [
  "arc-swap",
  "rayon",
@@ -305,7 +305,7 @@ dependencies = [
 [[package]]
 name = "core-relations"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=1a1f913#1a1f913e88101dbd6f98cc2468be0f0d1b87960b"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "egglog-bridge"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=1a1f913#1a1f913e88101dbd6f98cc2468be0f0d1b87960b"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
 dependencies = [
  "anyhow",
  "core-relations",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "numeric-id"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=1a1f913#1a1f913e88101dbd6f98cc2468be0f0d1b87960b"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1464,7 +1464,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 [[package]]
 name = "union-find"
 version = "0.1.0"
-source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=1a1f913#1a1f913e88101dbd6f98cc2468be0f0d1b87960b"
+source = "git+https://github.com/egraphs-good/egglog-backend.git?rev=cd51d04#cd51d048f9ef8e0bd9eac2966c35e054ac5c8368"
 dependencies = [
  "concurrency",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,9 @@ dyn-clone = "1.0.17"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
-core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "1a1f913" }
-egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "1a1f913" }
-numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "1a1f913" }
+core-relations = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "cd51d04" }
+egglog-bridge = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "cd51d04" }
+numeric-id = { git = "https://github.com/egraphs-good/egglog-backend.git", rev = "cd51d04" }
 
 [build-dependencies]
 chrono = { version = "0.4", default-features = false, features = ["now"], optional = true }

--- a/src/core.rs
+++ b/src/core.rs
@@ -116,6 +116,27 @@ impl Display for ResolvedCall {
     }
 }
 
+/// A trait encapsulating the ability to query a [`TypeInfo`] to determine
+/// whether or not a symbol is bound as a function in the current egglog program.
+pub trait IsFunc {
+    fn is_func(&self, type_info: &TypeInfo) -> bool;
+}
+
+impl IsFunc for ResolvedCall {
+    fn is_func(&self, type_info: &TypeInfo) -> bool {
+        match self {
+            ResolvedCall::Func(func) => type_info.get_func_type(&func.name).is_some(),
+            ResolvedCall::Primitive(_) => false,
+        }
+    }
+}
+
+impl IsFunc for String {
+    fn is_func(&self, type_info: &TypeInfo) -> bool {
+        type_info.get_func_type(self).is_some()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum GenericAtomTerm<Leaf> {
     Var(Span, Leaf),
@@ -456,7 +477,7 @@ where
 #[allow(clippy::type_complexity)]
 impl<Head, Leaf> GenericActions<Head, Leaf>
 where
-    Head: Clone + Display,
+    Head: Clone + Display + IsFunc,
     Leaf: Clone + PartialEq + Eq + Display + Hash,
 {
     pub(crate) fn to_core_actions<FG: FreshGen<Head, Leaf>>(
@@ -542,18 +563,74 @@ where
                     ));
                 }
                 GenericAction::Union(span, e1, e2) => {
-                    let mapped_e1 =
-                        e1.to_core_actions(typeinfo, binding, fresh_gen, &mut norm_actions)?;
-                    let mapped_e2 =
-                        e2.to_core_actions(typeinfo, binding, fresh_gen, &mut norm_actions)?;
-                    norm_actions.push(GenericCoreAction::Union(
-                        span.clone(),
-                        mapped_e1.get_corresponding_var_or_lit(typeinfo),
-                        mapped_e2.get_corresponding_var_or_lit(typeinfo),
-                    ));
-                    mapped_actions
-                        .0
-                        .push(GenericAction::Union(span.clone(), mapped_e1, mapped_e2));
+                    match (e1, e2) {
+                        (GenericExpr::Var(..), GenericExpr::Call(_, f, args))
+                            if f.is_func(typeinfo) =>
+                        {
+                            // This is a rewrite. Rewrites from a constructor or
+                            // function to an id are much faster when we perform a
+                            // `set` directly.
+                            let head = f;
+                            let expr = e1;
+
+                            let mut mapped_args = vec![];
+                            for arg in args {
+                                let mapped_arg = arg.to_core_actions(
+                                    typeinfo,
+                                    binding,
+                                    fresh_gen,
+                                    &mut norm_actions,
+                                )?;
+                                mapped_args.push(mapped_arg);
+                            }
+                            let mapped_expr = expr.to_core_actions(
+                                typeinfo,
+                                binding,
+                                fresh_gen,
+                                &mut norm_actions,
+                            )?;
+                            norm_actions.push(GenericCoreAction::Set(
+                                span.clone(),
+                                head.clone(),
+                                mapped_args
+                                    .iter()
+                                    .map(|e| e.get_corresponding_var_or_lit(typeinfo))
+                                    .collect(),
+                                mapped_expr.get_corresponding_var_or_lit(typeinfo),
+                            ));
+                            let v = fresh_gen.fresh(head);
+                            mapped_actions.0.push(GenericAction::Set(
+                                span.clone(),
+                                CorrespondingVar::new(head.clone(), v),
+                                mapped_args,
+                                mapped_expr,
+                            ));
+                        }
+                        _ => {
+                            let mapped_e1 = e1.to_core_actions(
+                                typeinfo,
+                                binding,
+                                fresh_gen,
+                                &mut norm_actions,
+                            )?;
+                            let mapped_e2 = e2.to_core_actions(
+                                typeinfo,
+                                binding,
+                                fresh_gen,
+                                &mut norm_actions,
+                            )?;
+                            norm_actions.push(GenericCoreAction::Union(
+                                span.clone(),
+                                mapped_e1.get_corresponding_var_or_lit(typeinfo),
+                                mapped_e2.get_corresponding_var_or_lit(typeinfo),
+                            ));
+                            mapped_actions.0.push(GenericAction::Union(
+                                span.clone(),
+                                mapped_e1,
+                                mapped_e2,
+                            ));
+                        }
+                    };
                 }
                 GenericAction::Panic(span, string) => {
                     norm_actions.push(GenericCoreAction::Panic(span.clone(), string.clone()));
@@ -786,7 +863,7 @@ where
 
 impl<Head, Leaf> GenericRule<Head, Leaf>
 where
-    Head: Clone + Display,
+    Head: Clone + Display + IsFunc,
     Leaf: Clone + PartialEq + Eq + Display + Hash + Debug,
 {
     pub(crate) fn to_core_rule(

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -187,7 +187,9 @@ impl EGraph {
     /// Gets the serialized class ID for a value.
     pub fn value_to_class_id(&self, sort: &ArcSort, value: Value) -> egraph_serialize::ClassId {
         // Canonicalize the value first so that we always use the canonical e-class ID
-        let value = self.backend.get_canon_repr(value, sort.column_ty(&self.backend));
+        let value = self
+            .backend
+            .get_canon_repr(value, sort.column_ty(&self.backend));
         assert!(
             !sort.name().to_string().contains('-'),
             "Tag cannot contain '-' when serializing"

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -634,6 +634,12 @@ impl TypeInfo {
         self.func_types.get(sym)
     }
 
+    pub(crate) fn is_constructor(&self, sym: &str) -> bool {
+        self.func_types
+            .get(sym)
+            .is_some_and(|f| f.subtype == FunctionSubtype::Constructor)
+    }
+
     pub fn get_global_sort(&self, sym: &str) -> Option<&ArcSort> {
         self.global_sorts.get(sym)
     }


### PR DESCRIPTION
Desugar `rewrite`s into calls to `set` where possible. Also bump the egglog-backend version.

* This speeds a lot of stuff up as it avoids creating a new Id that needs to be rewritten later
* The PR handles the case where such a rewrite is impossible and we need to keep `union` around.
* The current implementation of proofs needs to support minting new Ids in this case anyway. We shouldn't pessimize rules run without proofs just for proofs to work.l

Fixes #350 