### PR TITLE
Log proper function type instead of calling them all "function"

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -883,9 +883,9 @@ pub enum FunctionSubtype {
 impl Display for FunctionSubtype {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            FunctionSubtype::Constructor => write!(f, "Constructor"),
-            FunctionSubtype::Relation => write!(f, "Relation"),
-            FunctionSubtype::Custom => write!(f, "CustomFunction"),
+            FunctionSubtype::Constructor => write!(f, "constructor"),
+            FunctionSubtype::Relation => write!(f, "relation"),
+            FunctionSubtype::Custom => write!(f, "function"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1184,7 +1184,7 @@ impl EGraph {
             }
             ResolvedNCommand::Function(fdecl) => {
                 self.declare_function(&fdecl)?;
-                log::info!("Declared function {}.", fdecl.name)
+                log::info!("Declared {} {}.", fdecl.subtype, fdecl.name)
             }
             ResolvedNCommand::AddRuleset(_span, name) => {
                 self.add_ruleset(name.clone());


### PR DESCRIPTION
Closes https://github.com/egraphs-good/egglog/issues/656 by logging properly what kind of function is declared, whether its a relation, constructor, or function.

Before:

```bash
$ cargo run -- tests/subsume-relation.egg
   Compiling egglog v0.5.0 (/Users/saul/p/egg-smol)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.50s
     Running `target/debug/egglog tests/subsume-relation.egg`
[INFO ] Declared sort V.
[INFO ] Declared function A.
[INFO ] Declared function B.
[INFO ] Declared function C.
[INFO ] Declared function R.
[INFO ] Checked fact [Eq(In 9:8-25 of tests/subsume-relation.egg: (= (R (A) (B)) ()), Call(In 9:11-21 of tests/subsume-relation.egg: (R (A) (B)), Func(FuncType { name: "R", subtype: Relation, input: [EqSort { name: "V" }, EqSort { name: "V" }], output: BaseSortImpl(UnitSort) }), [Call(In 9:14-16 of tests/subsume-relation.egg: (A), Func(FuncType { name: "A", subtype: Constructor, input: [], output: EqSort { name: "V" } }), []), Call(In 9:18-20 of tests/subsume-relation.egg: (B), Func(FuncType { name: "B", subtype: Constructor, input: [], output: EqSort { name: "V" } }), [])]), Lit(In 9:23-24 of tests/subsume-relation.egg: (), Unit))].
```

After:

```bash
$ cargo run -- tests/subsume-relation.egg 
   Compiling egglog v0.5.0 (/Users/saul/p/egg-smol)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.27s
     Running `target/debug/egglog tests/subsume-relation.egg`
[INFO ] Declared sort V.
[INFO ] Declared constructor A.
[INFO ] Declared constructor B.
[INFO ] Declared constructor C.
[INFO ] Declared relation R.
[INFO ] Checked fact [Eq(In 9:8-25 of tests/subsume-relation.egg: (= (R (A) (B)) ()), Call(In 9:11-21 of tests/subsume-relation.egg: (R (A) (B)), Func(FuncType { name: "R", subtype: Relation, input: [EqSort { name: "V" }, EqSort { name: "V" }], output: BaseSortImpl(UnitSort) }), [Call(In 9:14-16 of tests/subsume-relation.egg: (A), Func(FuncType { name: "A", subtype: Constructor, input: [], output: EqSort { name: "V" } }), []), Call(In 9:18-20 of tests/subsume-relation.egg: (B), Func(FuncType { name: "B", subtype: Constructor, input: [], output: EqSort { name: "V" } }), [])]), Lit(In 9:23-24 of tests/subsume-relation.egg: (), Unit))].
```