### PR TITLE
Pin cargo codspeed version to fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-codspeed
+          tool: cargo-codspeed@4.0.1
       - uses: Swatinem/rust-cache@v2
       - run: cargo codspeed build
       - uses: CodSpeedHQ/action@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-codspeed
+          tool: cargo-codspeed@4.0.1
       - run: |
           git clone https://github.com/egraphs-good/egglog-benchmarks.git
           cd egglog-benchmarks


### PR DESCRIPTION
Closes #733 by pinning cargo codspeed version installed in CI

The newer version causes an issue currently This PR at least fixed to the old working version so CI is not broken. In the future, we should keep this pinned to not get CI failing randomly