### PR TITLE
Fix rule report and variable ordering

### DIFF
--- a/core-relations/src/action/mask.rs
+++ b/core-relations/src/action/mask.rs
@@ -101,6 +101,10 @@ impl Mask {
     pub(super) fn clear(&mut self) {
         self.data.clear();
     }
+
+    pub(crate) fn count_ones(&self) -> usize {
+        self.data.count_ones(..)
+    }
 }
 
 pub(crate) enum IterResult<T> {

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -517,6 +517,7 @@ impl<'a> ExecutionState<'a> {
 }
 
 impl ExecutionState<'_> {
+    /// Returns the number of matches that make it to the end of the instructions
     pub(crate) fn run_instrs(&mut self, instrs: &[Instr], bindings: &mut Bindings) -> usize {
         if bindings.var_offsets.next_id().rep() == 0 {
             // If we have no variables, we want to run the rules once.

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -531,7 +531,7 @@ impl ExecutionState<'_> {
             }
             self.run_instr(&mut mask, instr, bindings);
         }
-        return mask.count_ones();
+        mask.count_ones()
     }
     fn run_instr(&mut self, mask: &mut Mask, inst: &Instr, bindings: &mut Bindings) {
         fn assert_impl(

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -517,7 +517,7 @@ impl<'a> ExecutionState<'a> {
 }
 
 impl ExecutionState<'_> {
-    pub(crate) fn run_instrs(&mut self, instrs: &[Instr], bindings: &mut Bindings) {
+    pub(crate) fn run_instrs(&mut self, instrs: &[Instr], bindings: &mut Bindings) -> usize {
         if bindings.var_offsets.next_id().rep() == 0 {
             // If we have no variables, we want to run the rules once.
             bindings.matches = 1;
@@ -527,10 +527,11 @@ impl ExecutionState<'_> {
         let mut mask = with_pool_set(|ps| Mask::new(0..bindings.matches, ps));
         for instr in instrs {
             if mask.is_empty() {
-                break;
+                return 0;
             }
             self.run_instr(&mut mask, instr, bindings);
         }
+        return mask.count_ones();
     }
     fn run_instr(&mut self, mask: &mut Mask, inst: &Instr, bindings: &mut Bindings) {
         fn assert_impl(

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -265,10 +265,19 @@ pub struct RuleSetReport {
     pub merge_time: Duration,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct RuleReport {
     pub search_and_apply_time: Duration,
     pub num_matches: usize,
+}
+
+impl RuleReport {
+    pub fn union(&self, other: &RuleReport) -> RuleReport {
+        RuleReport {
+            search_and_apply_time: self.search_and_apply_time + other.search_and_apply_time,
+            num_matches: self.num_matches + other.num_matches,
+        }
+    }
 }
 
 /// A collection of tables and indexes over them.

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -50,7 +50,10 @@ impl std::fmt::Debug for JoinHeader {
         f.debug_struct("JoinHeader")
             .field("atom", &self.atom)
             .field("constraints", &self.constraints)
-            .field("subset", &format_args!("Subset(size={})", self.subset.size()))
+            .field(
+                "subset",
+                &format_args!("Subset(size={})", self.subset.size()),
+            )
             .finish()
     }
 }

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -30,7 +30,6 @@ pub(crate) struct SingleScanSpec {
 
 /// Join headers evaluate constraints on a single atom; they prune the search space before the rest
 /// of the join plan is executed.
-#[derive(Debug)]
 pub(crate) struct JoinHeader {
     pub atom: AtomId,
     /// We currently aren't using these at all. The plan is to use this to
@@ -44,6 +43,16 @@ pub(crate) struct JoinHeader {
     /// discover common plan nodes from different queries (subsets can be
     /// large).
     pub subset: Subset,
+}
+
+impl std::fmt::Debug for JoinHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JoinHeader")
+            .field("atom", &self.atom)
+            .field("constraints", &self.constraints)
+            .field("subset", &format_args!("Subset(size={})", self.subset.size()))
+            .finish()
+    }
 }
 
 impl Clone for JoinHeader {

--- a/core-relations/src/pool/mod.rs
+++ b/core-relations/src/pool/mod.rs
@@ -10,7 +10,10 @@ use std::{
     rc::Rc,
 };
 
-use crate::numeric_id::{DenseIdMap, IdVec};
+use crate::{
+    AtomId,
+    numeric_id::{DenseIdMap, IdVec},
+};
 use fixedbitset::FixedBitSet;
 use hashbrown::HashTable;
 
@@ -435,6 +438,7 @@ pool_set! {
         shard_hist: DenseIdMap<ShardId, usize> [ 1 << 20 ],
         instr_indexes: Vec<u32> [ 1 << 20 ],
         cached_subsets: IdVec<ColumnId, std::sync::OnceLock<std::sync::Arc<ColumnIndex>>> [ 4 << 20 ],
+        intersected_on: DenseIdMap<AtomId, i64> [ 1 << 20 ],
     }
 }
 


### PR DESCRIPTION
* The same description may correspond to multiple plans.
* The number of matches should only count succeeding ones.
* This PR also recovers (and slightly improves) the variable ordering used in the old backend.