### PR TITLE
remove "nondeterminism" flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ bin = [
 ]
 serde = ["egraph-serialize/serde"]
 graphviz = ["egraph-serialize/graphviz"]
-nondeterministic = []
 
 [dependencies]
 add_primitive = { path = "src/sort/add_primitive" }

--- a/src/core.rs
+++ b/src/core.rs
@@ -453,11 +453,11 @@ where
             match action {
                 GenericCoreAction::Let(_span, v, _, ats) => {
                     add_from_atoms(&mut free_vars, ats);
-                    free_vars.swap_remove(v);
+                    free_vars.remove(v);
                 }
                 GenericCoreAction::LetAtomTerm(_span, v, at) => {
                     add_from_atom(&mut free_vars, at);
-                    free_vars.swap_remove(v);
+                    free_vars.remove(v);
                 }
                 GenericCoreAction::Set(_span, _, ats, at) => {
                     add_from_atoms(&mut free_vars, ats);

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,25 +7,9 @@ use crate::core::SpecializedPrimitive;
 use crate::*;
 
 pub(crate) type BuildHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
-
-/// Use an index map by default everywhere.
-/// We could fix the seed, but symbol generation is not determinisic so
-/// this doesn't fix the problem.
-#[cfg(not(feature = "nondeterministic"))]
-pub(crate) type HashMap<K, V> = indexmap::IndexMap<K, V, BuildHasher>;
-#[cfg(feature = "nondeterministic")]
 pub(crate) type HashMap<K, V> = hashbrown::HashMap<K, V, BuildHasher>;
-
-#[cfg(not(feature = "nondeterministic"))]
-pub(crate) type HashSet<K> = indexmap::IndexSet<K, BuildHasher>;
-#[cfg(feature = "nondeterministic")]
 pub(crate) type HashSet<K> = hashbrown::HashSet<K, BuildHasher>;
-
-#[cfg(feature = "nondeterministic")]
-pub(crate) type HEntry<'a, A, B, D> = hashbrown::hash_map::Entry<'a, A, B, D>;
-#[cfg(not(feature = "nondeterministic"))]
-pub(crate) type HEntry<'a, A, B> = Entry<'a, A, B>;
-
+pub(crate) type HEntry<'a, A, B> = hashbrown::hash_map::Entry<'a, A, B, BuildHasher>;
 pub type IndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasher>;
 pub type IndexSet<K> = indexmap::IndexSet<K, BuildHasher>;
 


### PR DESCRIPTION
We no longer rely on `Symbol` in the frontend, so this doesn't do anything. We _hypothesize_ that the new backend is deterministic if parallelism is disabled. 