### PR TITLE
Tidy up documentation and improve naming consistency after backend refactoring

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -908,6 +908,7 @@ impl Schema {
 }
 
 impl FunctionDecl {
+    /// Constructs a `function`
     pub fn function(
         span: Span,
         name: String,
@@ -926,6 +927,7 @@ impl FunctionDecl {
         }
     }
 
+    /// Constructs a `constructor`
     pub fn constructor(
         span: Span,
         name: String,
@@ -945,6 +947,7 @@ impl FunctionDecl {
         }
     }
 
+    /// Constructs a `relation`
     pub fn relation(span: Span, name: String, input: Vec<String>) -> Self {
         Self {
             name,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,10 @@ pub mod bin {
         no_messages: bool,
     }
 
+    /// Start a command-line interface for the E-graph.
+    ///
+    /// This is what vanilla egglog uses, and custom egglog builds (i.e., "egglog batteries included")
+    /// should also call this function.
     #[allow(clippy::disallowed_macros)]
     pub fn cli(mut egraph: EGraph) {
         env_logger::Builder::new()
@@ -144,10 +148,12 @@ pub mod bin {
 }
 
 impl EGraph {
+    /// Start a Read-Eval-Print Loop with standard I/O.
     pub fn repl(&mut self) -> io::Result<()> {
         self.repl_with(io::stdin(), io::stdout())
     }
 
+    /// Start a Read-Eval-Print Loop with the given input and output channel.
     pub fn repl_with<R, W>(&mut self, input: R, mut output: W) -> io::Result<()>
     where
         R: Read,

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -293,6 +293,7 @@ pub enum ConstraintError<Var, Value> {
 }
 
 impl ConstraintError<AtomTerm, ArcSort> {
+    /// Converts a [`ConstraintError`] produced by type checking into a type error.
     pub fn to_type_error(&self) -> TypeError {
         match &self {
             ConstraintError::InconsistentConstraint(x, v1, v2) => TypeError::Mismatch {
@@ -326,6 +327,7 @@ impl ConstraintError<AtomTerm, ArcSort> {
     }
 }
 
+/// Represents a constraint-solving problem
 pub struct Problem<Var, Value> {
     pub constraints: Vec<Box<dyn Constraint<Var, Value>>>,
     pub range: HashSet<Var>,
@@ -364,10 +366,12 @@ where
     Var: Hash + cmp::Eq + PartialEq + Clone,
     Value: Clone,
 {
+    /// Insert into the assignment.
     pub fn insert(&mut self, var: Var, value: Value) -> Option<Value> {
         self.0.insert(var, value)
     }
 
+    /// Get the value from the assignment.
     pub fn get(&self, var: &Var) -> Option<&Value> {
         self.0.get(var)
     }
@@ -602,7 +606,7 @@ impl Problem<AtomTerm, ArcSort> {
         Ok(())
     }
 
-    pub fn add_actions(
+    pub(crate) fn add_actions(
         &mut self,
         actions: &GenericCoreActions<String, String>,
         typeinfo: &TypeInfo,
@@ -711,7 +715,7 @@ impl CoreAction {
 }
 
 impl Atom<StringOrEq> {
-    pub fn get_constraints(
+    pub(crate) fn get_constraints(
         &self,
         type_info: &TypeInfo,
     ) -> Result<Vec<Box<dyn Constraint<AtomTerm, ArcSort>>>, TypeError> {
@@ -837,11 +841,13 @@ pub struct SimpleTypeConstraint {
 }
 
 impl SimpleTypeConstraint {
+    /// Constructs a `SimpleTypeConstraint`
     pub fn new(name: &str, sorts: Vec<ArcSort>, span: Span) -> SimpleTypeConstraint {
         let name = name.to_owned();
         SimpleTypeConstraint { name, sorts, span }
     }
 
+    /// Converts self to a boxed type constraint.
     pub fn into_box(self) -> Box<dyn TypeConstraint> {
         Box::new(self)
     }
@@ -875,7 +881,7 @@ impl TypeConstraint for SimpleTypeConstraint {
     }
 }
 
-/// This constraint requires all types to be equivalent to each other
+/// This constraint requires all types to be equivalent to each other.
 pub struct AllEqualTypeConstraint {
     name: String,
     sort: Option<ArcSort>,
@@ -885,6 +891,7 @@ pub struct AllEqualTypeConstraint {
 }
 
 impl AllEqualTypeConstraint {
+    /// Creates the `AllEqualTypeConstraint`.
     pub fn new(name: &str, span: Span) -> AllEqualTypeConstraint {
         AllEqualTypeConstraint {
             name: name.to_owned(),
@@ -895,6 +902,7 @@ impl AllEqualTypeConstraint {
         }
     }
 
+    /// Converts self into a boxed type constraint.
     pub fn into_box(self) -> Box<dyn TypeConstraint> {
         Box::new(self)
     }

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -23,16 +23,22 @@ pub enum ImpossibleConstraint {
     },
 }
 
+/// A constraint that can be applied to variable assignments during solving.
 pub trait Constraint<Var, Value> {
+    /// Updates the assignment based on this constraint.
+    ///
+    /// Returns `true` if the assignment was modified, `false` otherwise.
     fn update(
         &self,
         assignment: &mut Assignment<Var, Value>,
         key: fn(&Value) -> &str,
     ) -> Result<bool, ConstraintError<Var, Value>>;
 
+    /// Returns a human-readable representation of this constraint.
     fn pretty(&self) -> String;
 }
 
+/// Creates an equality constraint between two variables.
 pub fn eq<Var, Value>(x: Var, y: Var) -> Box<dyn Constraint<Var, Value>>
 where
     Var: cmp::Eq + PartialEq + Hash + Clone + Debug + 'static,
@@ -41,6 +47,7 @@ where
     Box::new(Eq(x, y))
 }
 
+/// Creates an assignment constraint that binds a variable to a value.
 pub fn assign<Var, Value>(x: Var, v: Value) -> Box<dyn Constraint<Var, Value>>
 where
     Var: cmp::Eq + PartialEq + Hash + Clone + Debug + 'static,
@@ -49,6 +56,7 @@ where
     Box::new(Assign(x, v))
 }
 
+/// Creates a conjunction constraint that requires all sub-constraints to hold.
 pub fn and<Var, Value>(cs: Vec<Box<dyn Constraint<Var, Value>>>) -> Box<dyn Constraint<Var, Value>>
 where
     Var: cmp::Eq + PartialEq + Hash + Clone + Debug + 'static,
@@ -57,6 +65,7 @@ where
     Box::new(And(cs))
 }
 
+/// Creates an exclusive-or constraint where exactly one sub-constraint must hold.
 pub fn xor<Var, Value>(cs: Vec<Box<dyn Constraint<Var, Value>>>) -> Box<dyn Constraint<Var, Value>>
 where
     Var: cmp::Eq + PartialEq + Hash + Clone + Debug + 'static,
@@ -65,6 +74,7 @@ where
     Box::new(Xor(cs))
 }
 
+/// Creates a constraint that always fails with the given impossible constraint.
 pub fn impossible<Var, Value>(constraint: ImpossibleConstraint) -> Box<dyn Constraint<Var, Value>>
 where
     Var: cmp::Eq + PartialEq + Hash + Clone + Debug + 'static,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -3,24 +3,26 @@ use crate::util::{HashMap, HashSet};
 use crate::*;
 use std::collections::VecDeque;
 
-/// An interface for custom cost model
-/// To use it with the default extractor, the cost type must also satisify Ord + Eq + Copy + Debug
-/// Additionally, the model should guarantee a term has a no-smaller cost
+/// An interface for custom cost model.
+///
+/// To use it with the default extractor, the cost type must also satisify `Ord + Eq + Copy + Debug`.
+/// Additionally, the cost model should guarantee that a term has a no-smaller cost
 /// than its subterms to avoid cycles in the extracted terms for common case usages.
 /// For more niche usages, a term can have a cost less than its subterms.
 /// As long as there is no negative cost cycle,
 /// the default extractor is guaranteed to terminate in computing the costs.
 /// However, the user needs to be careful to guarantee acyclicity in the extracted terms.
 pub trait CostModel<C: Cost> {
-    /// Compute the total cost of a term given the cost of the root enode and its immediate children's total costs
+    /// The total cost of a term given the cost of the root e-node and its immediate children's total costs.
     fn fold(&self, head: &str, children_cost: &[C], head_cost: C) -> C;
 
-    /// Compute the cost of just a enode by itself, without taking its children into account
+    /// The cost of an enode (without the cost of children)
     fn enode_cost(&self, egraph: &EGraph, func: &Function, row: &egglog_bridge::FunctionRow) -> C;
 
-    /// Compute the cost of a container value given the costs of its elements
+    /// The cost of a container value given the costs of its elements.
+    ///
     /// The default cost for containers is just the sum of all the elements inside
-    fn container_primitive(
+    fn container_cost(
         &self,
         egraph: &EGraph,
         sort: &ArcSort,
@@ -35,9 +37,10 @@ pub trait CostModel<C: Cost> {
             .fold(C::identity(), |s, c| s.combine(c))
     }
 
-    /// Compute the cost of a primitive, non-container, value
-    /// The default cost for leaf primitives is the constant one
-    fn leaf_primitive(&self, egraph: &EGraph, sort: &ArcSort, value: Value) -> C {
+    /// Compute the cost of a (non-container) primitive value.
+    ///
+    /// The default cost for base values is the constant one
+    fn base_value_cost(&self, egraph: &EGraph, sort: &ArcSort, value: Value) -> C {
         let _egraph = egraph;
         let _sort = sort;
         let _value = value;
@@ -95,6 +98,7 @@ cost_impl_num!(f32, f64, OrderedFloat<f32>, OrderedFloat<f64>);
 
 pub type DefaultCost = usize;
 
+/// A cost model that computes the cost by summing the cost of each node.
 #[derive(Default, Clone)]
 pub struct TreeAdditiveCostModel {}
 
@@ -118,6 +122,7 @@ impl CostModel<DefaultCost> for TreeAdditiveCostModel {
     }
 }
 
+/// The default, Bellman-Ford like extractor. This extractor is optimal for [`CostModel`].
 pub struct Extractor<C: Cost + Ord + Eq + Copy + Debug> {
     rootsorts: Vec<ArcSort>,
     funcs: Vec<String>,
@@ -133,7 +138,8 @@ impl<C: Cost + Ord + Eq + Copy + Debug> Extractor<C> {
     /// The later extractions only reuses saved results.
     /// This means a new extractor must be created if the egraph changes.
     /// Holding a reference to the egraph would enforce this but prevents the extractor being reused.
-    /// For convenience, if the rootsorts is None, it defaults to extract all extractable rootsorts.
+    ///
+    /// For convenience, if the rootsorts is `None`, it defaults to extract all extractable rootsorts.
     pub fn compute_costs_from_rootsorts(
         rootsorts: Option<Vec<ArcSort>>,
         egraph: &EGraph,
@@ -248,7 +254,7 @@ impl<C: Cost + Ord + Eq + Copy + Debug> Extractor<C> {
             }
             Some(
                 self.cost_model
-                    .container_primitive(egraph, sort, value, &ch_costs),
+                    .container_cost(egraph, sort, value, &ch_costs),
             )
         } else if sort.is_eq_sort() {
             if self
@@ -262,11 +268,11 @@ impl<C: Cost + Ord + Eq + Copy + Debug> Extractor<C> {
             }
         } else {
             // Primitive
-            Some(self.cost_model.leaf_primitive(egraph, sort, value))
+            Some(self.cost_model.base_value_cost(egraph, sort, value))
         }
     }
 
-    /// A row in a [constructor] table is an hyperedge from the set of input terms to the constructed output term.
+    /// A row in a constructor table is a hyperedge from the set of input terms to the constructed output term.
     fn compute_cost_hyperedge(
         &self,
         egraph: &EGraph,
@@ -491,8 +497,10 @@ impl<C: Cost + Ord + Eq + Copy + Debug> Extractor<C> {
         term
     }
 
-    /// This expects the sort to be already computed
-    /// can be one of the rootsorts, or reachable from rootsorts, or primitives, or containers of computed sorts
+    /// Extract the best term of a value from a given sort.
+    ///
+    /// This function expects the sort to be already computed,
+    /// which can be one of the rootsorts, or reachable from rootsorts, or primitives, or containers of computed sorts.
     pub fn extract_best_with_sort(
         &self,
         egraph: &EGraph,
@@ -515,7 +523,9 @@ impl<C: Cost + Ord + Eq + Copy + Debug> Extractor<C> {
         }
     }
 
-    /// This expects the value to be of the single sort the extractor has been initialized with
+    /// A convenience method for extraction.
+    ///
+    /// This expects the value to be of the unique sort the extractor has been initialized with
     pub fn extract_best(
         &self,
         egraph: &EGraph,
@@ -534,7 +544,10 @@ impl<C: Cost + Ord + Eq + Copy + Debug> Extractor<C> {
         )
     }
 
-    /// This extract variants by selecting nvairants enodes with the lowest cost from the root eclass.
+    /// Extract variants of an e-class.
+    ///
+    /// The variants are selected by first picking `nvairants` e-nodes with the lowest cost from the e-class
+    /// and then extracting a term from each e-node.
     pub fn extract_variants_with_sort(
         &self,
         egraph: &EGraph,
@@ -605,7 +618,9 @@ impl<C: Cost + Ord + Eq + Copy + Debug> Extractor<C> {
         }
     }
 
-    /// This expects the value to be of the single sort the extractor has been initialized with
+    /// A convenience method for extracting variants of a value.
+    ///
+    /// This expects the value to be of the unique sort the extractor has been initialized with.
     pub fn extract_variants(
         &self,
         egraph: &EGraph,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,11 +61,20 @@ use web_time::Duration;
 
 pub type ArcSort = Arc<dyn Sort>;
 
+/// A trait for implementing custom primitive operations in egglog.
+///
+/// Primitives are built-in functions that can be called in both rule queries and actions.
 pub trait Primitive {
+    /// Returns the name of this primitive operation.
     fn name(&self) -> &str;
+
     /// Constructs a type constraint for the primitive that uses the span information
     /// for error localization.
     fn get_type_constraints(&self, span: &Span) -> Box<dyn TypeConstraint>;
+
+    /// Applies the primitive operation to the given arguments.
+    ///
+    /// Returns `Some(value)` if the operation succeeds, or `None` if it fails.
     fn apply(&self, exec_state: &mut ExecutionState, args: &[Value]) -> Option<Value>;
 }
 
@@ -178,6 +187,7 @@ impl RunReport {
         }
     }
 
+    /// Merge two reports.
     pub fn union(&mut self, other: Self) {
         self.updated |= other.updated;
         RunReport::union_times(
@@ -245,6 +255,19 @@ impl FromStr for RunMode {
     }
 }
 
+/// The main interface for an e-graph in egglog.
+///
+/// An [`EGraph`] maintains a collection of equivalence classes of terms and provides
+/// operations for adding facts, running rules, and extracting optimal terms.
+///
+/// # Examples
+///
+/// ```
+/// use egglog::*;
+///
+/// let mut egraph = EGraph::default();
+/// egraph.parse_and_run_program("(datatype Math (Num i64) (Add Math Math))").unwrap();
+/// ```
 #[derive(Clone)]
 pub struct EGraph {
     backend: egglog_bridge::EGraph,
@@ -317,6 +340,7 @@ pub struct ResolvedSchema {
 }
 
 impl ResolvedSchema {
+    /// Get the type at position `index`, counting the `output` sort as at position `input.len()`.
     pub fn get_by_pos(&self, index: usize) -> Option<&ArcSort> {
         if self.input.len() == index {
             Some(&self.output)
@@ -357,13 +381,13 @@ impl Default for EGraph {
             commands: Default::default(),
         };
 
-        add_leaf_sort(&mut eg, UnitSort, span!()).unwrap();
-        add_leaf_sort(&mut eg, StringSort, span!()).unwrap();
-        add_leaf_sort(&mut eg, BoolSort, span!()).unwrap();
-        add_leaf_sort(&mut eg, I64Sort, span!()).unwrap();
-        add_leaf_sort(&mut eg, F64Sort, span!()).unwrap();
-        add_leaf_sort(&mut eg, BigIntSort, span!()).unwrap();
-        add_leaf_sort(&mut eg, BigRatSort, span!()).unwrap();
+        add_base_sort(&mut eg, UnitSort, span!()).unwrap();
+        add_base_sort(&mut eg, StringSort, span!()).unwrap();
+        add_base_sort(&mut eg, BoolSort, span!()).unwrap();
+        add_base_sort(&mut eg, I64Sort, span!()).unwrap();
+        add_base_sort(&mut eg, F64Sort, span!()).unwrap();
+        add_base_sort(&mut eg, BigIntSort, span!()).unwrap();
+        add_base_sort(&mut eg, BigRatSort, span!()).unwrap();
         eg.type_info.add_presort::<MapSort>(span!()).unwrap();
         eg.type_info.add_presort::<SetSort>(span!()).unwrap();
         eg.type_info.add_presort::<VecSort>(span!()).unwrap();
@@ -395,6 +419,7 @@ impl Default for EGraph {
 pub struct NotFoundError(String);
 
 impl EGraph {
+    /// Add a user-defined command to the e-graph
     pub fn add_command(
         &mut self,
         name: String,
@@ -411,10 +436,17 @@ impl EGraph {
         Ok(())
     }
 
+    /// Test if the e-graph operates in interactive mode.
+    ///
+    /// In interactive mode, `(done)` will be printed after every successful command.
+    /// Otherwise, `(error)` will be printed.
     pub fn is_interactive_mode(&self) -> bool {
         self.interactive_mode
     }
 
+    /// Push a snapshot of the e-graph into the stack.
+    ///
+    /// See [`EGraph::pop`].
     pub fn push(&mut self) {
         let prev_prev: Option<Box<Self>> = self.pushed_egraph.take();
         let mut prev = self.clone();
@@ -631,8 +663,20 @@ impl EGraph {
         Ok((inputs, output, termdag))
     }
 
-    pub fn print_function(&mut self, sym: &str, n: usize) -> Result<(), Error> {
-        log::info!("Printing up to {n} tuples of table {sym}: ");
+    /// Print up to `n` the tuples in a given function.
+    /// Print all tuples if `n` is not provided.
+    pub fn print_function(&mut self, sym: &str, n: Option<usize>) -> Result<(), Error> {
+        let n = match n {
+            Some(n) => {
+                log::info!("Printing up to {n} tuples of function {sym}: ");
+                n
+            }
+            None => {
+                log::info!("Printing all tuples of function {sym}: ");
+                usize::MAX
+            }
+        };
+
         let (terms, outputs, termdag) = self.function_to_dag(sym, n, true)?;
         let f = self
             .functions
@@ -666,6 +710,8 @@ impl EGraph {
         Ok(())
     }
 
+    /// Print the size of a function. If no function name is provided,
+    /// print the size of all functions in "name: len" pairs.
     pub fn print_size(&mut self, sym: Option<&str>) -> Result<(), Error> {
         if let Some(sym) = sym {
             let f = self
@@ -800,6 +846,10 @@ impl EGraph {
         report
     }
 
+    /// Runs a ruleset for an iteration.
+    ///
+    /// This applies every match it finds (under semi-naive).
+    /// See [`EGraph::step_rules_with_scheduler`] for more fine-grained control.
     pub fn step_rules(&mut self, ruleset: &str) -> RunReport {
         fn collect_rule_ids(
             ruleset: &str,
@@ -915,6 +965,7 @@ impl EGraph {
         }
     }
 
+    /// Evaluates an expression, returns the sort of the expression and the evaluation result.
     pub fn eval_expr(&mut self, expr: &Expr) -> Result<(ArcSort, Value), Error> {
         let span = expr.span();
         let command = Command::Action(Action::Expr(span.clone(), expr.clone()));
@@ -1195,7 +1246,7 @@ impl EGraph {
                 log::info!("Popped {n} levels.")
             }
             ResolvedNCommand::PrintTable(span, f, n) => {
-                self.print_function(&f, n).map_err(|e| match e {
+                self.print_function(&f, Some(n)).map_err(|e| match e {
                     Error::TypeError(TypeError::UnboundFunction(f, _)) => {
                         Error::TypeError(TypeError::UnboundFunction(f, span.clone()))
                     }
@@ -1458,6 +1509,8 @@ impl EGraph {
         self.run_program(parsed)
     }
 
+    /// Get the number of tuples in the database.
+    ///
     pub fn num_tuples(&self) -> usize {
         self.functions
             .values()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ impl FromStr for RunMode {
 /// use egglog::*;
 ///
 /// let mut egraph = EGraph::default();
-/// egraph.parse_and_run_program("(datatype Math (Num i64) (Add Math Math))").unwrap();
+/// egraph.parse_and_run_program(None, "(datatype Math (Num i64) (Add Math Math))").unwrap();
 /// ```
 #[derive(Clone)]
 pub struct EGraph {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,30 +18,37 @@ pub use egglog::{span, EGraph};
 pub mod exprs {
     use super::*;
 
+    /// Creates a variable expression.
     pub fn var(name: &str) -> Expr {
         Expr::Var(span!(), name.to_owned())
     }
 
+    /// Creates an integer literal expression.
     pub fn int(value: i64) -> Expr {
         Expr::Lit(span!(), Literal::Int(value))
     }
 
+    /// Creates a float literal expression.
     pub fn float(value: f64) -> Expr {
         Expr::Lit(span!(), Literal::Float(value.into()))
     }
 
+    /// Creates a string literal expression.
     pub fn string(value: &str) -> Expr {
         Expr::Lit(span!(), Literal::String(value.to_owned()))
     }
 
+    /// Creates a unit literal expression.
     pub fn unit() -> Expr {
         Expr::Lit(span!(), Literal::Unit)
     }
 
+    /// Creates a boolean literal expression.
     pub fn bool(value: bool) -> Expr {
         Expr::Lit(span!(), Literal::Bool(value))
     }
 
+    /// Creates a function call expression.
     pub fn call(f: &str, xs: Vec<Expr>) -> Expr {
         Expr::Call(span!(), f.to_owned(), xs)
     }
@@ -629,7 +636,7 @@ macro_rules! datatype {
 /// A "default" implementation of [`Sort`] for simple types
 /// which just want to put some data in the e-graph. If you
 /// implement this trait, do not implement `Sort` or
-/// `ContainerSort. Use `add_leaf_sort` to register leaf
+/// `ContainerSort. Use `add_base_sort` to register leaf
 /// sorts with the `EGraph`. See `Sort` for documentation
 /// of the methods. Do not override `to_arcsort`.
 pub trait BaseSort: Any + Send + Sync + Debug {
@@ -779,12 +786,13 @@ impl<T: ContainerSort> Sort for ContainerSortImpl<T> {
     }
 }
 
-pub fn add_leaf_sort(
+/// Add a [`BaseSort`] to the e-graph
+pub fn add_base_sort(
     egraph: &mut EGraph,
-    leaf_sort: impl BaseSort,
+    base_sort: impl BaseSort,
     span: Span,
 ) -> Result<(), TypeError> {
-    egraph.add_sort(BaseSortImpl(leaf_sort), span)
+    egraph.add_sort(BaseSortImpl(base_sort), span)
 }
 
 pub fn add_container_sort(

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -636,7 +636,7 @@ macro_rules! datatype {
 /// A "default" implementation of [`Sort`] for simple types
 /// which just want to put some data in the e-graph. If you
 /// implement this trait, do not implement `Sort` or
-/// `ContainerSort. Use `add_base_sort` to register leaf
+/// `ContainerSort. Use `add_base_sort` to register base
 /// sorts with the `EGraph`. See `Sort` for documentation
 /// of the methods. Do not override `to_arcsort`.
 pub trait BaseSort: Any + Send + Sync + Debug {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -158,11 +158,12 @@ impl EGraph {
         })
     }
 
+    /// Removes a scheduler
     pub fn remove_scheduler(&mut self, scheduler_id: SchedulerId) -> Option<Box<dyn Scheduler>> {
         self.schedulers.take(scheduler_id).map(|r| r.scheduler)
     }
 
-    /// Get the scheduler by its id.
+    /// Runs a ruleset for one iteration using the given ruleset
     pub fn step_rules_with_scheduler(
         &mut self,
         scheduler_id: SchedulerId,

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -44,9 +44,12 @@ pub use r#fn::*;
 mod multiset;
 pub use multiset::*;
 
+/// A sort (type) in the e-graph that defines values in egglog. Sorts are user-extensible (e.g., [`prelude::BaseSort`]).
 pub trait Sort: Any + Send + Sync + Debug {
+    /// Returns the name of this sort.
     fn name(&self) -> &str;
 
+    /// Returns the backend-specific column type. See [`ColumnTy`].
     fn column_ty(&self, backend: &egglog_bridge::EGraph) -> ColumnTy;
 
     /// return the inner sorts if a container sort

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -58,10 +58,16 @@ pub struct TypeInfo {
 // These methods need to be on the `EGraph` in order to
 // register sorts and primitives with the backend.
 impl EGraph {
+    /// Add a user-defined sort to the e-graph.
+    ///
+    /// Also look at [`prelude::add_base_sort`] for a convenience method for adding user-defined sorts
     pub fn add_sort<S: Sort + 'static>(&mut self, sort: S, span: Span) -> Result<(), TypeError> {
         self.add_arcsort(Arc::new(sort), span)
     }
 
+    /// Declare a sort. This corresponds to the `sort` keyword in egglog.
+    /// It can either declares a new [`EqSort`] if `presort_and_args` is not provided,
+    /// or an instantiation of a presort (e.g., containers like `Vec`).
     pub fn declare_sort(
         &mut self,
         name: impl Into<String>,
@@ -87,7 +93,7 @@ impl EGraph {
         self.add_arcsort(sort, span)
     }
 
-    /// Add a user-defined sort
+    /// Add a user-defined sort to the e-graph.
     pub fn add_arcsort(&mut self, sort: ArcSort, span: Span) -> Result<(), TypeError> {
         sort.register_type(&mut self.backend);
 


### PR DESCRIPTION
This PR consists of the following:

* Add documentation to public functions
* Improve documentation for some functions, which didn't display nicely with `cargo doc`
* Be consistent about naming (`base_value` rather than `leaf`)
* Allow `print_function` to print all tuples in a function

Some of the edits are suggested by Claude Code and reviewed by me.