### PR TITLE
Make interactive mode a delimiter

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -360,7 +360,7 @@ mod tests {
         egraph
             .repl_with(input.as_bytes(), &mut output, RunMode::Interactive, false)
             .unwrap();
-        assert_eq!(String::from_utf8(output).unwrap(), "(done)\n1\n");
+        assert_eq!(String::from_utf8(output).unwrap(), "1\n(done)\n");
 
         let input = "xyz";
         let mut output: Vec<u8> = Vec::new();


### PR DESCRIPTION
In interactive mode, egglog prints `(done)` after every command. This makes it easier to use egglog as an inferior program, since you can submit a command and then consume output until `(done)` is printed. However, messages are currently printed after the `(done)` message. This PR changes them to print before that message, which ensures that `(done)` is a delimiter between commands.