### PR TITLE
Don't panic when extracting non existent term

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -978,9 +978,12 @@ impl EGraph {
         );
 
         let id = translator.build();
-        let _ = self.backend.run_rules(&[id]).unwrap();
+        let rule_result = self.backend.run_rules(&[id]);
         self.backend.free_rule(id);
         self.backend.free_external_func(ext_id);
+        let _ = rule_result.map_err(|e| {
+            Error::BackendError(format!("Failed to evaluate expression '{}': {}", expr, e))
+        })?;
 
         let result = result.lock().unwrap().unwrap();
         Ok(result)

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -187,7 +187,9 @@ impl EGraph {
     /// Gets the serialized class ID for a value.
     pub fn value_to_class_id(&self, sort: &ArcSort, value: Value) -> egraph_serialize::ClassId {
         // Canonicalize the value first so that we always use the canonical e-class ID
-        let value = self.backend.get_canon_repr(value, sort.column_ty(&self.backend));
+        let value = self
+            .backend
+            .get_canon_repr(value, sort.column_ty(&self.backend));
         assert!(
             !sort.name().to_string().contains('-'),
             "Tag cannot contain '-' when serializing"


### PR DESCRIPTION
This PR changes the behavior of extract when it is a primitive sort and it does not exist, so that it does not panic but raises an error instead.

This was the previous behavior on the old backend and it was relied on by the Python bindings. They used this fact to try extracting a term, and only if it doesn't exist, then run some rules to create it (https://github.com/egraphs-good/egglog-python/blob/b8be0848e22137396f31f86a73c447f4997f68fe/python/egglog/exp/array_api.py#L1973-L1985).

The alterantive of using `check` and then extracting is slower especially when the terms are large. Currently, it will panic and catching a panic in Rust and then continuing is not ideal. This PR handles a cleanup as well even if the rule doesn't succeed.