### PR TITLE
Fix serialized unstable function name

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -705,7 +705,7 @@ pub trait ContainerSort: Any + Send + Sync + Debug {
         _: &mut TermDag,
         _: Vec<Term>,
     ) -> Term;
-    fn serialized_name(&self, _: Value) -> &str;
+    fn serialized_name(&self, container_values: &ContainerValues, value: Value) -> String;
 
     fn to_arcsort(self) -> ArcSort
     where
@@ -759,8 +759,8 @@ impl<T: ContainerSort> Sort for ContainerSortImpl<T> {
         self.0.is_eq_container_sort()
     }
 
-    fn serialized_name(&self, value: Value) -> &str {
-        self.0.serialized_name(value)
+    fn serialized_name(&self, container_values: &ContainerValues, value: Value) -> String {
+        self.0.serialized_name(container_values, value)
     }
 
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -187,7 +187,9 @@ impl EGraph {
     /// Gets the serialized class ID for a value.
     pub fn value_to_class_id(&self, sort: &ArcSort, value: Value) -> egraph_serialize::ClassId {
         // Canonicalize the value first so that we always use the canonical e-class ID
-        let value = self.backend.get_canon_repr(value, sort.column_ty(&self.backend));
+        let value = self
+            .backend
+            .get_canon_repr(value, sort.column_ty(&self.backend));
         assert!(
             !sort.name().to_string().contains('-'),
             "Tag cannot contain '-' when serializing"
@@ -290,9 +292,10 @@ impl EGraph {
             let node_id = self.to_node_id(Some(sort), SerializedNode::Primitive(value));
             // Add node for value
             {
+                let container_values = self.backend.container_values();
                 // Children will be empty unless this is a container sort
                 let children: Vec<egraph_serialize::NodeId> = sort
-                    .inner_values(self.backend.container_values(), value)
+                    .inner_values(container_values, value)
                     .into_iter()
                     .map(|(s, v)| {
                         self.serialize_value(serializer, &s, v, &self.value_to_class_id(&s, v))
@@ -300,7 +303,7 @@ impl EGraph {
                     .collect();
                 // If this is a container sort, use the name, otherwise use the value
                 let op = if sort.is_container_sort() {
-                    sort.serialized_name(value).to_string()
+                    sort.serialized_name(container_values, value)
                 } else {
                     let primitive_id = self
                         .backend

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -134,11 +134,11 @@ impl Sort for FunctionSort {
         self.inputs.iter().any(|s| s.is_eq_sort())
     }
 
-    fn serialized_name(&self, _value: Value) -> &str {
-        // TODO: The old implementation looks up the function name contained in the function structure.
-        // In the new backend, this requires a handle to the new backend to get the container value.
-        // We can change the interface of `serialized_name` to take an `EGraph` in a follow-up PR.
-        "unstable-fn"
+    fn serialized_name(&self, container_values: &ContainerValues, value: Value) -> String {
+        let val = container_values
+            .get_val::<FunctionContainer>(value)
+            .unwrap();
+        val.2.clone()
     }
 
     fn inner_sorts(&self) -> Vec<ArcSort> {

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -183,7 +183,7 @@ impl ContainerSort for MapSort {
         term
     }
 
-    fn serialized_name(&self, _: Value) -> &str {
-        self.name()
+    fn serialized_name(&self, _container_values: &ContainerValues, _: Value) -> String {
+        self.name().to_owned()
     }
 }

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -82,8 +82,8 @@ pub trait Sort: Any + Send + Sync + Debug {
     /// Return the serialized name of the sort
     ///
     /// Only used for container sorts, which cannot be serialized with make_expr so need an explicit name
-    fn serialized_name(&self, _value: Value) -> &str {
-        self.name()
+    fn serialized_name(&self, _container_values: &ContainerValues, _value: Value) -> String {
+        self.name().to_owned()
     }
 
     /// Return the inner values and sorts.

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -157,8 +157,8 @@ impl ContainerSort for MultiSetSort {
         termdag.app("multiset-of".into(), element_terms)
     }
 
-    fn serialized_name(&self, _value: Value) -> &str {
-        "multiset-of"
+    fn serialized_name(&self, _container_values: &ContainerValues, _: Value) -> String {
+        "multiset-of".to_owned()
     }
 }
 

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -150,7 +150,7 @@ impl ContainerSort for SetSort {
         termdag.app("set-of".into(), element_terms)
     }
 
-    fn serialized_name(&self, _value: Value) -> &str {
-        "set-of"
+    fn serialized_name(&self, _container_values: &ContainerValues, _: Value) -> String {
+        "set-of".to_owned()
     }
 }

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -153,8 +153,8 @@ impl ContainerSort for VecSort {
         }
     }
 
-    fn serialized_name(&self, _value: Value) -> &str {
-        "vec-of"
+    fn serialized_name(&self, _container_values: &ContainerValues, _: Value) -> String {
+        "vec-of".to_owned()
     }
 }
 


### PR DESCRIPTION
Fixes a TODO to use output the name of the function when serializing it, so that it comes up in the visualizer for example. Otherwise, in the visualizer there is no way to see what function is referenced.


