### PR TITLE
Speedup CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ rustc-hash = "2.1"
 thiserror = "2.0"
 web-time = "1.1"
 dyn-clone = "1.0.17"
+rayon = "1.10.0"
+mimalloc = "0.1.46"
 
 # Backend
 # TODO: move egglog-backend repo into core egglog repo
@@ -70,8 +72,6 @@ chrono = { version = "0.4", default-features = false, features = ["now"], option
 codspeed-criterion-compat = "2.7.2"
 glob = "0.3.1"
 libtest-mimic = "0.8"
-mimalloc = "0.1.46"
-rayon = "1.10.0"
 
 [profile.release]
 incremental = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,6 @@
 use crate::*;
 use std::io::{self, BufRead, BufReader, Read, Write};
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 #[cfg(feature = "bin")]
 pub mod bin {
     use super::*;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,9 @@
 use crate::*;
 use std::io::{self, BufRead, BufReader, Read, Write};
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[cfg(feature = "bin")]
 pub mod bin {
     use super::*;
@@ -49,6 +52,10 @@ pub mod bin {
 
     #[allow(clippy::disallowed_macros)]
     pub fn cli(mut egraph: EGraph) {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build_global()
+            .unwrap();
         env_logger::Builder::new()
             .filter_level(log::LevelFilter::Info)
             .format_timestamp(None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     egglog::cli(egglog::EGraph::default())
 }


### PR DESCRIPTION
Speeds up CLI by using options in benchmark mode of a custom allocator and reducing the number of threads.

Locally, this decreased the time of running `time ./target/release/egglog tests/no-messages/python_array_optimize.egg --no-messages` from about 6 seconds to 3 seconds after running `cargo build --release`.

We could add more options in the future to configure these things from public API, but for now I wanted to at least speed up performance so we can better profile things in the CLI and have it be representative. 