### PR TITLE
raw_add_rule_with_name API & expose dependency

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -37,14 +37,14 @@ impl<Head> HeadOrEq<Head> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SpecializedPrimitive {
+pub struct SpecializedPrimitive {
     pub(crate) primitive: PrimitiveWithId,
     pub(crate) input: Vec<ArcSort>,
     pub(crate) output: ArcSort,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum ResolvedCall {
+pub enum ResolvedCall {
     Func(FuncType),
     Primitive(SpecializedPrimitive),
 }


### PR DESCRIPTION
Currently I've built a suite of API with which you can implement constant propagation and define a DSL. Only 50 lines of code is needed! [constant_prop.rs](https://github.com/MilkBlock/eggplant/blob/main/examples/constant_prop.rs).

It depends on an unmerged API called raw_add_rule_with_name in [prelude.rs](https://github.com/MilkBlock/egglog/blob/eggplant_test_use/src/prelude.rs).

Could you please have a look and give some suggestion on which struct shouldn't I expose and which is not good?

For detailed API desgin please have a look at [intro](https://zhuanlan.zhihu.com/p/1933523964161942218).

Thank you!