### PR TITLE
Add support for the `:unextractable` flag for `datatype` variants

### DIFF
--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -179,7 +179,7 @@ fn desugar_datatype(span: Span, name: String, variants: Vec<Variant>) -> Vec<NCo
                     output: name.clone(),
                 },
                 variant.cost,
-                false,
+                variant.unextractable,
             ))
         }))
         .collect()

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -885,6 +885,7 @@ pub struct Variant {
     pub name: String,
     pub types: Vec<String>,
     pub cost: Option<DefaultCost>,
+    pub unextractable: bool,
 }
 
 impl Display for Variant {

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -783,11 +783,12 @@ impl Parser {
     pub fn variant(&mut self, sexp: &Sexp) -> Result<Variant, ParseError> {
         let (name, tail, span) = sexp.expect_call("datatype variant")?;
 
-        let (types, cost) = match tail {
+        let (types, cost, unextractable) = match tail {
+            [types @ .., Sexp::Atom(o, _)] if *o == ":unextractable" => (types, None, true),
             [types @ .., Sexp::Atom(o, _), c] if *o == ":cost" => {
-                (types, Some(c.expect_uint("cost")?))
+                (types, Some(c.expect_uint("cost")?), false)
             }
-            types => (types, None),
+            types => (types, None, false),
         };
 
         Ok(Variant {
@@ -797,6 +798,7 @@ impl Parser {
                 sexp.expect_atom("variant argument type")
             })?,
             cost,
+            unextractable,
         })
     }
 


### PR DESCRIPTION
This PR adds support for the `:unextractable` flag for `datatype` variants. Currently only variants defined by `constructor` allow the `:unextractable` flag. I have run `cargo test` locally and all the tests pass. Let me know if anything else needs to change.