### PR TITLE
Only run bigger benchmarks in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,11 @@ jobs:
       matrix:
         runner: [codspeed-macro, ubuntu-latest]
         benchmark:
+          - math-microbenchmark
           - cykjson
           - eggcc-extraction
           - extract-vec-bench
           - herbie
-          - math-microbenchmark
           - python_array_optimize
           - repro-665-set-union
           - stresstest_large_expr


### PR DESCRIPTION
Only runs the bigger benchmarks in CI so that noise on the small ones doesn't distract on PRs.

Also now shards based on benchmark to reduce total CI time, closing #523. The total runtime until all CI tasks finished decreased roughly from 20 minutes to 9 minutes.