### PR TITLE
Refactor query planning

### DIFF
--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -571,7 +571,13 @@ impl<'a> JoinState<'a> {
                                     db,
                                     exec_state: exec_state_for_work.clone(),
                                 }
-                                .run_plan(plan, instr_order, cur + 1, binding_info, buf);
+                                .run_plan(
+                                    plan,
+                                    instr_order,
+                                    cur + 1,
+                                    binding_info,
+                                    buf,
+                                );
                             }
                         })
                     },

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -432,7 +432,13 @@ fn plan_headers(
     ctx: &PlanningContext,
 ) -> (
     Vec<JoinHeader>,
-    DenseIdMap<AtomId, (usize, &Pooled<Vec<Constraint>>)>,
+    DenseIdMap<
+        AtomId,
+        (
+            usize, /* The approx size of the subset matching the constraints. */
+            &Pooled<Vec<Constraint>>,
+        ),
+    >,
 ) {
     let mut header = Vec::new();
     let mut remaining_constraints: DenseIdMap<AtomId, (usize, &Pooled<Vec<Constraint>>)> =

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -290,8 +290,8 @@ pub enum PlanStrategy {
 
 pub(crate) fn plan_query(query: Query) -> Plan {
     let ctx = PlanningContext {
-        vars: &query.var_info,
-        atoms: &query.atoms,
+        vars: query.var_info,
+        atoms: query.atoms,
     };
     plan_with_context(&ctx, query.plan_strategy, query.action)
 }
@@ -312,9 +312,9 @@ struct StageInfo {
 }
 
 /// Immutable context for query planning containing references to query metadata.
-struct PlanningContext<'a> {
-    vars: &'a DenseIdMap<Variable, VarInfo>,
-    atoms: &'a DenseIdMap<AtomId, Atom>,
+struct PlanningContext {
+    vars: DenseIdMap<Variable, VarInfo>,
+    atoms: DenseIdMap<AtomId, Atom>,
 }
 
 /// Mutable state tracked during query planning.
@@ -483,7 +483,7 @@ fn plan_free_join(
         }
         PlanStrategy::MinCover => {
             let mut eligible_covers = HashSet::default();
-            let mut queue = BucketQueue::new(ctx.vars, ctx.atoms);
+            let mut queue = BucketQueue::new(&ctx.vars, &ctx.atoms);
             while let Some(atom) = queue.pop_min() {
                 eligible_covers.insert(atom);
             }

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -1,8 +1,7 @@
-use std::{collections::BTreeMap, iter, mem};
+use std::{collections::BTreeMap, iter, mem, sync::Arc};
 
 use crate::{
-    numeric_id::{DenseIdMap, NumericId},
-    query::SymbolMap,
+    numeric_id::{DenseIdMap, NumericId}, query::SymbolMap
 };
 use fixedbitset::FixedBitSet;
 use smallvec::{SmallVec, smallvec};
@@ -164,7 +163,7 @@ impl JoinStage {
 
 #[derive(Debug, Clone)]
 pub(crate) struct Plan {
-    pub atoms: DenseIdMap<AtomId, Atom>,
+    pub atoms: Arc<DenseIdMap<AtomId, Atom>>,
     pub stages: JoinStages,
 }
 impl Plan {
@@ -259,7 +258,7 @@ impl Plan {
 #[derive(Debug, Clone)]
 pub(crate) struct JoinStages {
     pub header: Vec<JoinHeader>,
-    pub instrs: Vec<JoinStage>,
+    pub instrs: Arc<Vec<JoinStage>>,
     pub actions: ActionId,
 }
 
@@ -297,10 +296,10 @@ pub(crate) fn plan_query(query: Query) -> Plan {
     let (header, instrs) = plan_stages(&ctx, query.plan_strategy);
 
     Plan {
-        atoms: ctx.atoms,
+        atoms: Arc::new(ctx.atoms),
         stages: JoinStages {
             header,
-            instrs,
+            instrs: Arc::new(instrs),
             actions: query.action,
         },
     }

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, iter, mem, sync::Arc};
+use std::{collections::BTreeMap, mem, sync::Arc};
 
 use crate::{
     numeric_id::{DenseIdMap, NumericId},
@@ -259,7 +259,7 @@ impl Plan {
 #[derive(Debug, Clone)]
 pub(crate) struct JoinStages {
     pub header: Vec<JoinHeader>,
-    pub instrs: Arc<Vec<JoinStage>>,
+    pub instrs: Vec<JoinStage>,
     pub actions: ActionId,
 }
 
@@ -289,19 +289,11 @@ pub enum PlanStrategy {
 }
 
 pub(crate) fn plan_query(query: Query) -> Plan {
-    Planner::new(&query.var_info, &query.atoms).plan(query.plan_strategy, query.action)
-}
-
-struct Planner<'a> {
-    // immutable
-    vars: &'a DenseIdMap<Variable, VarInfo>,
-    atoms: &'a DenseIdMap<AtomId, Atom>,
-
-    // mutable
-    used: VarSet,
-    constrained: AtomSet,
-
-    scratch_subatom: HashMap<AtomId, SmallVec<[ColumnId; 2]>>,
+    let ctx = PlanningContext {
+        vars: &query.var_info,
+        atoms: &query.atoms,
+    };
+    plan_with_context(&ctx, query.plan_strategy, query.action)
 }
 
 /// StageInfo is an intermediate stage used to describe the ordering of
@@ -319,288 +311,43 @@ struct StageInfo {
     )>,
 }
 
-impl<'a> Planner<'a> {
-    pub(crate) fn new(
-        vars: &'a DenseIdMap<Variable, VarInfo>,
-        atoms: &'a DenseIdMap<AtomId, Atom>,
-    ) -> Self {
-        Planner {
-            vars,
-            atoms,
-            used: VarSet::with_capacity(vars.n_ids()),
-            constrained: AtomSet::with_capacity(atoms.n_ids()),
-            scratch_subatom: Default::default(),
+/// Immutable context for query planning containing references to query metadata.
+struct PlanningContext<'a> {
+    vars: &'a DenseIdMap<Variable, VarInfo>,
+    atoms: &'a DenseIdMap<AtomId, Atom>,
+}
+
+/// Mutable state tracked during query planning.
+#[derive(Clone)]
+struct PlanningState {
+    used_vars: VarSet,
+    constrained_atoms: AtomSet,
+}
+
+impl PlanningState {
+    fn new(n_vars: usize, n_atoms: usize) -> Self {
+        Self {
+            used_vars: VarSet::with_capacity(n_vars),
+            constrained_atoms: AtomSet::with_capacity(n_atoms),
         }
     }
 
-    fn plan_free_join(
-        &mut self,
-        strat: PlanStrategy,
-        remaining_constraints: &DenseIdMap<AtomId, (usize, &Pooled<Vec<Constraint>>)>,
-        stages: &mut Vec<JoinStage>,
-    ) {
-        let mut size_info = Vec::<(AtomId, usize)>::new();
-        match strat {
-            PlanStrategy::PureSize => {
-                for (atom, (size, _)) in remaining_constraints.iter() {
-                    size_info.push((atom, *size));
-                }
-            }
-            PlanStrategy::MinCover => {
-                let mut eligible_covers = HashSet::default();
-                let mut queue = BucketQueue::new(self.vars, self.atoms);
-                while let Some(atom) = queue.pop_min() {
-                    eligible_covers.insert(atom);
-                }
-                for (atom, (size, _)) in remaining_constraints
-                    .iter()
-                    .filter(|(atom, _)| eligible_covers.contains(atom))
-                {
-                    size_info.push((atom, *size));
-                }
-            }
-            PlanStrategy::Gj => unreachable!(),
-        };
-        size_info.sort_by_key(|(_, size)| *size);
-        let mut atoms = size_info.iter().map(|(atom, _)| *atom);
-        while let Some(info) = self.get_next_freejoin_stage(&mut atoms) {
-            stages.push(self.compile_stage(info))
-        }
+    fn mark_var_used(mut self, var: Variable) -> Self {
+        self.used_vars.insert(var.index());
+        self
     }
 
-    fn plan_gj(
-        &mut self,
-        remaining_constraints: &DenseIdMap<AtomId, (usize, &Pooled<Vec<Constraint>>)>,
-        stages: &mut Vec<JoinStage>,
-    ) {
-        // First, map all variables to the size of the smallest atom in which they appear:
-        let mut min_sizes = Vec::with_capacity(self.vars.n_ids());
-        let mut atoms_hit = AtomSet::with_capacity(self.atoms.n_ids());
-        for (var, var_info) in self.vars.iter() {
-            let n_occs = var_info.occurrences.len();
-            if n_occs == 1 && !var_info.used_in_rhs {
-                // Do not plan this one. Unless (see below).
-                continue;
-            }
-            if let Some(min_size) = var_info
-                .occurrences
-                .iter()
-                .map(|subatom| {
-                    atoms_hit.set(subatom.atom.index(), true);
-                    remaining_constraints[subatom.atom].0
-                })
-                .min()
-            {
-                min_sizes.push((var, min_size, n_occs));
-            }
-            // If the variable has no ocurrences, it may be bound on the RHS of a
-            // rule (or it may just be unused). Either way, we will ignore it when
-            // planning the query.
-        }
-        for (var, var_info) in self.vars.iter() {
-            if var_info.occurrences.len() == 1 && !var_info.used_in_rhs {
-                // We skipped this variable the first time around because it
-                // looks "unused". If it belongs to an atom that otherwise has
-                // gone unmentioned, though, we need to plan it anyway.
-                let atom = var_info.occurrences[0].atom;
-                if !atoms_hit.contains(atom.index()) {
-                    min_sizes.push((var, remaining_constraints[atom].0, 1));
-                }
-            }
-        }
-        // Sort ascending by size, then descending by number of occurrences.
-        min_sizes.sort_by_key(|(_, size, occs)| (*size, -(*occs as i64)));
-        for (var, _, _) in min_sizes {
-            let occ = self.vars[var].occurrences[0].clone();
-            let mut info = StageInfo {
-                cover: occ,
-                vars: smallvec![var],
-                filters: Default::default(),
-            };
-            for occ in &self.vars[var].occurrences[1..] {
-                info.filters
-                    .push((occ.clone(), smallvec![ColumnId::new(0)]));
-            }
-            let next_stage = self.compile_stage(info);
-            if let Some(prev) = stages.last_mut() {
-                if prev.fuse(&next_stage) {
-                    continue;
-                }
-            }
-            stages.push(next_stage);
-        }
+    fn is_var_used(&self, var: Variable) -> bool {
+        self.used_vars.contains(var.index())
     }
 
-    pub(crate) fn plan(&mut self, strat: PlanStrategy, actions: ActionId) -> Plan {
-        let mut instrs = Vec::new();
-        let mut header = Vec::new();
-        self.used.clear();
-        self.constrained.clear();
-        let mut remaining_constraints: DenseIdMap<AtomId, (usize, &Pooled<Vec<Constraint>>)> =
-            Default::default();
-        // First, plan all the constants:
-        for (atom, atom_info) in self.atoms.iter() {
-            remaining_constraints.insert(
-                atom,
-                (
-                    atom_info.constraints.approx_size(),
-                    &atom_info.constraints.slow,
-                ),
-            );
-            if atom_info.constraints.fast.is_empty() {
-                continue;
-            }
-            header.push(JoinHeader {
-                atom,
-                constraints: Pooled::cloned(&atom_info.constraints.fast),
-                subset: atom_info.constraints.subset.clone(),
-            });
-        }
-        match strat {
-            PlanStrategy::PureSize | PlanStrategy::MinCover => {
-                self.plan_free_join(strat, &remaining_constraints, &mut instrs);
-            }
-            PlanStrategy::Gj => {
-                self.plan_gj(&remaining_constraints, &mut instrs);
-            }
-        }
-        Plan {
-            atoms: self.atoms.clone().into(),
-            stages: JoinStages {
-                header,
-                instrs: Arc::new(instrs),
-                actions,
-            },
-        }
+    fn mark_atom_constrained(mut self, atom: AtomId) -> Self {
+        self.constrained_atoms.insert(atom.index());
+        self
     }
 
-    fn get_next_freejoin_stage(
-        &mut self,
-        ordering: &mut impl Iterator<Item = AtomId>,
-    ) -> Option<StageInfo> {
-        loop {
-            let mut covered = false;
-            let mut filters = Vec::new();
-            let atom = ordering.next()?;
-            let atom_info = &self.atoms[atom];
-            let mut cover = SubAtom::new(atom);
-            let mut vars = SmallVec::<[Variable; 1]>::new();
-            for (ix, var) in atom_info.column_to_var.iter() {
-                if self.used.contains(var.index()) {
-                    continue;
-                }
-                // This atom is not completely covered by previous stages.
-                covered = true;
-                self.used.insert(var.index());
-                vars.push(*var);
-                cover.vars.push(ix);
-                for subatom in self.vars[*var].occurrences.iter() {
-                    if subatom.atom == atom {
-                        continue;
-                    }
-                    self.scratch_subatom
-                        .entry(subatom.atom)
-                        .or_default()
-                        .extend(subatom.vars.iter().copied());
-                }
-            }
-            if !covered {
-                // Search the next atom.
-                continue;
-            }
-            for (atom, cols) in self.scratch_subatom.drain() {
-                let mut form_key = SmallVec::<[ColumnId; 2]>::new();
-                for var_ix in &cols {
-                    let var = self.atoms[atom].column_to_var[*var_ix];
-                    // form_key is an index _into the subatom forming the cover_.
-                    let cover_col = vars
-                        .iter()
-                        .enumerate()
-                        .find(|(_, v)| **v == var)
-                        .map(|(ix, _)| ix)
-                        .unwrap();
-                    form_key.push(ColumnId::from_usize(cover_col));
-                }
-                filters.push((SubAtom { atom, vars: cols }, form_key));
-            }
-            return Some(StageInfo {
-                cover,
-                vars,
-                filters,
-            });
-        }
-    }
-
-    fn compile_stage(
-        &mut self,
-        StageInfo {
-            cover,
-            vars,
-            filters,
-        }: StageInfo,
-    ) -> JoinStage {
-        if vars.len() == 1 {
-            debug_assert!(
-                filters
-                    .iter()
-                    .all(|(_, x)| x.len() == 1 && x[0] == ColumnId::new(0)),
-                "filters={filters:?}"
-            );
-            let scans = SmallVec::<[SingleScanSpec; 3]>::from_iter(
-                iter::once(&cover)
-                    .chain(filters.iter().map(|(x, _)| x))
-                    .map(|subatom| {
-                        let atom = subatom.atom;
-                        SingleScanSpec {
-                            atom,
-                            column: subatom.vars[0],
-                            cs: if !self.constrained.put(atom.index()) {
-                                self.atoms[atom].constraints.slow.clone()
-                            } else {
-                                Default::default()
-                            },
-                        }
-                    }),
-            );
-            return JoinStage::Intersect {
-                var: vars[0],
-                scans,
-            };
-        }
-        let atom = cover.atom;
-        let cover = ScanSpec {
-            to_index: cover,
-            constraints: if !self.constrained.put(atom.index()) {
-                self.atoms[atom].constraints.slow.clone()
-            } else {
-                Default::default()
-            },
-        };
-        let mut bind = SmallVec::new();
-        let var_set = &self.atoms[atom].var_to_column;
-        for var in vars {
-            bind.push((var_set[&var], var));
-        }
-
-        let mut to_intersect = Vec::with_capacity(filters.len());
-        for (subatom, key_spec) in filters {
-            let atom = subatom.atom;
-            let scan = ScanSpec {
-                to_index: subatom,
-                constraints: if !self.constrained.put(atom.index()) {
-                    self.atoms[atom].constraints.slow.clone()
-                } else {
-                    Default::default()
-                },
-            };
-            to_intersect.push((scan, key_spec));
-        }
-
-        JoinStage::FusedIntersect {
-            cover,
-            bind,
-            to_intersect,
-        }
+    fn is_atom_constrained(&self, atom: AtomId) -> bool {
+        self.constrained_atoms.contains(atom.index())
     }
 }
 
@@ -668,4 +415,335 @@ impl<'a> BucketQueue<'a> {
         self.cover.union_with(&vars);
         Some(res)
     }
+}
+
+/// Main planning function
+fn plan_with_context(
+    ctx: &PlanningContext,
+    strat: PlanStrategy,
+    actions: ActionId,
+) -> Plan {
+    let mut instrs = Vec::new();
+    let mut header = Vec::new();
+    let state = PlanningState::new(ctx.vars.n_ids(), ctx.atoms.n_ids());
+
+    let mut remaining_constraints: DenseIdMap<AtomId, (usize, &Pooled<Vec<Constraint>>)> =
+        Default::default();
+
+    // Build headers
+    for (atom, atom_info) in ctx.atoms.iter() {
+        remaining_constraints.insert(
+            atom,
+            (
+                atom_info.constraints.approx_size(),
+                &atom_info.constraints.slow,
+            ),
+        );
+        if !atom_info.constraints.fast.is_empty() {
+            header.push(JoinHeader {
+                atom,
+                constraints: Pooled::cloned(&atom_info.constraints.fast),
+                subset: atom_info.constraints.subset.clone(),
+            });
+        }
+    }
+
+    let _final_state = match strat {
+        PlanStrategy::PureSize | PlanStrategy::MinCover => {
+            plan_free_join(ctx, state, strat, &remaining_constraints, &mut instrs)
+        }
+        PlanStrategy::Gj => plan_gj(ctx, state, &remaining_constraints, &mut instrs),
+    };
+
+    Plan {
+        atoms: ctx.atoms.clone().into(),
+        stages: JoinStages {
+            header,
+            instrs,
+            actions,
+        },
+    }
+}
+
+/// Plan free join queries using pure size or minimal cover strategy.
+fn plan_free_join(
+    ctx: &PlanningContext,
+    mut state: PlanningState,
+    strat: PlanStrategy,
+    remaining_constraints: &DenseIdMap<AtomId, (usize, &Pooled<Vec<Constraint>>)>,
+    stages: &mut Vec<JoinStage>,
+) -> PlanningState {
+    let mut size_info = Vec::<(AtomId, usize)>::new();
+
+    match strat {
+        PlanStrategy::PureSize => {
+            for (atom, (size, _)) in remaining_constraints.iter() {
+                size_info.push((atom, *size));
+            }
+        }
+        PlanStrategy::MinCover => {
+            let mut eligible_covers = HashSet::default();
+            let mut queue = BucketQueue::new(ctx.vars, ctx.atoms);
+            while let Some(atom) = queue.pop_min() {
+                eligible_covers.insert(atom);
+            }
+            for (atom, (size, _)) in remaining_constraints
+                .iter()
+                .filter(|(atom, _)| eligible_covers.contains(atom))
+            {
+                size_info.push((atom, *size));
+            }
+        }
+        PlanStrategy::Gj => unreachable!(),
+    };
+
+    size_info.sort_by_key(|(_, size)| *size);
+    let mut atoms = size_info.iter().map(|(atom, _)| *atom);
+
+    loop {
+        let current = mem::replace(&mut state, PlanningState::new(ctx.vars.n_ids(), ctx.atoms.n_ids()));
+        match get_next_freejoin_stage(ctx, current, &mut atoms) {
+            Some((info, new_state)) => {
+                let (stage, final_state) = compile_stage(ctx, new_state, info);
+                stages.push(stage);
+                state = final_state;
+            }
+            None => break,
+        }
+    }
+
+    state
+}
+
+/// Plan generic join queries (one variable per stage).
+fn plan_gj(
+    ctx: &PlanningContext,
+    mut state: PlanningState,
+    remaining_constraints: &DenseIdMap<AtomId, (usize, &Pooled<Vec<Constraint>>)>,
+    stages: &mut Vec<JoinStage>,
+) -> PlanningState {
+    // First, map all variables to the size of the smallest atom in which they appear:
+    let mut min_sizes = Vec::with_capacity(ctx.vars.n_ids());
+    let mut atoms_hit = AtomSet::with_capacity(ctx.atoms.n_ids());
+    for (var, var_info) in ctx.vars.iter() {
+        let n_occs = var_info.occurrences.len();
+        if n_occs == 1 && !var_info.used_in_rhs {
+            // Do not plan this one. Unless (see below).
+            continue;
+        }
+        if let Some(min_size) = var_info
+            .occurrences
+            .iter()
+            .map(|subatom| {
+                atoms_hit.set(subatom.atom.index(), true);
+                remaining_constraints[subatom.atom].0
+            })
+            .min()
+        {
+            min_sizes.push((var, min_size, n_occs));
+        }
+        // If the variable has no ocurrences, it may be bound on the RHS of a
+        // rule (or it may just be unused). Either way, we will ignore it when
+        // planning the query.
+    }
+    for (var, var_info) in ctx.vars.iter() {
+        if var_info.occurrences.len() == 1 && !var_info.used_in_rhs {
+            // We skipped this variable the first time around because it
+            // looks "unused". If it belongs to an atom that otherwise has
+            // gone unmentioned, though, we need to plan it anyway.
+            let atom = var_info.occurrences[0].atom;
+            if !atoms_hit.contains(atom.index()) {
+                min_sizes.push((var, remaining_constraints[atom].0, 1));
+            }
+        }
+    }
+    // Sort ascending by size, then descending by number of occurrences.
+    min_sizes.sort_by_key(|(_, size, occs)| (*size, -(*occs as i64)));
+    for (var, _, _) in min_sizes {
+        let occ = ctx.vars[var].occurrences[0].clone();
+        let mut info = StageInfo {
+            cover: occ,
+            vars: smallvec![var],
+            filters: Default::default(),
+        };
+        for occ in &ctx.vars[var].occurrences[1..] {
+            info.filters
+                .push((occ.clone(), smallvec![ColumnId::new(0)]));
+        }
+
+        let (next_stage, new_state) = compile_stage(ctx, state, info);
+        if let Some(prev) = stages.last_mut() {
+            if prev.fuse(&next_stage) {
+                state = new_state;
+                continue;
+            }
+        }
+        stages.push(next_stage);
+        state = new_state;
+    }
+
+    state
+}
+
+/// Generate the next free join stage by picking an atom from the ordering.
+/// Returns the stage info and updated state, or None if all atoms are covered.
+fn get_next_freejoin_stage(
+    ctx: &PlanningContext,
+    mut state: PlanningState,
+    ordering: &mut impl Iterator<Item = AtomId>,
+) -> Option<(StageInfo, PlanningState)> {
+    // Local variable instead of struct field!
+    let mut scratch_subatom: HashMap<AtomId, SmallVec<[ColumnId; 2]>> = Default::default();
+
+    loop {
+        let mut covered = false;
+        let atom = ordering.next()?;
+        let atom_info = &ctx.atoms[atom];
+        let mut cover = SubAtom::new(atom);
+        let mut vars = SmallVec::<[Variable; 1]>::new();
+
+        for (ix, var) in atom_info.column_to_var.iter() {
+            if state.is_var_used(*var) {
+                continue;
+            }
+            // This atom is not completely covered by previous stages.
+            covered = true;
+            state = state.mark_var_used(*var);
+            vars.push(*var);
+            cover.vars.push(ix);
+
+            for subatom in ctx.vars[*var].occurrences.iter() {
+                if subatom.atom == atom {
+                    continue;
+                }
+                scratch_subatom
+                    .entry(subatom.atom)
+                    .or_default()
+                    .extend(subatom.vars.iter().copied());
+            }
+        }
+
+        if !covered {
+            // Search the next atom.
+            continue;
+        }
+
+        let mut filters = Vec::new();
+        for (atom, cols) in scratch_subatom.drain() {
+            let mut form_key = SmallVec::<[ColumnId; 2]>::new();
+            for var_ix in &cols {
+                let var = ctx.atoms[atom].column_to_var[*var_ix];
+                // form_key is an index _into the subatom forming the cover_.
+                let cover_col = vars
+                    .iter()
+                    .enumerate()
+                    .find(|(_, v)| **v == var)
+                    .map(|(ix, _)| ix)
+                    .unwrap();
+                form_key.push(ColumnId::from_usize(cover_col));
+            }
+            filters.push((SubAtom { atom, vars: cols }, form_key));
+        }
+
+        return Some((StageInfo { cover, vars, filters }, state));
+    }
+}
+
+/// Compile a stage info into a concrete join stage, updating constraint state.
+fn compile_stage(
+    ctx: &PlanningContext,
+    mut state: PlanningState,
+    StageInfo {
+        cover,
+        vars,
+        filters,
+    }: StageInfo,
+) -> (JoinStage, PlanningState) {
+    if vars.len() == 1 {
+        debug_assert!(
+            filters
+                .iter()
+                .all(|(_, x)| x.len() == 1 && x[0] == ColumnId::new(0)),
+            "filters={filters:?}"
+        );
+
+        let mut scans = SmallVec::<[SingleScanSpec; 3]>::new();
+
+        // Process cover
+        let atom = cover.atom;
+        let cs = if state.is_atom_constrained(atom) {
+            Default::default()
+        } else {
+            state = state.mark_atom_constrained(atom);
+            ctx.atoms[atom].constraints.slow.clone()
+        };
+        scans.push(SingleScanSpec {
+            atom,
+            column: cover.vars[0],
+            cs,
+        });
+
+        // Process filters
+        for (subatom, _) in filters.iter() {
+            let atom = subatom.atom;
+            let cs = if state.is_atom_constrained(atom) {
+                Default::default()
+            } else {
+                state = state.mark_atom_constrained(atom);
+                ctx.atoms[atom].constraints.slow.clone()
+            };
+            scans.push(SingleScanSpec {
+                atom,
+                column: subatom.vars[0],
+                cs,
+            });
+        }
+
+        return (JoinStage::Intersect { var: vars[0], scans }, state);
+    }
+
+    // FusedIntersect case
+    let atom = cover.atom;
+    let constraints = if state.is_atom_constrained(atom) {
+        Default::default()
+    } else {
+        state = state.mark_atom_constrained(atom);
+        ctx.atoms[atom].constraints.slow.clone()
+    };
+
+    let cover_spec = ScanSpec {
+        to_index: cover,
+        constraints,
+    };
+
+    let mut bind = SmallVec::new();
+    let var_set = &ctx.atoms[atom].var_to_column;
+    for var in vars {
+        bind.push((var_set[&var], var));
+    }
+
+    let mut to_intersect = Vec::with_capacity(filters.len());
+    for (subatom, key_spec) in filters {
+        let atom = subatom.atom;
+        let constraints = if state.is_atom_constrained(atom) {
+            Default::default()
+        } else {
+            state = state.mark_atom_constrained(atom);
+            ctx.atoms[atom].constraints.slow.clone()
+        };
+        let scan = ScanSpec {
+            to_index: subatom,
+            constraints,
+        };
+        to_intersect.push((scan, key_spec));
+    }
+
+    (
+        JoinStage::FusedIntersect {
+            cover: cover_spec,
+            bind,
+            to_intersect,
+        },
+        state,
+    )
 }

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeMap, iter, mem, sync::Arc};
 
 use crate::{
-    numeric_id::{DenseIdMap, NumericId}, query::SymbolMap
+    numeric_id::{DenseIdMap, NumericId},
+    query::SymbolMap,
 };
 use fixedbitset::FixedBitSet;
 use smallvec::{SmallVec, smallvec};

--- a/core-relations/src/row_buffer/mod.rs
+++ b/core-relations/src/row_buffer/mod.rs
@@ -4,7 +4,7 @@ use core::slice;
 use std::{cell::Cell, mem, ops::Deref};
 
 use crate::numeric_id::NumericId;
-use egglog_concurrency::ParallelVecWriter;
+use egglog_concurrency::{ParallelVecWriter, parallel_writer::write_cell_slice};
 use rayon::iter::ParallelIterator;
 use smallvec::SmallVec;
 
@@ -426,7 +426,7 @@ impl ParallelRowBufWriter {
 
     pub(crate) fn append_contents(&self, rows: &RowBuffer) -> RowId {
         assert_eq!(rows.n_columns, self.buf.n_columns);
-        let start_off = self.vec.write_cell_slice(rows.data.as_slice());
+        let start_off = write_cell_slice(&self.vec, rows.data.as_slice());
         debug_assert_eq!(start_off % self.buf.n_columns, 0);
         RowId::from_usize(start_off / self.buf.n_columns)
     }

--- a/core-relations/src/tests.rs
+++ b/core-relations/src/tests.rs
@@ -277,6 +277,98 @@ fn line_graph_2_test(strat: PlanStrategy) {
     assert_eq!(expected, got);
 }
 
+fn intersection_test(strat: PlanStrategy) {
+    let mut db = Database::default();
+    let rst = (0..3).map(|_| {
+        SortedWritesTable::new(
+            2,
+            2,
+            None,
+            vec![],
+            Box::new(move |_, a, b, _| {
+                if a != b {
+                    panic!("merge not supported")
+                } else {
+                    false
+                }
+            }),
+        )
+    });
+    let u = SortedWritesTable::new(
+        1,
+        1,
+        None,
+        vec![],
+        Box::new(move |_, a, b, _| {
+            if a != b {
+                panic!("merge not supported")
+            } else {
+                false
+            }
+        }),
+    );
+    let rst_ids = rst
+        .map(|r| db.add_table(r, iter::empty(), iter::empty()))
+        .collect::<Vec<TableId>>();
+    let u_id = db.add_table(u, iter::empty(), iter::empty());
+
+    for rel in rst_ids.iter() {
+        let mut rel_buf = db.new_buffer(*rel);
+        for x in 0..10 {
+            rel_buf.stage_insert(&[Value::new(x), Value::new(x)]);
+        }
+    }
+    db.merge_all();
+
+    let mut rsb = RuleSetBuilder::new(&mut db);
+    let mut query = rsb.new_rule();
+    query.set_plan_strategy(strat);
+    // R(x), S(x), T(x), x > 5 => U(X)
+    let x = query.new_var_named("x");
+    for rel in rst_ids.iter() {
+        query
+            .add_atom(
+                *rel,
+                &[x.into(), x.into()],
+                &[Constraint::GtConst {
+                    col: ColumnId::new(0),
+                    val: Value::new(5),
+                }],
+            )
+            .unwrap();
+    }
+    let mut rule = query.build();
+    rule.insert(u_id, &[x.into()]).unwrap();
+    rule.build();
+    let rule_set = rsb.build();
+
+    assert!(db.run_rule_set(&rule_set, ReportLevel::TimeOnly).changed);
+
+    let expected = Vec::from_iter((6..10).map(|x| vec![Value::new(x)]));
+
+    let u_table = db.get_table(u_id);
+    let all = u_table.all();
+    let vals = u_table.scan(all.as_ref());
+    let mut got = Vec::from_iter(vals.iter().map(|(_, row)| row.to_vec()));
+    got.sort();
+    assert_eq!(expected, got);
+}
+
+#[test]
+fn intersection_test_fj_puresize() {
+    intersection_test(PlanStrategy::PureSize);
+}
+
+#[test]
+fn intersection_test_fj_mincover() {
+    intersection_test(PlanStrategy::MinCover);
+}
+
+#[test]
+fn intersection_test_gj() {
+    intersection_test(PlanStrategy::Gj);
+}
+
 #[test]
 fn minimal_ac() {
     let MathEgraph {

--- a/core-relations/src/tests.rs
+++ b/core-relations/src/tests.rs
@@ -1195,8 +1195,8 @@ fn early_stop() {
     // External function that triggers early stop after 1000 calls.
     let call_count = Arc::new(Mutex::new(0usize));
     let call_count_clone = call_count.clone();
-    let stop_trigger = db.add_external_function(Box::new(make_external_func(
-        move |exec_state, args| {
+    let stop_trigger =
+        db.add_external_function(Box::new(make_external_func(move |exec_state, args| {
             let mut count = call_count_clone.lock().unwrap();
             *count += 1;
 
@@ -1206,8 +1206,7 @@ fn early_stop() {
 
             let [x] = args else { panic!() };
             Some(*x)
-        },
-    )));
+        })));
 
     // Build a rule that scans the table and calls the external function.
     let mut rsb = RuleSetBuilder::new(&mut db);


### PR DESCRIPTION
This PR

* Breaks down the planner into an immutable context and a mutable state, and makes code more modular at a few places.
* Removes unnecessary references
* Fixes a minor bug that can happen if directly using core-relations (when using free join to plan R(x, x), S(x, x), T(x, x), the JoinStage will contain only one variable but a `filter` can have two columns)