### PR TITLE
Emit prompt and debug info when running from REPL

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,6 +154,7 @@ pub mod bin {
     }
 }
 
+#[cfg(feature = "bin")]
 impl EGraph {
     /// Start a Read-Eval-Print Loop with standard I/O.
     pub fn repl(&mut self, mode: RunMode) -> io::Result<()> {
@@ -203,6 +204,7 @@ impl EGraph {
     }
 }
 
+#[cfg(feature = "bin")]
 fn welcome_prompt() -> String {
     format!("Welcome to Egglog REPL! (build: {})", env!("FULL_VERSION"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 //! We plan to have a text tutorial here soon, PRs welcome!
 //!
 pub mod ast;
+#[cfg(feature = "bin")]
 mod cli;
 pub mod constraint;
 mod core;
@@ -29,7 +30,7 @@ pub mod util;
 extern crate self as egglog;
 use ast::*;
 #[cfg(feature = "bin")]
-pub use cli::bin::*;
+pub use cli::*;
 use constraint::{Constraint, Problem, SimpleTypeConstraint, TypeConstraint};
 use core::{AtomTerm, ResolvedAtomTerm, ResolvedCall};
 pub use core_relations::{BaseValue, ContainerValue, ExecutionState, Value};


### PR DESCRIPTION
Emits a `> ` prompt and the welcome message when running from the CLI with no file inputs and no stdin piped.

Adds a test for this mode in the repl tests.

```
$ ./target/debug/egglog
Welcome to Egglog REPL! (build: 1.0.0_2025-09-10_34c2f2de)
> (extract 10)
10
> ^C⏎
$ echo '(extract 1)' | ./target/debug/egglog
1
```

Follow up of #659 now that INFO is not printed by default.