### PR TITLE
Index catalog optimized for small set of indices

### DIFF
--- a/concurrency/src/lib.rs
+++ b/concurrency/src/lib.rs
@@ -43,6 +43,15 @@ pub struct ReadOptimizedLock<T> {
     data: UnsafeCell<T>,
 }
 
+impl<T: Default> Default for ReadOptimizedLock<T> {
+    fn default() -> Self {
+        Self {
+            token: ArcSwap::from_pointee(ReadToken::ReadOk(TriggerWhenDone::default())),
+            data: Default::default(),
+        }
+    }
+}
+
 /// A handle granting read access to the data guarded by a [`ReadOptimizedLock`].
 pub struct MutexReader<'lock, T> {
     data: &'lock T,

--- a/core-relations/src/common.rs
+++ b/core-relations/src/common.rs
@@ -211,22 +211,3 @@ impl SubsetTracker {
         res
     }
 }
-
-/// Iterate over the contents of a `DashMap`, using a lower-overhead method than the built-in
-/// iterators available from `DashMap`.
-pub(crate) fn iter_dashmap_bulk<K: Hash + Eq, V>(
-    map: &mut DashMap<K, V>,
-    mut f: impl FnMut(&K, &mut V),
-) {
-    let shards = map.shards_mut();
-    for shard in shards {
-        let mut_shard = shard.get_mut();
-        // SAFETY: this iterator does not outlive `shard`: it is not returned from this function
-        // and `f` cannot store it anywhere as it takes an arbitrary lifetime.
-        for entry in unsafe { mut_shard.iter() } {
-            // SAFETY: we have exclusive access to the whole table.
-            let (k, v) = unsafe { entry.as_mut() };
-            f(k, v.get_mut());
-        }
-    }
-}


### PR DESCRIPTION
We currently stores indexes as a DashMap from access patterns to indices, which can be slow for several reasons:

* DashMap by default has available_parallelism() * 4 many shards, so to enumerate the DashMap requires visiting 128 shards on a 32-core desktop, even when very few indices are stored. This has been a bottleneck for workloads with many iterations.
* DashMap is optimized for concurrently accessing a large amount of data. An associative array is usually faster when data size is small (i.e < 32-64)

This PR addresses this issue by replacing the DashMap with a lightweight read-optimized array.