### PR TITLE
Low-level optimization for rebuilding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ pkg/
 flamegraph.svg
 perf.data*
 profile.json
+/*.json
+/*.txt
 
 _scratch.egg
 /*.egg

--- a/core-relations/src/containers/mod.rs
+++ b/core-relations/src/containers/mod.rs
@@ -62,9 +62,7 @@ impl ContainerIds {
     }
 
     fn get(&self, ty: &TypeId) -> Option<ContainerValueId> {
-        self.ids
-            .get_index_of(ty)
-            .map(|idx| ContainerValueId::from_usize(idx))
+        self.ids.get_index_of(ty).map(ContainerValueId::from_usize)
     }
 }
 

--- a/core-relations/src/containers/mod.rs
+++ b/core-relations/src/containers/mod.rs
@@ -26,7 +26,7 @@ use rustc_hash::FxHasher;
 use crate::{
     ColumnId, CounterId, ExecutionState, Offset, SubsetRef, TableId, TaggedRowBuffer, Value,
     WrappedTable,
-    common::{DashMap, IndexSet, InternTable, SubsetTracker},
+    common::{DashMap, IndexSet, SubsetTracker},
     parallel_heuristics::{parallelize_inter_container_op, parallelize_intra_container_op},
     table_spec::Rebuilder,
 };
@@ -46,9 +46,32 @@ impl<T: Fn(&mut ExecutionState, Value, Value) -> Value + Clone + Send + Sync> Me
 dyn_clone::clone_trait_object!(MergeFn);
 
 #[derive(Clone, Default)]
+struct ContainerIds {
+    ids: IndexSet<TypeId>,
+}
+
+impl ContainerIds {
+    fn insert(&mut self, ty: TypeId) -> ContainerValueId {
+        if let Some(idx) = self.ids.get_index_of(&ty) {
+            ContainerValueId::from_usize(idx)
+        } else {
+            let idx = self.ids.len();
+            self.ids.insert(ty);
+            ContainerValueId::from_usize(idx)
+        }
+    }
+
+    fn get(&self, ty: &TypeId) -> Option<ContainerValueId> {
+        self.ids
+            .get_index_of(ty)
+            .map(|idx| ContainerValueId::from_usize(idx))
+    }
+}
+
+#[derive(Clone, Default)]
 pub struct ContainerValues {
     subset_tracker: SubsetTracker,
-    container_ids: InternTable<TypeId, ContainerValueId>,
+    container_ids: ContainerIds,
     data: DenseIdMap<ContainerValueId, Box<dyn DynamicContainerEnv + Send + Sync>>,
 }
 
@@ -58,7 +81,7 @@ impl ContainerValues {
     }
 
     fn get<C: ContainerValue>(&self) -> Option<&ContainerEnv<C>> {
-        let id = self.container_ids.intern(&TypeId::of::<C>());
+        let id = self.container_ids.get(&TypeId::of::<C>())?;
         let res = self.data.get(id)?.as_any();
         Some(res.downcast_ref::<ContainerEnv<C>>().unwrap())
     }
@@ -145,7 +168,7 @@ impl ContainerValues {
         id_counter: CounterId,
         merge_fn: impl MergeFn + 'static,
     ) -> ContainerValueId {
-        let id = self.container_ids.intern(&TypeId::of::<C>());
+        let id = self.container_ids.insert(TypeId::of::<C>());
         self.data.get_or_insert(id, || {
             Box::new(ContainerEnv::<C>::new(Box::new(merge_fn), id_counter))
         });

--- a/core-relations/src/pool/mod.rs
+++ b/core-relations/src/pool/mod.rs
@@ -395,7 +395,7 @@ macro_rules! pool_set {
             }
 
             $vis fn get<T: InPoolSet<Self> + Default>(&self) -> Pooled<T> {
-                self.get_pool().get()
+                T::with_pool(self, |pool| pool.get())
             }
             $vis fn clear(&self) {
                 $( self.$ident.clear(); )*

--- a/core-relations/src/uf/mod.rs
+++ b/core-relations/src/uf/mod.rs
@@ -168,9 +168,10 @@ impl Rebuilder for Canonicalizer<'_> {
         out: &mut TaggedRowBuffer,
         _exec_state: &mut ExecutionState,
     ) {
+        let old_len = u32::try_from(out.len()).expect("row buffer sizes should fit in a u32");
         let _next = other.scan_bounded(subset, Offset::new(0), usize::MAX, out);
         debug_assert!(_next.is_none());
-        for i in 0..u32::try_from(out.len()).expect("row buffer sizes should fit in a u32") {
+        for i in old_len..u32::try_from(out.len()).expect("row buffer sizes should fit in a u32") {
             let i = RowId::new(i);
             let (_id, row) = out.get_row_mut(i);
             let mut changed = false;

--- a/core-relations/src/uf/mod.rs
+++ b/core-relations/src/uf/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{
     any::Any,
-    mem,
+    mem::{self, ManuallyDrop},
     sync::{Arc, Weak},
 };
 
@@ -221,17 +221,25 @@ impl Clone for DisplacedTable {
 }
 
 struct UfBuffer {
-    to_insert: RowBuffer,
+    to_insert: ManuallyDrop<RowBuffer>,
     buffered_writes: Weak<SegQueue<RowBuffer>>,
 }
 
 impl Drop for UfBuffer {
     fn drop(&mut self) {
         let Some(buffered_writes) = self.buffered_writes.upgrade() else {
+            // SAFETY: If we can't write updates, manually drop to_insert
+            unsafe {
+                ManuallyDrop::drop(&mut self.to_insert);
+            }
             return;
         };
-        let arity = self.to_insert.arity();
-        buffered_writes.push(mem::replace(&mut self.to_insert, RowBuffer::new(arity)));
+        // SAFETY: self.to_insert will not be used again after this point.
+        //
+        // This avoids creating a fresh row buffer via `mem::take` or `mem::swap` and
+        // dropping it immediately.
+        let to_insert = unsafe { ManuallyDrop::take(&mut self.to_insert) };
+        buffered_writes.push(to_insert);
     }
 }
 
@@ -244,7 +252,7 @@ impl MutationBuffer for UfBuffer {
     }
     fn fresh_handle(&self) -> Box<dyn MutationBuffer> {
         Box::new(UfBuffer {
-            to_insert: RowBuffer::new(self.to_insert.arity()),
+            to_insert: ManuallyDrop::new(RowBuffer::new(self.to_insert.arity())),
             buffered_writes: self.buffered_writes.clone(),
         })
     }
@@ -431,7 +439,7 @@ impl Table for DisplacedTable {
 
     fn new_buffer(&self) -> Box<dyn MutationBuffer> {
         Box::new(UfBuffer {
-            to_insert: RowBuffer::new(3),
+            to_insert: ManuallyDrop::new(RowBuffer::new(3)),
             buffered_writes: Arc::downgrade(&self.buffered_writes),
         })
     }
@@ -828,7 +836,7 @@ impl Table for DisplacedTableWithProvenance {
 
     fn new_buffer(&self) -> Box<dyn MutationBuffer> {
         Box::new(UfBuffer {
-            to_insert: RowBuffer::new(4),
+            to_insert: ManuallyDrop::new(RowBuffer::new(4)),
             buffered_writes: Arc::downgrade(&self.buffered_writes),
         })
     }

--- a/numeric-id/src/lib.rs
+++ b/numeric-id/src/lib.rs
@@ -74,7 +74,9 @@ impl<K: NumericId, V> DenseIdMap<K, V> {
     /// Create an empty map with space for `n` entries pre-allocated.
     pub fn with_capacity(n: usize) -> Self {
         let mut res = Self::new();
-        res.reserve_space(K::from_usize(n));
+        if n > 0 {
+            res.reserve_space(K::from_usize(n - 1));
+        }
         res
     }
 

--- a/numeric-id/src/lib.rs
+++ b/numeric-id/src/lib.rs
@@ -74,9 +74,7 @@ impl<K: NumericId, V> DenseIdMap<K, V> {
     /// Create an empty map with space for `n` entries pre-allocated.
     pub fn with_capacity(n: usize) -> Self {
         let mut res = Self::new();
-        if n > 0 {
-            res.reserve_space(K::from_usize(n - 1));
-        }
+        res.reserve_space(K::from_usize(n.saturating_sub(1)));
         res
     }
 


### PR DESCRIPTION
1. Avoid using a concurrent structure for TypeId -> ContainerId map
2. Avoid creating a new RowBuffer when dropping a UfBuffer
3. Avoid creating a new buffer during rebuilding when the table does not have updates (only in single-thread mode)

One optimization we can do is to replace the SegQueue in pending_rows/pending_removals with a bespoke queue implementation by noticing:

* Each producer only produces once (when the containing `Buffer` is dropped)
* There is only one consumer, the consumer only consumes after all producers have produced (i.e., it has exclusive access), and it always consumes everything.

I had an implementation in [yihozhang-sharded-update-queue-legacy](https://github.com/egraphs-good/egglog/tree/yihozhang-sharded-update-queue-legacy) that tries to replace the SegQueue by pre-allocating each producer a slot, so that each producer doesn't need a write lock to write to the slot. Ideally this should turn the required write locks to reads when producing and consuming. However, my implementation actually slows things down.. So I will skip this for now, as it does not seem to contribute to the performance critically.