### PR TITLE
Fixing rust compiler warning

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -82,7 +82,7 @@ impl Matches {
     }
 
     /// Get `idx`-th match.
-    pub fn get_match(&self, idx: usize) -> Match {
+    pub fn get_match(&self, idx: usize) -> Match<'_> {
         Match {
             values: &self.matches[idx * self.tuple_len()..(idx + 1) * self.tuple_len()],
             vars: &self.vars,


### PR DESCRIPTION
Whenever I build egglog, I get this warning from the rust compiler:

```
+ cargo build --manifest-path egglog/Cargo.toml --quiet
warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/scheduler.rs:85:22
   |
85 |     pub fn get_match(&self, idx: usize) -> Match {
   |                      ^^^^^                 ----- the same lifetime is hidden here
   |                      |
   |                      the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
85 |     pub fn get_match(&self, idx: usize) -> Match<'_> {
   |                                                 ++++
```
I don't really know much about rust, but this seems like something that could cause an issue somewhere down the line? It should be sort of important if the compiler is complaining about it. I've made the fix the rust compiler suggests in this PR.