### PR TITLE
Only install mimalloc for bin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["concurrency", "core-relations", "egglog-bridge", "numeric-id", "union-find"] 
+members = ["concurrency", "core-relations", "egglog-bridge", "numeric-id", "union-find"]
 
 [package]
 edition = "2021"
@@ -39,6 +39,7 @@ bin = [
   "dep:clap",
   "dep:env_logger",
   "dep:chrono",
+  "dep:mimalloc",
 ]
 serde = ["egraph-serialize/serde"]
 graphviz = ["egraph-serialize/graphviz"]
@@ -60,7 +61,7 @@ thiserror = "2.0"
 web-time = "1.1"
 dyn-clone = "1.0.17"
 rayon = "1.10.0"
-mimalloc = "0.1.46"
+mimalloc =  { version = "0.1.46", optional = true }
 core-relations = { path = "core-relations" }
 egglog-bridge = { path = "egglog-bridge" }
 numeric-id = { path = "numeric-id" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "bin")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
Currently building egglog is failing for the web demo because of an issues installing the mimalloc allocator (https://github.com/egraphs-good/egglog-demo/actions/runs/17182776958/job/48747498611)

I also had issues building mimalloc in CI when building one target of the Python bindings.

This PR changes mimalloc to only be a bin dependency, so its not installed when just installing the package.