### PR TITLE
Refactor TermDag API to use Ids and add pretty printer for proofs

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,4 +1,4 @@
-use crate::termdag::{Term, TermDag};
+use crate::termdag::{TermDag, TermId};
 use crate::util::{HashMap, HashSet};
 use crate::*;
 use std::collections::VecDeque;
@@ -431,7 +431,7 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
         termdag: &mut TermDag,
         value: Value,
         sort: &ArcSort,
-    ) -> Term {
+    ) -> TermId {
         self.reconstruct_termdag_node_helper(egraph, termdag, value, sort, &mut Default::default())
     }
 
@@ -441,16 +441,16 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
         termdag: &mut TermDag,
         value: Value,
         sort: &ArcSort,
-        cache: &mut HashMap<(Value, String), Term>,
-    ) -> Term {
+        cache: &mut HashMap<(Value, String), TermId>,
+    ) -> TermId {
         let key = (value, sort.name().to_owned());
         if let Some(term) = cache.get(&key) {
-            return term.clone();
+            return *term;
         }
 
         let term = if sort.is_container_sort() {
             let elements = sort.inner_values(egraph.backend.container_values(), value);
-            let mut ch_terms: Vec<Term> = Vec::new();
+            let mut ch_terms: Vec<TermId> = Vec::new();
             for ch in elements.iter() {
                 ch_terms.push(
                     self.reconstruct_termdag_node_helper(egraph, termdag, ch.1, &ch.0, cache),
@@ -469,7 +469,7 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
                 .unwrap()
                 .get(&value)
                 .unwrap();
-            let mut ch_terms: Vec<Term> = Vec::new();
+            let mut ch_terms: Vec<TermId> = Vec::new();
             let ch_sorts = &egraph.functions.get(func_name).unwrap().schema.input;
             for (value, sort) in hyperedge.iter().zip(ch_sorts.iter()) {
                 ch_terms.push(
@@ -482,7 +482,7 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
             sort.reconstruct_termdag_base(egraph.backend.base_values(), value, termdag)
         };
 
-        cache.insert(key, term.clone());
+        cache.insert(key, term);
         term
     }
 
@@ -496,7 +496,7 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
         termdag: &mut TermDag,
         value: Value,
         sort: ArcSort,
-    ) -> Option<(C, Term)> {
+    ) -> Option<(C, TermId)> {
         match self.compute_cost_node(egraph, value, &sort) {
             Some(best_cost) => {
                 log::debug!("Best cost for the extract root: {:?}", best_cost);
@@ -520,7 +520,7 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
         egraph: &EGraph,
         termdag: &mut TermDag,
         value: Value,
-    ) -> Option<(C, Term)> {
+    ) -> Option<(C, TermId)> {
         assert!(
             self.rootsorts.len() == 1,
             "extract_best requires a single rootsort"
@@ -544,7 +544,7 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
         value: Value,
         nvariants: usize,
         sort: ArcSort,
-    ) -> Vec<(C, Term)> {
+    ) -> Vec<(C, TermId)> {
         debug_assert!(self.rootsorts.iter().any(|s| { s.name() == sort.name() }));
 
         if sort.is_eq_sort() {
@@ -583,11 +583,11 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
                 egraph.backend.for_each(func.backend_id, find_root_variants);
             }
 
-            let mut res: Vec<(C, Term)> = Vec::new();
+            let mut res: Vec<(C, TermId)> = Vec::new();
             root_variants.sort();
             root_variants.truncate(nvariants);
             for (cost, func_name, hyperedge) in root_variants {
-                let mut ch_terms: Vec<Term> = Vec::new();
+                let mut ch_terms: Vec<TermId> = Vec::new();
                 let ch_sorts = &egraph.functions.get(&func_name).unwrap().schema.input;
                 // zip truncates the row
                 for (value, sort) in hyperedge.iter().zip(ch_sorts.iter()) {
@@ -618,7 +618,7 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
         termdag: &mut TermDag,
         value: Value,
         nvariants: usize,
-    ) -> Vec<(C, Term)> {
+    ) -> Vec<(C, TermId)> {
         assert!(
             self.rootsorts.len() == 1,
             "extract_variants requires a single rootsort"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -771,7 +771,7 @@ impl EGraph {
     }
 
     /// Extract a value to a [`TermDag`] and [`TermId`] in the [`TermDag`].
-    /// Note that the `TermDag` may contain a superset of the nodes in the `Term`.
+    /// Note that the `TermDag` may contain a superset of the nodes referenced by the returned `TermId`.
     /// See also [`EGraph::extract_value_to_string`] for convenience.
     pub fn extract_value_with_cost_model<CM: CostModel<DefaultCost> + 'static>(
         &self,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -661,7 +661,7 @@ pub trait BaseSort: Any + Send + Sync + Debug {
     type Base: BaseValue;
     fn name(&self) -> &str;
     fn register_primitives(&self, _eg: &mut EGraph) {}
-    fn reconstruct_termdag(&self, _: &BaseValues, _: Value, _: &mut TermDag) -> Term;
+    fn reconstruct_termdag(&self, _: &BaseValues, _: Value, _: &mut TermDag) -> TermId;
 
     fn to_arcsort(self) -> ArcSort
     where
@@ -705,7 +705,7 @@ impl<T: BaseSort> Sort for BaseSortImpl<T> {
         base_values: &BaseValues,
         value: Value,
         termdag: &mut TermDag,
-    ) -> Term {
+    ) -> TermId {
         self.0.reconstruct_termdag(base_values, value, termdag)
     }
 }
@@ -728,8 +728,8 @@ pub trait ContainerSort: Any + Send + Sync + Debug {
         _: &ContainerValues,
         _: Value,
         _: &mut TermDag,
-        _: Vec<Term>,
-    ) -> Term;
+        _: Vec<TermId>,
+    ) -> TermId;
     fn serialized_name(&self, container_values: &ContainerValues, value: Value) -> String;
 
     fn to_arcsort(self) -> ArcSort
@@ -797,8 +797,8 @@ impl<T: ContainerSort> Sort for ContainerSortImpl<T> {
         container_values: &ContainerValues,
         value: Value,
         termdag: &mut TermDag,
-        element_terms: Vec<Term>,
-    ) -> Term {
+        element_terms: Vec<TermId>,
+    ) -> TermId {
         self.0
             .reconstruct_termdag(container_values, value, termdag, element_terms)
     }

--- a/src/sort/bigint.rs
+++ b/src/sort/bigint.rs
@@ -54,7 +54,7 @@ impl BaseSort for BigIntSort {
         base_values: &BaseValues,
         value: Value,
         termdag: &mut TermDag,
-    ) -> Term {
+    ) -> TermId {
         let bigint = base_values.unwrap::<Z>(value);
 
         let as_string = termdag.lit(Literal::String(bigint.0.to_string()));

--- a/src/sort/bigrat.rs
+++ b/src/sort/bigrat.rs
@@ -110,7 +110,7 @@ impl BaseSort for BigRatSort {
         base_values: &BaseValues,
         value: Value,
         termdag: &mut TermDag,
-    ) -> Term {
+    ) -> TermId {
         let rat = base_values.unwrap::<Q>(value);
         let numer = rat.numer();
         let denom = rat.denom();

--- a/src/sort/bool.rs
+++ b/src/sort/bool.rs
@@ -24,7 +24,7 @@ impl BaseSort for BoolSort {
         base_values: &BaseValues,
         value: Value,
         termdag: &mut TermDag,
-    ) -> Term {
+    ) -> TermId {
         let b = base_values.unwrap::<bool>(value);
 
         termdag.lit(Literal::Bool(b))

--- a/src/sort/f64.rs
+++ b/src/sort/f64.rs
@@ -48,7 +48,7 @@ impl BaseSort for F64Sort {
         base_values: &BaseValues,
         value: Value,
         termdag: &mut TermDag,
-    ) -> Term {
+    ) -> TermId {
         let f = base_values.unwrap::<F>(value);
 
         termdag.lit(Literal::Float(f.0))

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -206,8 +206,8 @@ impl Sort for FunctionSort {
         container_values: &ContainerValues,
         value: Value,
         termdag: &mut TermDag,
-        mut element_terms: Vec<Term>,
-    ) -> Term {
+        mut element_terms: Vec<TermId>,
+    ) -> TermId {
         let name = &container_values
             .get_val::<FunctionContainer>(value)
             .unwrap()

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -69,7 +69,7 @@ impl BaseSort for I64Sort {
         base_values: &BaseValues,
         value: Value,
         termdag: &mut TermDag,
-    ) -> Term {
+    ) -> TermId {
         let i = base_values.unwrap::<i64>(value);
 
         termdag.lit(Literal::Int(i))

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -172,12 +172,12 @@ impl ContainerSort for MapSort {
         _container_values: &ContainerValues,
         _value: Value,
         termdag: &mut TermDag,
-        element_terms: Vec<Term>,
-    ) -> Term {
+        element_terms: Vec<TermId>,
+    ) -> TermId {
         let mut term = termdag.app("map-empty".into(), vec![]);
 
         for x in element_terms.chunks(2) {
-            term = termdag.app("map-insert".into(), vec![term, x[0].clone(), x[1].clone()])
+            term = termdag.app("map-insert".into(), vec![term, x[0], x[1]])
         }
 
         term

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -117,8 +117,8 @@ pub trait Sort: Any + Send + Sync + Debug {
         container_values: &ContainerValues,
         value: Value,
         termdag: &mut TermDag,
-        element_terms: Vec<Term>,
-    ) -> Term {
+        element_terms: Vec<TermId>,
+    ) -> TermId {
         let _container_values = container_values;
         let _value = value;
         let _termdag = termdag;
@@ -132,7 +132,7 @@ pub trait Sort: Any + Send + Sync + Debug {
         base_values: &BaseValues,
         value: Value,
         termdag: &mut TermDag,
-    ) -> Term {
+    ) -> TermId {
         let _base_values = base_values;
         let _value = value;
         let _termdag = termdag;

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -152,8 +152,8 @@ impl ContainerSort for MultiSetSort {
         _container_values: &ContainerValues,
         _value: Value,
         termdag: &mut TermDag,
-        element_terms: Vec<Term>,
-    ) -> Term {
+        element_terms: Vec<TermId>,
+    ) -> TermId {
         termdag.app("multiset-of".into(), element_terms)
     }
 

--- a/src/sort/set.rs
+++ b/src/sort/set.rs
@@ -145,8 +145,8 @@ impl ContainerSort for SetSort {
         _container_values: &ContainerValues,
         _value: Value,
         termdag: &mut TermDag,
-        element_terms: Vec<Term>,
-    ) -> Term {
+        element_terms: Vec<TermId>,
+    ) -> TermId {
         termdag.app("set-of".into(), element_terms)
     }
 

--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -27,7 +27,7 @@ impl BaseSort for StringSort {
         base_values: &BaseValues,
         value: Value,
         termdag: &mut TermDag,
-    ) -> Term {
+    ) -> TermId {
         let s = base_values.unwrap::<S>(value);
 
         termdag.lit(Literal::String(s.0))

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -15,7 +15,7 @@ impl BaseSort for UnitSort {
         _base_values: &BaseValues,
         _value: Value,
         termdag: &mut TermDag,
-    ) -> Term {
+    ) -> TermId {
         termdag.lit(Literal::Unit)
     }
 }

--- a/src/sort/vec.rs
+++ b/src/sort/vec.rs
@@ -144,8 +144,8 @@ impl ContainerSort for VecSort {
         _container_values: &ContainerValues,
         _value: Value,
         termdag: &mut TermDag,
-        element_terms: Vec<Term>,
-    ) -> Term {
+        element_terms: Vec<TermId>,
+    ) -> TermId {
         if element_terms.is_empty() {
             termdag.app("vec-empty".into(), vec![])
         } else {

--- a/src/termdag.rs
+++ b/src/termdag.rs
@@ -59,11 +59,20 @@ impl RenderedTerm {
     }
 }
 
+/// Context used during term rendering with let-binding support.
 struct TermRenderContext<'a> {
+    /// Generator for fresh variable names used in let bindings.
     fresh: &'a mut SymbolGen,
+    /// Maps each term ID to the number of times it is referenced in the DAG.
+    /// Terms referenced multiple times are candidates for let-binding.
     ref_counts: &'a HashMap<TermId, usize>,
+    /// Maps each term ID to its size (number of nodes in the subtree).
+    /// Used to decide whether a term is large enough to warrant let-binding.
     sizes: &'a HashMap<TermId, usize>,
+    /// Maps term IDs to the variable names they've been bound to.
+    /// Once a term is let-bound, subsequent references use this name.
     bindings: HashMap<TermId, String>,
+    /// Buffer where let bindings are accumulated as they are created.
     buf: &'a mut String,
     /// Function that takes a constructor name and returns the name hint to use
     name_hint_fn: Box<dyn Fn(&str) -> String + 'a>,

--- a/src/termdag.rs
+++ b/src/termdag.rs
@@ -1,3 +1,4 @@
+use crate::util::{FreshGen, HashMap, HashSet, SymbolGen};
 use crate::*;
 use std::fmt::Write;
 
@@ -22,6 +23,10 @@ pub struct TermDag {
     nodes: IndexSet<Term>,
 }
 
+const MAX_PRETTY_LINE_WIDTH: usize = 80;
+const PRETTY_INDENT_STEP: usize = 2;
+const MIN_SHARED_TERM_SIZE: usize = 4;
+
 #[macro_export]
 macro_rules! match_term_app {
     ($e:expr; $body:tt) => {
@@ -32,6 +37,61 @@ macro_rules! match_term_app {
             }
             _ => panic!("not an app")
         }
+    }
+}
+
+#[derive(Clone)]
+struct RenderedTerm {
+    inline: String,
+    pretty: String,
+}
+
+impl RenderedTerm {
+    fn from_symbol(symbol: String) -> Self {
+        Self {
+            inline: symbol.clone(),
+            pretty: symbol,
+        }
+    }
+
+    fn is_multiline(&self) -> bool {
+        self.pretty.contains('\n')
+    }
+}
+
+struct TermRenderContext<'a> {
+    fresh: &'a mut SymbolGen,
+    ref_counts: &'a HashMap<TermId, usize>,
+    sizes: &'a HashMap<TermId, usize>,
+    bindings: HashMap<TermId, String>,
+    buf: &'a mut String,
+    /// Function that takes a constructor name and returns the name hint to use
+    name_hint_fn: Box<dyn Fn(&str) -> String + 'a>,
+}
+
+impl<'a> TermRenderContext<'a> {
+    fn new<F>(
+        fresh: &'a mut SymbolGen,
+        ref_counts: &'a HashMap<TermId, usize>,
+        sizes: &'a HashMap<TermId, usize>,
+        buf: &'a mut String,
+        name_hint_fn: F,
+    ) -> Self
+    where
+        F: Fn(&str) -> String + 'a,
+    {
+        Self {
+            fresh,
+            ref_counts,
+            sizes,
+            bindings: HashMap::default(),
+            buf,
+            name_hint_fn: Box::new(name_hint_fn),
+        }
+    }
+
+    fn get_name_hint(&self, constructor_name: &str) -> String {
+        (self.name_hint_fn)(constructor_name)
     }
 }
 
@@ -59,38 +119,34 @@ impl TermDag {
     /// and insert into the DAG if it is not already present.
     ///
     /// Panics if any of the children are not already in the DAG.
-    pub fn app(&mut self, sym: String, children: Vec<Term>) -> Term {
-        let node = Term::App(sym, children.iter().map(|c| self.lookup(c)).collect());
+    pub fn app(&mut self, sym: String, children: Vec<TermId>) -> TermId {
+        let node = Term::App(sym, children);
 
-        self.add_node(&node);
-
-        node
+        self.add_node(&node)
     }
 
     /// Make and return a [`Term::Lit`] with the given literal, and insert into
     /// the DAG if it is not already present.
-    pub fn lit(&mut self, lit: Literal) -> Term {
+    pub fn lit(&mut self, lit: Literal) -> TermId {
         let node = Term::Lit(lit);
 
-        self.add_node(&node);
-
-        node
+        self.add_node(&node)
     }
 
     /// Make and return a [`Term::Var`] with the given symbol, and insert into
     /// the DAG if it is not already present.
-    pub fn var(&mut self, sym: String) -> Term {
+    pub fn var(&mut self, sym: String) -> TermId {
         let node = Term::Var(sym);
 
-        self.add_node(&node);
-
-        node
+        self.add_node(&node)
     }
 
-    fn add_node(&mut self, node: &Term) {
-        if self.nodes.get(node).is_none() {
+    fn add_node(&mut self, node: &Term) -> TermId {
+        self.nodes.get_index_of(node).unwrap_or_else(|| {
+            let id = self.nodes.len();
             self.nodes.insert(node.clone());
-        }
+            id
+        })
     }
 
     /// Recursively converts the given expression to a term.
@@ -98,38 +154,241 @@ impl TermDag {
     /// This involves inserting every subexpression into this DAG. Because
     /// TermDags are hashconsed, the resulting term is guaranteed to maximally
     /// share subterms.
-    pub fn expr_to_term(&mut self, expr: &GenericExpr<String, String>) -> Term {
+    pub fn expr_to_term(&mut self, expr: &GenericExpr<String, String>) -> TermId {
         let res = match expr {
             GenericExpr::Lit(_, lit) => Term::Lit(lit.clone()),
             GenericExpr::Var(_, v) => Term::Var(v.to_owned()),
             GenericExpr::Call(_, op, args) => {
-                let args = args
-                    .iter()
-                    .map(|a| {
-                        let term = self.expr_to_term(a);
-                        self.lookup(&term)
-                    })
-                    .collect();
+                let args = args.iter().map(|a| self.expr_to_term(a)).collect();
                 Term::App(op.clone(), args)
             }
         };
-        self.add_node(&res);
-        res
+        self.add_node(&res)
     }
 
     /// Recursively converts the given term to an expression.
     ///
     /// Panics if the term contains subterms that are not in the DAG.
-    pub fn term_to_expr(&self, term: &Term, span: Span) -> Expr {
+    pub fn term_to_expr(&self, term: &TermId, span: Span) -> Expr {
+        let term = self.get(*term);
         match term {
             Term::Lit(lit) => Expr::Lit(span, lit.clone()),
             Term::Var(v) => Expr::Var(span, v.clone()),
             Term::App(op, args) => {
                 let args: Vec<_> = args
                     .iter()
-                    .map(|a| self.term_to_expr(self.get(*a), span.clone()))
+                    .map(|a| self.term_to_expr(a, span.clone()))
                     .collect();
                 Expr::Call(span, op.clone(), args)
+            }
+        }
+    }
+
+    /// Prints a term to a string, putting let bindings for shared subterms.
+    pub fn to_string_with_let(&self, fresh: &mut SymbolGen, term_id: TermId) -> String {
+        self.to_string_with_let_and_hint(fresh, term_id, "t")
+    }
+
+    /// Prints a term to a string, putting let bindings for shared subterms.
+    /// Uses the given name hint for generated variable names.
+    pub fn to_string_with_let_and_hint(
+        &self,
+        fresh: &mut SymbolGen,
+        term_id: TermId,
+        name_hint: &str,
+    ) -> String {
+        let mut buf = String::new();
+        let hint = name_hint.to_string();
+        let final_str =
+            self.to_string_with_let_internal(fresh, term_id, &mut buf, move |_| hint.clone());
+        format!("{buf}\n{final_str}")
+    }
+
+    /// Prints a term to a string, putting let bindings for shared subterms in `buf`.
+    /// Returns the final string representation of the term.
+    /// The `name_hint_fn` takes a constructor name and returns the hint to use for that term.
+    pub(crate) fn to_string_with_let_internal<'a, F>(
+        &self,
+        fresh: &'a mut SymbolGen,
+        term_id: TermId,
+        buf: &'a mut String,
+        name_hint_fn: F,
+    ) -> String
+    where
+        F: Fn(&str) -> String + 'a,
+    {
+        let (ref_counts, sizes) = self.collect_term_stats(term_id);
+        let mut ctx = TermRenderContext::new(fresh, &ref_counts, &sizes, buf, name_hint_fn);
+        let rendered = self.render_term(term_id, &mut ctx, false, 0);
+        rendered.pretty
+    }
+
+    fn render_term(
+        &self,
+        term_id: TermId,
+        ctx: &mut TermRenderContext,
+        allow_binding: bool,
+        indent: usize,
+    ) -> RenderedTerm {
+        if let Some(existing) = ctx.bindings.get(&term_id) {
+            return RenderedTerm::from_symbol(existing.clone());
+        }
+
+        // Get the constructor name for the hint function (if it's an App)
+        let constructor_name = match self.get(term_id) {
+            Term::App(name, _) => Some(name.clone()),
+            _ => None,
+        };
+
+        let rendered = match self.get(term_id) {
+            Term::App(name, children) => {
+                let mut child_renderings = Vec::with_capacity(children.len());
+                for child_id in children {
+                    let rendered_child =
+                        self.render_term(*child_id, ctx, true, indent + PRETTY_INDENT_STEP);
+                    child_renderings.push(rendered_child);
+                }
+
+                let mut inline = format!("({}", name);
+                for child in &child_renderings {
+                    inline.push(' ');
+                    inline.push_str(&child.inline);
+                }
+                inline.push(')');
+
+                let inline_len = inline.chars().count();
+                let exceeds_width = indent + inline_len > MAX_PRETTY_LINE_WIDTH;
+                let child_multiline = child_renderings.iter().any(|c| c.is_multiline());
+
+                let pretty = if exceeds_width || child_multiline {
+                    if child_renderings.is_empty() {
+                        format!("({})", name)
+                    } else {
+                        let mut s = format!("({}", name);
+                        for (idx, child) in child_renderings.iter().enumerate() {
+                            s.push('\n');
+                            s.push_str(&" ".repeat(indent + PRETTY_INDENT_STEP));
+                            s.push_str(&child.pretty);
+                            if idx + 1 == child_renderings.len() {
+                                s.push(')');
+                            }
+                        }
+                        s
+                    }
+                } else {
+                    inline.clone()
+                };
+
+                RenderedTerm { inline, pretty }
+            }
+            Term::Lit(lit) => {
+                let repr = format!("{lit}");
+                RenderedTerm {
+                    inline: repr.clone(),
+                    pretty: repr,
+                }
+            }
+            Term::Var(v) => RenderedTerm {
+                inline: v.clone(),
+                pretty: v.clone(),
+            },
+        };
+
+        let term_size = *ctx.sizes.get(&term_id).unwrap_or(&1);
+        let repeat_count = ctx.ref_counts.get(&term_id).copied().unwrap_or(1);
+        let should_bind = allow_binding && repeat_count > 1 && term_size >= MIN_SHARED_TERM_SIZE;
+
+        if should_bind {
+            let hint = ctx.get_name_hint(constructor_name.as_deref().unwrap_or("t"));
+            let let_name = ctx.fresh.fresh(&hint);
+            self.push_binding(ctx.buf, &let_name, &rendered.pretty);
+            ctx.bindings.insert(term_id, let_name.clone());
+            RenderedTerm::from_symbol(let_name)
+        } else {
+            rendered
+        }
+    }
+
+    fn push_binding(&self, buf: &mut String, name: &str, body: &str) {
+        let trimmed = body.trim_end();
+        if trimmed.is_empty() {
+            buf.push_str("(let ");
+            buf.push_str(name);
+            buf.push_str(")\n");
+            return;
+        }
+
+        if trimmed.contains('\n') {
+            buf.push_str("(let ");
+            buf.push_str(name);
+            buf.push('\n');
+            let lines: Vec<&str> = trimmed.lines().collect();
+            for (idx, line) in lines.iter().enumerate() {
+                buf.push_str(&" ".repeat(PRETTY_INDENT_STEP));
+                buf.push_str(line);
+                if idx + 1 < lines.len() {
+                    buf.push('\n');
+                } else {
+                    buf.push(')');
+                    buf.push('\n');
+                }
+            }
+        } else {
+            buf.push_str("(let ");
+            buf.push_str(name);
+            buf.push(' ');
+            buf.push_str(trimmed);
+            buf.push_str(")\n");
+        }
+    }
+
+    fn collect_term_stats(
+        &self,
+        term_id: TermId,
+    ) -> (HashMap<TermId, usize>, HashMap<TermId, usize>) {
+        let mut counts = HashMap::default();
+        let mut visited = HashSet::default();
+        self.collect_term_ref_counts_inner(term_id, &mut counts, &mut visited);
+
+        let mut sizes = HashMap::default();
+        self.compute_term_size(term_id, &mut sizes);
+
+        (counts, sizes)
+    }
+
+    fn compute_term_size(&self, term_id: TermId, sizes: &mut HashMap<TermId, usize>) -> usize {
+        if let Some(size) = sizes.get(&term_id) {
+            return *size;
+        }
+
+        let size = match self.get(term_id) {
+            Term::App(_, children) => {
+                1 + children
+                    .iter()
+                    .map(|child| self.compute_term_size(*child, sizes))
+                    .sum::<usize>()
+            }
+            Term::Lit(_) | Term::Var(_) => 1,
+        };
+
+        sizes.insert(term_id, size);
+        size
+    }
+
+    fn collect_term_ref_counts_inner(
+        &self,
+        term_id: TermId,
+        counts: &mut HashMap<TermId, usize>,
+        visited: &mut HashSet<TermId>,
+    ) {
+        *counts.entry(term_id).or_insert(0) += 1;
+        if !visited.insert(term_id) {
+            return;
+        }
+
+        if let Term::App(_, children) = self.get(term_id) {
+            for child in children {
+                self.collect_term_ref_counts_inner(*child, counts, visited);
             }
         }
     }
@@ -137,14 +396,13 @@ impl TermDag {
     /// Converts the given term to a string.
     ///
     /// Panics if the term or any of its subterms are not in the DAG.
-    pub fn to_string(&self, term: &Term) -> String {
+    pub fn to_string(&self, term: TermId) -> String {
         let mut result = String::new();
         // subranges of the `result` string containing already stringified subterms
         let mut ranges = HashMap::<TermId, (usize, usize)>::default();
-        let id = self.lookup(term);
         // use a stack to avoid stack overflow
 
-        let mut stack = vec![(id, false, None)];
+        let mut stack = vec![(term, false, None)];
         while let Some((id, space_before, mut start_index)) = stack.pop() {
             if space_before {
                 result.push(' ');
@@ -189,9 +447,9 @@ impl TermDag {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ast::*, span};
+    use crate::{ast::*, span, util::SymbolGen};
 
-    fn parse_term(s: &str) -> (TermDag, Term) {
+    fn parse_term(s: &str) -> (TermDag, TermId) {
         let e = Parser::default().get_expr_from_string(None, s).unwrap();
         let mut td = TermDag::default();
         let t = td.expr_to_term(&e);
@@ -230,11 +488,12 @@ mod tests {
     fn test_match_term_app() {
         let s = r#"(f (g x y) x y (g x y))"#;
         let (td, t) = parse_term(s);
-        match_term_app!(t; {
+        let term = td.get(t);
+        match_term_app!(term; {
             ("f", [_, x, _, _]) => {
                 let span = span!();
                 assert_eq!(
-                    td.term_to_expr(td.get(*x), span.clone()),
+                    td.term_to_expr(x, span.clone()),
                     crate::ast::GenericExpr::Var(span, "x".to_owned())
                 )
             }
@@ -246,14 +505,14 @@ mod tests {
     fn test_to_string() {
         let s = r#"(f (g x y) x y (g x y))"#;
         let (td, t) = parse_term(s);
-        assert_eq!(td.to_string(&t), s);
+        assert_eq!(td.to_string(t), s);
     }
 
     #[test]
     fn test_lookup() {
         let s = r#"(f (g x y) x y (g x y))"#;
         let (td, t) = parse_term(s);
-        assert_eq!(td.lookup(&t), td.size() - 1);
+        assert_eq!(t, td.size() - 1);
     }
 
     #[test]
@@ -263,8 +522,77 @@ mod tests {
         let x = td.var("x".into());
         let y = td.var("y".into());
         let seven = td.lit(7.into());
-        let g = td.app("g".into(), vec![x.clone(), y.clone()]);
-        let t2 = td.app("f".into(), vec![g.clone(), x, seven, g]);
+        let g = td.app("g".into(), vec![x, y]);
+        let t2 = td.app("f".into(), vec![g, x, seven, g]);
         assert_eq!(t, t2);
+    }
+
+    #[test]
+    fn test_to_string_with_let_inlines_small_terms() {
+        let s = r#"(f (g x) (g x) (g x))"#;
+        let (td, t) = parse_term(s);
+        let mut sym = SymbolGen::new(String::new());
+        let result = td.to_string_with_let(&mut sym, t);
+        // No let bindings means result is just newline + repr
+        assert_eq!(result.trim(), s);
+    }
+
+    #[test]
+    fn test_to_string_with_let_shares_large_terms() {
+        let g_segment = ["(g a b)"; 8].join(" ");
+        let s = format!("(f (h {0}) (h {0}))", g_segment);
+        let (td, t) = parse_term(&s);
+        let mut buf = String::new();
+        let mut sym = SymbolGen::new(String::new());
+        let repr = td.to_string_with_let_internal(&mut sym, t, &mut buf, |_| "t".to_string());
+        let first_line = buf.lines().next().expect("expected let binding");
+        assert!(first_line.starts_with("(let t"));
+        assert!(buf.contains("(h"));
+        let has_lonely_paren = buf.lines().any(|line| line.trim() == ")");
+        assert!(
+            !has_lonely_paren,
+            "unexpected standalone closing paren in\n{buf}"
+        );
+        assert!(buf.trim_end().ends_with(')'));
+        assert_eq!(repr, "(f t0 t0)");
+    }
+
+    #[test]
+    fn test_to_string_with_let_wraps_long_lines() {
+        let s = r#"(verylongfunctionnamewithmanysegments alpha_argument beta_argument gamma_argument delta_argument epsilon_argument zeta_argument)"#;
+        let (td, t) = parse_term(s);
+        let mut sym = SymbolGen::new(String::new());
+        let result = td.to_string_with_let(&mut sym, t);
+        // No let bindings, so result is just newline + repr
+        let repr = result.trim();
+        assert!(repr.contains('\n'));
+        assert!(repr.contains("\n  "));
+        assert!(repr.starts_with("(verylongfunctionnamewithmanysegments"));
+    }
+
+    #[test]
+    fn test_multiline_parentheses_share_final_line() {
+        let expr = "(Trans (Add 3 2) (start) (Rule (Add 3 2) (Add 2 3) (name rw1) (premises t1) (substitution (a 2) (b 3))) t)";
+        let (td, t) = parse_term(expr);
+        let mut buf = String::new();
+        let mut sym = SymbolGen::new(String::new());
+        let repr = td.to_string_with_let_internal(&mut sym, t, &mut buf, |_| "t".to_string());
+        assert!(repr.contains('\n'), "expected multiline output, got {repr}");
+        let has_lonely_paren = repr.lines().any(|line| line.trim() == ")");
+        assert!(
+            !has_lonely_paren,
+            "found standalone closing paren line in {repr}"
+        );
+        if let Some(last_line) = repr.lines().last() {
+            assert!(
+                last_line.ends_with(')'),
+                "last line should end with closing paren: {last_line}"
+            );
+        }
+        let buf_has_lonely = buf.lines().any(|line| line.trim() == ")");
+        assert!(
+            !buf_has_lonely,
+            "bindings contain standalone closing paren in\n{buf}"
+        );
     }
 }

--- a/src/termdag.rs
+++ b/src/termdag.rs
@@ -125,8 +125,8 @@ impl TermDag {
         self.add_node(&node)
     }
 
-    /// Make and return a [`Term::Lit`] with the given literal, and insert into
-    /// the DAG if it is not already present.
+    /// Make a [`Term::Lit`] with the given literal and return its [`TermId`],
+    /// inserting it into the DAG if it is not already present.
     pub fn lit(&mut self, lit: Literal) -> TermId {
         let node = Term::Lit(lit);
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -532,10 +532,12 @@ fn test_subsumed_unextractable_action_extract() {
         )
         .unwrap();
     // Originally should give back numeric term
-    assert!(matches!(
-        outputs[0],
-        CommandOutput::ExtractBest(_, _, Term::App(ref s, ..)) if s == "cheap"
-    ));
+    assert!(match &outputs[0] {
+        CommandOutput::ExtractBest(termdag, _, term_id) => {
+            matches!(termdag.get(*term_id), Term::App(s, ..) if s == "cheap")
+        }
+        _ => false,
+    });
     // Then if we make one as subsumed, it should give back the variable term
     let outputs = egraph
         .parse_and_run_program(
@@ -546,10 +548,12 @@ fn test_subsumed_unextractable_action_extract() {
             "#,
         )
         .unwrap();
-    assert!(matches!(
-        outputs[0],
-        CommandOutput::ExtractBest(_, _, Term::App(ref s, ..)) if s == "exp"
-    ));
+    assert!(match &outputs[0] {
+        CommandOutput::ExtractBest(termdag, _, term_id) => {
+            matches!(termdag.get(*term_id), Term::App(s, ..) if s == "exp")
+        }
+        _ => false,
+    });
 }
 
 #[test]
@@ -576,10 +580,12 @@ fn test_subsume_unextractable_insert_and_merge() {
             "#,
         )
         .unwrap();
-    assert!(matches!(
-        outputs[0],
-        CommandOutput::ExtractBest(_, _, Term::App(ref s, ..)) if s == "exp"
-    ));
+    assert!(match &outputs[0] {
+        CommandOutput::ExtractBest(termdag, _, term_id) => {
+            matches!(termdag.get(*term_id), Term::App(s, ..) if s == "exp")
+        }
+        _ => false,
+    });
 }
 
 #[test]

--- a/tests/terms.rs
+++ b/tests/terms.rs
@@ -8,7 +8,7 @@ fn test_termdag_public() {
     let x = td.var("x".into());
     let seven = td.lit(7.into());
     let f = td.app("f".into(), vec![x, seven]);
-    assert_eq!(td.to_string(&f), "(f x 7)");
+    assert_eq!(td.to_string(f), "(f x 7)");
 }
 
 #[test]
@@ -24,10 +24,10 @@ fn test_termdag_malicious_client() {
     let td2 = td.clone();
     let y = td.var("y".into());
     // now td = [0 |-> x, 1 |-> y]
-    let f = td.app("f".into(), vec![x.clone(), y.clone()]);
+    let f = td.app("f".into(), vec![x, y]);
     // f is Term::App("f", [0, 1])
-    assert_eq!(td.to_string(&f), "(f x y)");
+    assert_eq!(td.to_string(f), "(f x y)");
     // recall that td2 = [0 |-> x]
     // notice that f refers to index 1, so this crashes:
-    td2.to_string(&f);
+    td2.to_string(f);
 }

--- a/tests/terms.rs
+++ b/tests/terms.rs
@@ -25,7 +25,7 @@ fn test_termdag_malicious_client() {
     let y = td.var("y".into());
     // now td = [0 |-> x, 1 |-> y]
     let f = td.app("f".into(), vec![x, y]);
-    // f is Term::App("f", [0, 1])
+    // f is a TermId (2) that refers to Term::App("f", [0, 1])
     assert_eq!(td.to_string(f), "(f x y)");
     // recall that td2 = [0 |-> x]
     // notice that f refers to index 1, so this crashes:


### PR DESCRIPTION
This PR makes the termdag API use ids, simplifying code (especially incoming proof code)
It also adds a pretty printer which is good for printing terms with intermediate let bindings. It's used for proofs in the incoming PR. 