### PR TITLE
Specify that extractor does not support DAG costs

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -127,7 +127,7 @@ impl CostModel<DefaultCost> for TreeAdditiveCostModel {
 /// Note that this assumes optimal substructure in the cost model, that is, a lower-cost
 /// subterm should always lead to a non-worse superterm, to guarantee the extracted term
 /// being optimal under the given cost model.
-/// If this is not followed, the extractor may panic on reconunstrction
+/// If this is not followed, the extractor may panic on reconstruction
 pub struct Extractor<C: Cost + Ord + Eq + Clone + Debug> {
     rootsorts: Vec<ArcSort>,
     funcs: Vec<String>,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -123,6 +123,11 @@ impl CostModel<DefaultCost> for TreeAdditiveCostModel {
 }
 
 /// The default, Bellman-Ford like extractor. This extractor is optimal for [`CostModel`].
+///
+/// Note that this assumes optimal substructure in the cost model, that is, a lower-cost
+/// subterm should always lead to a non-worse superterm, to guarantee the extracted term
+/// being optimal under the given cost model.
+/// If this is not followed, the extractor may panic on reconunstrction
 pub struct Extractor<C: Cost + Ord + Eq + Clone + Debug> {
     rootsorts: Vec<ArcSort>,
     funcs: Vec<String>,


### PR DESCRIPTION
Follow up on https://github.com/egraphs-good/egglog/pull/758 to specify clearly that the extractor does not support DAG like cost models.