### PR TITLE
Expose whether serialization is cut off, fixes #643

### DIFF
--- a/benches/common.rs
+++ b/benches/common.rs
@@ -16,7 +16,7 @@ pub fn run_example(filename: &str, program: &str, no_messages: bool) {
         .parse_and_run_program(Some(filename.to_owned()), program)
         .unwrap();
     // test performance of serialization as well
-    let _ = egraph.serialize(egglog::SerializeConfig::default());
+    let (_ser, _trimmed) = egraph.serialize(egglog::SerializeConfig::default());
 }
 
 pub fn benchmark_files_in_glob(c: &mut Criterion, glob: &str) {

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -16,7 +16,7 @@ pub fn run_example(filename: &str, program: &str, no_messages: bool) {
         .parse_and_run_program(Some(filename.to_owned()), program)
         .unwrap();
     // test performance of serialization as well
-    let (_ser, _trimmed) = egraph.serialize(egglog::SerializeConfig::default());
+    egraph.serialize(egglog::SerializeConfig::default());
 }
 
 pub fn benchmark_files_in_glob(c: &mut Criterion, glob: &str) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,11 +110,14 @@ pub mod bin {
                 }
 
                 if args.to_json || args.to_dot || args.to_svg {
-                    let mut serialized = egraph.serialize(SerializeConfig {
+                    let (mut serialized, trimmed_msg) = egraph.serialize(SerializeConfig {
                         max_functions: Some(args.max_functions),
                         max_calls_per_function: Some(args.max_calls_per_function),
                         ..SerializeConfig::default()
                     });
+                    if let Some(msg) = trimmed_msg.as_ref() {
+                        log::warn!("{msg}");
+                    }
                     if args.serialize_split_primitive_outputs {
                         serialized.split_classes(|id, _| egraph.from_node_id(id).is_primitive())
                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,14 +110,15 @@ pub mod bin {
                 }
 
                 if args.to_json || args.to_dot || args.to_svg {
-                    let (mut serialized, trimmed_msg) = egraph.serialize(SerializeConfig {
+                    let serialized_output = egraph.serialize(SerializeConfig {
                         max_functions: Some(args.max_functions),
                         max_calls_per_function: Some(args.max_calls_per_function),
                         ..SerializeConfig::default()
                     });
-                    if let Some(msg) = trimmed_msg.as_ref() {
-                        log::warn!("{msg}");
+                    if serialized_output.is_complete() {
+                        log::warn!("{}", serialized_output.omitted_description());
                     }
+                    let mut serialized = serialized_output.egraph;
                     if args.serialize_split_primitive_outputs {
                         serialized.split_classes(|id, _| egraph.from_node_id(id).is_primitive())
                     }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -87,49 +87,55 @@ impl EGraph {
     /// - Nodes will have consistant IDs throughout execution of e-graph (used for animating changes in the visualization)
     /// - Edges in the visualization will be well distributed (used for animating changes in the visualization)
     ///   (Note that this will be changed in `<https://github.com/egraphs-good/egglog/pull/158>` so that edges point to exact nodes instead of looking up the e-class)
-    pub fn serialize(&self, config: SerializeConfig) -> egraph_serialize::EGraph {
-        // First collect a list of all the calls we want to serialize
-        let all_calls: Vec<(
+    pub fn serialize(&self, config: SerializeConfig) -> (egraph_serialize::EGraph, Option<String>) {
+        let mut msg = String::new();
+        let max_calls_per_function = config.max_calls_per_function.unwrap_or(usize::MAX);
+        let max_functions = config.max_functions.unwrap_or(usize::MAX);
+        let mut all_calls: Vec<(
             &Function,
             Vec<Value>, // inputs
             Value,      // output
             bool,       // is subsumed
             egraph_serialize::ClassId,
             egraph_serialize::NodeId,
-        )> = self
-            .functions
-            .iter()
-            .filter(|(_, function)| !function.decl.ignore_viz)
-            .map(|(name, function)| {
-                let mut tuples = vec![];
-                self.backend.for_each_while(function.backend_id, |row| {
-                    if tuples.len() >= config.max_calls_per_function.unwrap_or(usize::MAX) {
-                        return false;
-                    }
-                    let (out, inps) = row.vals.split_last().unwrap();
-                    tuples.push((
-                        function,
-                        inps.to_vec(),
-                        *out,
-                        row.subsumed,
-                        self.value_to_class_id(&function.schema.output, *out),
-                        self.to_node_id(
-                            None,
-                            SerializedNode::Function {
-                                name: name.clone(),
-                                offset: tuples.len(),
-                            },
-                        ),
+        )> = Vec::new();
+        let mut functions_kept = 0usize;
+        for (name, function) in self.functions.iter().filter(|(_, f)| !f.decl.ignore_viz) {
+            if functions_kept >= max_functions {
+                msg.push_str(&format!("Max {} unique functions\n", functions_kept));
+                break;
+            }
+            let mut rows = 0;
+            self.backend.for_each_while(function.backend_id, |row| {
+                if rows >= max_calls_per_function {
+                    msg.push_str(&format!(
+                        "Max {} unique nodes for function {}\n",
+                        max_calls_per_function, name
                     ));
-                    true
-                });
-                tuples
-            })
-            // Filter out functions with no calls
-            .filter(|f| !f.is_empty())
-            .take(config.max_functions.unwrap_or(usize::MAX))
-            .flatten()
-            .collect();
+                    return false;
+                }
+                let (out, inps) = row.vals.split_last().unwrap();
+                all_calls.push((
+                    function,
+                    inps.to_vec(),
+                    *out,
+                    row.subsumed,
+                    self.value_to_class_id(&function.schema.output, *out),
+                    self.to_node_id(
+                        None,
+                        SerializedNode::Function {
+                            name: name.clone(),
+                            offset: rows,
+                        },
+                    ),
+                ));
+                rows += 1;
+                true
+            });
+            if rows != 0 {
+                functions_kept += 1;
+            }
+        }
 
         // Then create a mapping from each canonical e-class ID to the set of node IDs in that e-class
         // Note that this is only for e-classes, primitives have e-classes equal to their node ID
@@ -181,7 +187,8 @@ impl EGraph {
             .map(|(sort, v)| self.value_to_class_id(sort, *v))
             .collect();
 
-        serializer.result
+        let msg = if msg.is_empty() { None } else { Some(msg) };
+        (serializer.result, msg)
     }
 
     /// Gets the serialized class ID for a value.

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -102,7 +102,7 @@ impl EGraph {
         let mut functions_kept = 0usize;
         for (name, function) in self.functions.iter().filter(|(_, f)| !f.decl.ignore_viz) {
             if functions_kept >= max_functions {
-                msg.push_str(&format!("Max {} unique functions reached\n", functions_kept));
+                msg.push_str(&format!("Max {} unique functions\n", functions_kept));
                 break;
             }
             let mut rows = 0;

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -102,7 +102,7 @@ impl EGraph {
         let mut functions_kept = 0usize;
         for (name, function) in self.functions.iter().filter(|(_, f)| !f.decl.ignore_viz) {
             if functions_kept >= max_functions {
-                msg.push_str(&format!("Max {} unique functions\n", functions_kept));
+                msg.push_str(&format!("Max {} unique functions reached\n", functions_kept));
                 break;
             }
             let mut rows = 0;

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -14,6 +14,40 @@ pub struct SerializeConfig {
     pub root_eclasses: Vec<(ArcSort, Value)>,
 }
 
+/// Output of serializing an e-graph, including values that were omitted if any.
+pub struct SerializeOutput {
+    /// The serialized e-graph.
+    pub egraph: egraph_serialize::EGraph,
+    /// Functions with more calls than max_calls_per_function, so that not all values are included.
+    pub truncated_functions: Vec<String>,
+    /// Functions that were discarded from the output, because more functions were present than max_functions
+    pub discarded_functions: Vec<String>,
+}
+
+impl SerializeOutput {
+    /// Returns true if the serialization is complete and no functions were truncated or discarded.
+    pub fn is_complete(&self) -> bool {
+        self.truncated_functions.is_empty() && self.discarded_functions.is_empty()
+    }
+    /// Description of what was omitted from the e-graph
+    pub fn omitted_description(&self) -> String {
+        let mut msg = String::new();
+        if !self.discarded_functions.is_empty() {
+            msg.push_str(&format!(
+                "Omitted: {}\n",
+                self.discarded_functions.join(", ")
+            ));
+        }
+        if !self.truncated_functions.is_empty() {
+            msg.push_str(&format!(
+                "Truncated: {}\n",
+                self.truncated_functions.join(", ")
+            ));
+        }
+        msg
+    }
+}
+
 #[allow(dead_code)]
 struct Serializer {
     node_ids: NodeIDs,
@@ -87,8 +121,9 @@ impl EGraph {
     /// - Nodes will have consistant IDs throughout execution of e-graph (used for animating changes in the visualization)
     /// - Edges in the visualization will be well distributed (used for animating changes in the visualization)
     ///   (Note that this will be changed in `<https://github.com/egraphs-good/egglog/pull/158>` so that edges point to exact nodes instead of looking up the e-class)
-    pub fn serialize(&self, config: SerializeConfig) -> (egraph_serialize::EGraph, Option<String>) {
-        let mut msg = String::new();
+    pub fn serialize(&self, config: SerializeConfig) -> SerializeOutput {
+        let mut truncated_functions = Vec::new();
+        let mut discarded_functions = Vec::new();
         let max_calls_per_function = config.max_calls_per_function.unwrap_or(usize::MAX);
         let max_functions = config.max_functions.unwrap_or(usize::MAX);
         let mut all_calls: Vec<(
@@ -102,16 +137,13 @@ impl EGraph {
         let mut functions_kept = 0usize;
         for (name, function) in self.functions.iter().filter(|(_, f)| !f.decl.ignore_viz) {
             if functions_kept >= max_functions {
-                msg.push_str(&format!("Max {} unique functions\n", functions_kept));
-                break;
+                discarded_functions.push(name.clone());
+                continue;
             }
             let mut rows = 0;
             self.backend.for_each_while(function.backend_id, |row| {
                 if rows >= max_calls_per_function {
-                    msg.push_str(&format!(
-                        "Max {} unique nodes for function {}\n",
-                        max_calls_per_function, name
-                    ));
+                    truncated_functions.push(name.clone());
                     return false;
                 }
                 let (out, inps) = row.vals.split_last().unwrap();
@@ -186,9 +218,11 @@ impl EGraph {
             .iter()
             .map(|(sort, v)| self.value_to_class_id(sort, *v))
             .collect();
-
-        let msg = if msg.is_empty() { None } else { Some(msg) };
-        (serializer.result, msg)
+        SerializeOutput {
+            egraph: serializer.result,
+            truncated_functions,
+            discarded_functions,
+        }
     }
 
     /// Gets the serialized class ID for a value.

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -51,7 +51,7 @@ impl Run {
                         log::info!("  {}", msg);
                     }
                     // Test graphviz dot generation
-                    let mut serialized = egraph.serialize(SerializeConfig {
+                    let (mut serialized, _trimmed_msg) = egraph.serialize(SerializeConfig {
                         max_functions: Some(40),
                         max_calls_per_function: Some(40),
                         ..Default::default()

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -51,11 +51,13 @@ impl Run {
                         log::info!("  {}", msg);
                     }
                     // Test graphviz dot generation
-                    let (mut serialized, _trimmed_msg) = egraph.serialize(SerializeConfig {
-                        max_functions: Some(40),
-                        max_calls_per_function: Some(40),
-                        ..Default::default()
-                    });
+                    let mut serialized = egraph
+                        .serialize(SerializeConfig {
+                            max_functions: Some(40),
+                            max_calls_per_function: Some(40),
+                            ..Default::default()
+                        })
+                        .egraph;
                     serialized.to_dot();
                     // Also try splitting and inlining
                     serialized.split_classes(|id, _| egraph.from_node_id(id).is_primitive());


### PR DESCRIPTION
Implement functionality to indicate when serialization exceeds specified limits, enhancing user feedback during serialization processes. Fixes #643 