### PR TITLE
Invert condition for serialized output completeness check

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,7 +101,7 @@ pub fn cli(mut egraph: EGraph) {
                     max_calls_per_function: Some(args.max_calls_per_function),
                     ..SerializeConfig::default()
                 });
-                if serialized_output.is_complete() {
+                if !serialized_output.is_complete() {
                     log::warn!("{}", serialized_output.omitted_description());
                 }
                 let mut serialized = serialized_output.egraph;


### PR DESCRIPTION
Thanks to @ajpal for catching this bug. We should print a warning if the serialized output is not complete.