### PR TITLE
Make fields public in FunctionContainer for better API access

### DIFF
--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -13,7 +13,7 @@
 use super::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct FunctionContainer(ResolvedFunctionId, Vec<(bool, Value)>, String);
+pub struct FunctionContainer(ResolvedFunctionId, pub Vec<(bool, Value)>, pub String);
 
 impl ContainerValue for FunctionContainer {
     fn rebuild_contents(&mut self, rebuilder: &dyn Rebuilder) -> bool {


### PR DESCRIPTION
Expose name and partially applied fields in FunctionContainer to align with other containers and support the `value_to_base` functionality in the Python API for custom cost models.