### PR TITLE
Simplify extract option handling

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -269,7 +269,6 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
     ) -> Option<C> {
         let mut ch_costs: Vec<C> = Vec::new();
         let sorts = &func.schema.input;
-        //log::debug!("compute_cost_hyperedge head {} sorts {:?}", head, sorts);
         // Relying on .zip to truncate the values
         for (value, sort) in row.vals.iter().zip(sorts.iter()) {
             ch_costs.push(self.compute_cost_node(egraph, *value, sort)?);


### PR DESCRIPTION
Removes a few lines from extract to help make the code slightly easier to understand. This shouldn't change behavior at all, it just changes some of the option handling to use ? and also only looks up the cost once instead of twice.