### PR TITLE
Add wasm example to test building in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,3 +37,14 @@ jobs:
       - uses: CodSpeedHQ/action@v3
         with:
           run: cargo codspeed run
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+      - uses: Swatinem/rust-cache@v2
+      - run: make test
+        working-directory: wasm-example

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "egglog-webasm-test"
+version = "0.0.0"
+dependencies = [
+ "egglog",
+ "getrandom 0.2.16",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "egraph-serialize"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,8 +691,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["concurrency", "core-relations", "egglog-bridge", "numeric-id", "union-find"]
+members = ["concurrency", "core-relations", "egglog-bridge", "numeric-id", "union-find", "wasm-example"]
 
 [package]
 edition = "2024"

--- a/wasm-example/Makefile
+++ b/wasm-example/Makefile
@@ -1,0 +1,3 @@
+test:
+	wasm-pack build --target nodejs
+	node run.js

--- a/wasm-example/README.md
+++ b/wasm-example/README.md
@@ -1,0 +1,10 @@
+# Webassembly Example
+
+This package shows how to build egglog to webassembly.
+
+It is modified from the [`wasm-bindgen` docs on how to build without a bundler](https://wasm-bindgen.github.io/wasm-bindgen/examples/without-a-bundler.html).
+
+```bash
+cargo install wasm-pack
+make test
+```

--- a/wasm-example/cargo.toml
+++ b/wasm-example/cargo.toml
@@ -1,0 +1,15 @@
+[package]
+edition = "2024"
+name = "egglog-webasm-test"
+publish = false
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+# remove default features so that custom allocator isn't built that's only used for bin
+egglog = { path = "../", default-features = false }
+# enable JS support for random https://docs.rs/getrandom/latest/getrandom/#webassembly-support
+getrandom = { version = "0.2", features = ["js"] }

--- a/wasm-example/package.json
+++ b/wasm-example/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/wasm-example/run.js
+++ b/wasm-example/run.js
@@ -1,0 +1,7 @@
+import { run } from "./pkg/egglog_webasm_test.js";
+
+if (run() !== 0) {
+  throw new Error("run() should return 0");
+}
+
+console.log("Successfully ran egglog program");

--- a/wasm-example/src/lib.rs
+++ b/wasm-example/src/lib.rs
@@ -1,0 +1,10 @@
+use egglog::EGraph;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn run() -> usize {
+    EGraph::default()
+        .parse_and_run_program(None, "(datatype Math (Num i64) (Add Math Math))")
+        .unwrap()
+        .len()
+}


### PR DESCRIPTION
Previously, when we introduced a dependency on minimalloc, we didn't realize that it broke the webassmebly build. This PR adds a minimal webassembly example which builds egglog and then tests it with NodeJS. It doesnt' really run any extensive testing, just runs a few commands.