### PR TITLE
Fixes serialization of strings

### DIFF
--- a/core-relations/src/base_values/mod.rs
+++ b/core-relations/src/base_values/mod.rs
@@ -193,7 +193,7 @@ impl<P: BaseValue> BaseInternTable<P> {
 /// This type is just a helper: users can also implement the [`BaseValue`] trait directly on their
 /// types if the type is defined in the crate in which the implementation is defined, or if they
 /// need custom logic for boxing or unboxing the type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Boxed<T>(pub T);
 
 impl<T> Boxed<T> {
@@ -203,6 +203,12 @@ impl<T> Boxed<T> {
 
     pub fn into_inner(self) -> T {
         self.0
+    }
+}
+
+impl<T: Debug> Debug for Boxed<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
     }
 }
 


### PR DESCRIPTION
Previously, strings were serialized as `Box("string")` instead of just `"string"`. Closes #674

This fixes it by changing the debug for boxed values to just write out the debug of the inner value.

Tested locally on:

```
(relation hi (String))
(hi "hi")
```

```
cargo run -- tmp.egg --to-json
```