### PR TITLE
Serialize let bindings

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -889,9 +889,6 @@ where
     pub merge: Option<GenericExpr<Head, Leaf>>,
     pub cost: Option<DefaultCost>,
     pub unextractable: bool,
-    /// Globals are desugared to functions, with this flag set to true.
-    /// This is used by visualization to handle globals differently.
-    pub ignore_viz: bool,
     pub span: Span,
 }
 
@@ -949,7 +946,6 @@ impl FunctionDecl {
             merge,
             cost: None,
             unextractable: true,
-            ignore_viz: false,
             span,
         }
     }
@@ -969,7 +965,6 @@ impl FunctionDecl {
             merge: None,
             cost,
             unextractable,
-            ignore_viz: false,
             span,
         }
     }
@@ -986,7 +981,6 @@ impl FunctionDecl {
             merge: None,
             cost: None,
             unextractable: true,
-            ignore_viz: false,
             span,
         }
     }
@@ -1008,7 +1002,6 @@ where
             merge: self.merge.map(|expr| expr.visit_exprs(f)),
             cost: self.cost,
             unextractable: self.unextractable,
-            ignore_viz: self.ignore_viz,
             span: self.span,
         }
     }

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -102,7 +102,6 @@ impl GlobalRemover<'_> {
                         merge: None,
                         cost: None,
                         unextractable: true,
-                        ignore_viz: true,
                         span: span.clone(),
                     };
                     let resolved_call = ResolvedCall::Func(FuncType {

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -135,7 +135,7 @@ impl EGraph {
             egraph_serialize::NodeId,
         )> = Vec::new();
         let mut functions_kept = 0usize;
-        for (name, function) in self.functions.iter().filter(|(_, f)| !f.decl.ignore_viz) {
+        for (name, function) in self.functions.iter() {
             if functions_kept >= max_functions {
                 discarded_functions.push(name.clone());
                 continue;

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -410,7 +410,6 @@ impl TypeInfo {
             },
             cost: fdecl.cost,
             unextractable: fdecl.unextractable,
-            ignore_viz: fdecl.ignore_viz,
             span: fdecl.span.clone(),
         })
     }


### PR DESCRIPTION
This closes #376 by removing the special case where functions created by let bindings will not be serialized.

This is helpful when looking at examples/tutorial, to easily orient in the e-graph where the expressions you saved ended up.

It doesn't special case this in the visualization at all so far. For example the program `(let x 10)` would show up like:

<img width="217" height="92" alt="Screenshot 2025-09-11 at 3 43 01 PM" src="https://github.com/user-attachments/assets/935b28c7-af03-4efd-ac75-6e49a2ad3c6b" />

Previously, it would be empty.