### PR TITLE
add parallelism flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,6 +45,11 @@ pub mod bin {
         /// Prevents egglog from printing messages
         #[clap(long)]
         no_messages: bool,
+
+        #[clap(short = 'j', long, default_value = "1")]
+        /// Number of threads to use for parallel execution. Passing `0` will use the maximum
+        /// inferred parallelism available on the current system.
+        threads: usize,
     }
 
     /// Start a command-line interface for the E-graph.
@@ -53,10 +58,6 @@ pub mod bin {
     /// should also call this function.
     #[allow(clippy::disallowed_macros)]
     pub fn cli(mut egraph: EGraph) {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build_global()
-            .unwrap();
         env_logger::Builder::new()
             .filter_level(log::LevelFilter::Info)
             .format_timestamp(None)
@@ -65,6 +66,10 @@ pub mod bin {
             .init();
 
         let args = Args::parse();
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(args.threads)
+            .build_global()
+            .unwrap();
         egraph.fact_directory.clone_from(&args.fact_directory);
         egraph.seminaive = !args.naive;
         egraph.run_mode = args.show;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,10 @@ pub mod bin {
             .num_threads(args.threads)
             .build_global()
             .unwrap();
+        log::debug!(
+            "Initialized thread pool with {} threads",
+            rayon::current_num_threads()
+        );
         egraph.fact_directory.clone_from(&args.fact_directory);
         egraph.seminaive = !args.naive;
         egraph.run_mode = args.show;


### PR DESCRIPTION
```
% time target/release/egglog  /tmp/cykjson-big.egg
[INFO ] Declared sort tree.
[INFO ] Declared function NT.
[INFO ] Declared function T.
[INFO ] Declared function getString.
[INFO ] Declared function Prod.
[INFO ] Declared function End.
[INFO ] Declared function P.
[INFO ] Declared function B.
[INFO ] Declared rule (rule ((End a s)
           (= s (getString pos)))
          ((P 1 pos a)
           (set (B 1 pos a) (T a s)))
             ).
[INFO ] Declared rule (rule ((Prod a b c)
           (P p1 s b)
           (P p2 (+ s p1) c))
          ((P (+ p1 p2) s a))
             ).
[INFO ] Declared rule (rule ((Prod a b c)
           (= f1 (B p1 s b))
           (= f2 (B p2 (+ s p1) c)))
          ((set (B (+ p1 p2) s a) (NT a f1 f2)))
             ).
[INFO ] Opening file '"./tests/cykjson_Prod.csv"'...
[INFO ] Read 17 facts into Prod from './tests/cykjson_Prod.csv'.
[INFO ] Opening file '"./tests/cykjson_End.csv"'...
[INFO ] Read 17 facts into End from './tests/cykjson_End.csv'.
[INFO ] Opening file '"./tests/cykjson_medium_token.csv"'...
[INFO ] Read 7821 facts into getString from './tests/cykjson_medium_token.csv'.
[INFO ] Ran schedule (repeat 10000 (run)).
[INFO ] Report: Rule (rule ((End a s)        (= s (getString pos)))       ((P 1 pos a)        (set (B...: search and apply 0.006s, num matches 55
    Rule (rule ((Prod a b c)        (P p1 s b)        (P p2 (+ s p1) c))       ((P (+ p1 ...: search and apply 0.744s, num matches 7702
    Rule (rule ((Prod a b c)        (= f1 (B p1 s b))        (= f2 (B p2 (+ s p1) c)))   ...: search and apply 0.819s, num matches 7702
    Ruleset : search 4.438s, merge 0.007s, rebuild 0.002s

target/release/egglog /tmp/cykjson-big.egg  4.43s user 0.02s system 99% cpu 4.464 total
% time target/release/egglog  -j8 /tmp/cykjson-big.egg
[INFO ] Declared sort tree.
[INFO ] Declared function NT.
[INFO ] Declared function T.
[INFO ] Declared function getString.
[INFO ] Declared function Prod.
[INFO ] Declared function End.
[INFO ] Declared function P.
[INFO ] Declared function B.
[INFO ] Declared rule (rule ((End a s)
           (= s (getString pos)))
          ((P 1 pos a)
           (set (B 1 pos a) (T a s)))
             ).
[INFO ] Declared rule (rule ((Prod a b c)
           (P p1 s b)
           (P p2 (+ s p1) c))
          ((P (+ p1 p2) s a))
             ).
[INFO ] Declared rule (rule ((Prod a b c)
           (= f1 (B p1 s b))
           (= f2 (B p2 (+ s p1) c)))
          ((set (B (+ p1 p2) s a) (NT a f1 f2)))
             ).
[INFO ] Opening file '"./tests/cykjson_Prod.csv"'...
[INFO ] Read 17 facts into Prod from './tests/cykjson_Prod.csv'.
[INFO ] Opening file '"./tests/cykjson_End.csv"'...
[INFO ] Read 17 facts into End from './tests/cykjson_End.csv'.
[INFO ] Opening file '"./tests/cykjson_medium_token.csv"'...
[INFO ] Read 7821 facts into getString from './tests/cykjson_medium_token.csv'.
[INFO ] Ran schedule (repeat 10000 (run)).
[INFO ] Report: Rule (rule ((End a s)        (= s (getString pos)))       ((P 1 pos a)        (set (B...: search and apply 0.007s, num matches 55
    Rule (rule ((Prod a b c)        (= f1 (B p1 s b))        (= f2 (B p2 (+ s p1) c)))   ...: search and apply 0.010s, num matches 14998
    Rule (rule ((Prod a b c)        (P p1 s b)        (P p2 (+ s p1) c))       ((P (+ p1 ...: search and apply 0.010s, num matches 14998
    Ruleset : search 0.962s, merge 0.017s, rebuild 0.014s

target/release/egglog -j8 /tmp/cykjson-big.egg  6.77s user 0.71s system 726% cpu 1.028 total
```