### PR TITLE
Add initial early stopping support and use it for panic functions

### DIFF
--- a/core-relations/src/action/tests.rs
+++ b/core-relations/src/action/tests.rs
@@ -101,3 +101,50 @@ fn fill_vec() {
         }
     }
 }
+
+#[test]
+fn test_early_stop_initial_state() {
+    empty_execution_state!(state);
+    assert!(!state.should_stop());
+}
+
+#[test]
+fn test_early_stop_trigger() {
+    empty_execution_state!(state);
+    assert!(!state.should_stop());
+
+    state.trigger_early_stop();
+
+    assert!(state.should_stop());
+}
+
+#[test]
+fn test_early_stop_shared_across_clones() {
+    empty_execution_state!(state1);
+    let state2 = state1.clone();
+
+    assert!(!state1.should_stop());
+    assert!(!state2.should_stop());
+
+    state1.trigger_early_stop();
+
+    assert!(state1.should_stop());
+    assert!(state2.should_stop());
+}
+
+#[test]
+fn test_early_stop_multiple_clones() {
+    empty_execution_state!(state1);
+    let state2 = state1.clone();
+    let state3 = state2.clone();
+
+    assert!(!state1.should_stop());
+    assert!(!state2.should_stop());
+    assert!(!state3.should_stop());
+
+    state2.trigger_early_stop();
+
+    assert!(state1.should_stop());
+    assert!(state2.should_stop());
+    assert!(state3.should_stop());
+}

--- a/core-relations/src/table_shortcuts.rs
+++ b/core-relations/src/table_shortcuts.rs
@@ -12,7 +12,9 @@ use crate::{
 /// do not actually use one.
 macro_rules! empty_execution_state {
     ($es:ident) => {
+        #[allow(unused_mut)]
         let mut __db = $crate::free_join::Database::default();
+        #[allow(unused_mut)]
         let mut $es =
             $crate::action::ExecutionState::new(__db.read_only_view(), Default::default());
     };


### PR DESCRIPTION
This change adds a simple global "early stop" flag to ExecutionState that can be used to short-circuit rule execution. This doesn't let you get match limits or node limits on their own, but it is a useful primitive towards that feature.

Relevant to #671 