### PR TITLE
Add index for union-find in proof mode

### DIFF
--- a/src/proofs/proof_encoding.md
+++ b/src/proofs/proof_encoding.md
@@ -7,6 +7,9 @@ This makes proof production easier, since all equality reasoning is explicit and
   can be instrumented with proof tracking.
 The term encoding adds an explicit union-find structure per sort, and maintains it via
   rules that run during scheduled maintenance.
+To speed up rebuild queries, each sort now uses two UF tables:
+  a constructor UF table (`UF_<Sort>`) that stores raw parent edges, and a function UF table
+  (`UF_<Sort>f`) that stores the current parent for each term as an index.
 For efficiency, every constructor becomes two tables:
   a term table that stores the actual terms, and a view table storing representative terms along with their e-class (stored as the leader term).
 The term encoding enables proof tracking, done at the
@@ -38,12 +41,14 @@ Lowering the program with the term encoding expands to a bunch of new egglog, wh
 ```text
 (ruleset parent)
 (ruleset single_parent)
+(ruleset uf_function_index)
 (ruleset rebuilding)
 (ruleset rebuilding_cleanup)
 (ruleset delete_subsume_ruleset)
 ```
 
 *The new rulesets* orchestrate new rules for per-sort union-find tables (`parent` and `single_parent`),
+building a fast function index over UF (`uf_function_index`),
 rebuild-time congruence (`rebuilding` + `rebuilding_cleanup`), and deferred deletions/subsumptions (`delete_subsume_ruleset`).
 
 ```text
@@ -52,6 +57,7 @@ rebuild-time congruence (`rebuilding` + `rebuilding_cleanup`), and deferred dele
        rebuilding_cleanup ;; cleanup merged rows
        (saturate single_parent) ;; ensure each term points to single parent
        (saturate parent) ;; transitively close parent links
+       (saturate uf_function_index) ;; mirror UF constructor rows into UF function index
        rebuilding) ;; find new equalities via congruence
     delete_subsume_ruleset) ;; process deletions/subsumptions
 ```
@@ -63,6 +69,7 @@ rebuild-time congruence (`rebuilding` + `rebuilding_cleanup`), and deferred dele
 (sort Math)
 (sort uf)
 (constructor UF_Math (Math Math) uf)
+(function UF_Mathf (Math) Math :merge new)
 (rule ((UF_Math a b)
       (UF_Math b c)
       (!= b c))
@@ -76,24 +83,32 @@ rebuild-time congruence (`rebuilding` + `rebuilding_cleanup`), and deferred dele
      ((delete (UF_Math a b))
       (UF_Math b c))
        :ruleset single_parent :name "singleparentuf_update")
+(rule ((UF_Math a b))
+      ((set (UF_Mathf a) b))
+       :ruleset uf_function_index :name "uf_function_index_update")
 ```
 
-*The union-find* tables for each sort store the equivalence 
+*The union-find* tables for each sort store the equivalence
   classes of terms of that sort.
-A couple rules ensure the union-find is kept up to date as 
-  equalities are added.
+`UF_<Sort>` remains the source of truth for UF maintenance updates,
+  while `UF_<Sort>f` is a function-backed index used by rebuild rules.
+A couple rules ensure the constructor UF is kept up to date as
+  equalities are added, and the indexing ruleset mirrors those rows
+  into the function UF.
 We use the `ordering-max` and `ordering-min` egglog primitives
   to define an arbitrary ordering on terms based on insertion order,
   so that we can deterministically choose which term becomes the parent
   in the union-find structure.
 
 **Important invariant:** every representative term must have a self-loop
-  entry in the union-find table (e.g., `(UF_Math v v)`).
+  entry in the constructor union-find table (e.g., `(UF_Math v v)`).
 This is because the rebuild rules query the union-find for every
   eq-sort column simultaneously, so a missing entry for any column
   prevents the rule from firing even when other columns have changed.
 Self-loops are added in `add_term_and_view` whenever a constructor
   value is created.
+The `uf_function_index` ruleset then copies those rows into
+  `UF_<Sort>f`, so representatives also satisfy `(= (UF_<Sort>f v) v)`.
 We may want to remove this invariant in the future if we move
   to a different encoding, saving some space and time.
 
@@ -122,7 +137,7 @@ The view tables are kept up to date during rebuilding.
       ((UF_Math (ordering-max new old) (ordering-min new old)))
        :ruleset rebuilding :name "congruence_rule")
 (rule ((AddView c0 c1 c2)
-       (UF_Math c2 c2_leader)
+       (= c2_leader (UF_Mathf c2))
        (guard
          (or (bool-!= c2 c2_leader))))
       ((AddView c0 c1 c2_leader)
@@ -135,6 +150,9 @@ The congruence rule adds equalities to the union-find table when two constructor
   have equal arguments.
 The rebuild rule updates view tables so that views
   point to representative terms for child e-classes.
+Rebuild rules read representatives from `UF_<Sort>f` (function lookup)
+  rather than joining directly on `UF_<Sort>` (constructor rows),
+  which avoids expensive UF constructor joins during rebuilding.
 
 ```text
 (function v2 () Math :no-merge)

--- a/src/proofs/proof_encoding.rs
+++ b/src/proofs/proof_encoding.rs
@@ -7,6 +7,7 @@ use crate::*;
 #[derive(Clone)]
 pub(crate) struct EncodingState {
     pub uf_parent: HashMap<String, String>,
+    pub uf_function: HashMap<String, String>,
     /// Maps sort name -> proof function name (set from :internal-proof-func annotation).
     pub proof_func_parent: HashMap<String, String>,
     pub term_header_added: bool,
@@ -23,6 +24,7 @@ impl EncodingState {
     pub(crate) fn new(symbol_gen: &mut SymbolGen) -> Self {
         Self {
             uf_parent: HashMap::default(),
+            uf_function: HashMap::default(),
             proof_func_parent: HashMap::default(),
             term_header_added: false,
             original_typechecking: None,
@@ -97,8 +99,10 @@ impl<'a> ProofInstrumentor<'a> {
     /// canonical representative.
     fn declare_sort(&mut self, sort_name: &str) -> Vec<Command> {
         let pname = self.uf_name(sort_name);
+        let uf_function_name = self.uf_function_name(sort_name);
         let fresh_sort = self.egraph.parser.symbol_gen.fresh("uf");
         let fresh_name = self.egraph.parser.symbol_gen.fresh("uf_update");
+        let uf_function_index_name = self.egraph.parser.symbol_gen.fresh("uf_function_index");
         let proof_tables = if self.egraph.proof_state.proofs_enabled {
             let term_proof_name = self.term_proof_name(sort_name);
             let proof_type = self.proof_names().proof_datatype.clone();
@@ -162,10 +166,13 @@ impl<'a> ProofInstrumentor<'a> {
 
         let path_compress_ruleset_name = self.proof_names().path_compress_ruleset_name.clone();
         let single_parent_ruleset_name = self.proof_names().single_parent_ruleset_name.clone();
+        let uf_function_index_ruleset_name =
+            self.proof_names().uf_function_index_ruleset_name.clone();
 
         self.parse_program(&format!(
             "(sort {fresh_sort})
              (constructor {pname} ({sort_name} {sort_name}) {fresh_sort} :internal-hidden)
+             (function {uf_function_name} ({sort_name}) {sort_name} :merge new :internal-hidden)
              {to_ast_constructor_code}
              {proof_tables}
              ;; performs path compression, ensuring each term points to the representative
@@ -189,6 +196,11 @@ impl<'a> ProofInstrumentor<'a> {
                     {proof_action2})
                    :ruleset {single_parent_ruleset_name}
                    :name \"singleparent{fresh_name}\")
+             ;; mirrors UF rows into a function-backed UF index for faster rebuild lookups
+             (rule (({pname} a b))
+                   ((set ({uf_function_name} a) b))
+                   :ruleset {uf_function_index_ruleset_name}
+                   :name \"{uf_function_index_name}\")
                    ",
         ))
     }
@@ -506,19 +518,19 @@ impl<'a> ProofInstrumentor<'a> {
         for (i, ty) in types.iter().enumerate() {
             if ty.is_eq_sort() {
                 let leader_var = format!("c{i}_leader_");
-                let parent = self.uf_name(ty.name());
+                let uf_function_name = self.uf_function_name(ty.name());
                 let ci = child(i);
 
                 if self.egraph.proof_state.proofs_enabled {
                     let uf_proof = self.uf_proof_name(ty.name());
                     let proof_var = self.fresh_var();
                     uf_queries.push(format!(
-                        "({parent} {ci} {leader_var})
+                        "(= {leader_var} ({uf_function_name} {ci}))
                          (= {proof_var} ({uf_proof} {ci} {leader_var}))"
                     ));
                     uf_proof_vars.push(Some(proof_var));
                 } else {
-                    uf_queries.push(format!("({parent} {ci} {leader_var})"));
+                    uf_queries.push(format!("(= {leader_var} ({uf_function_name} {ci}))"));
                     uf_proof_vars.push(None);
                 }
 
@@ -1117,6 +1129,7 @@ impl<'a> ProofInstrumentor<'a> {
     fn rebuild(&mut self) -> Schedule {
         let path_compress_ruleset = self.proof_names().path_compress_ruleset_name.clone();
         let single_parent = self.proof_names().single_parent_ruleset_name.clone();
+        let uf_function_index = self.proof_names().uf_function_index_ruleset_name.clone();
         let rebuilding_cleanup_ruleset = self.proof_names().rebuilding_cleanup_ruleset_name.clone();
         let rebuilding_ruleset = self.proof_names().rebuilding_ruleset_name.clone();
         let delete_ruleset = self.proof_names().delete_subsume_ruleset_name.clone();
@@ -1126,6 +1139,7 @@ impl<'a> ProofInstrumentor<'a> {
                   {rebuilding_cleanup_ruleset}
                   (saturate {single_parent})
                   (saturate {path_compress_ruleset})
+                  (saturate {uf_function_index})
                   {rebuilding_ruleset})
               {delete_ruleset})"
         ))

--- a/src/proofs/proof_encoding_helpers.rs
+++ b/src/proofs/proof_encoding_helpers.rs
@@ -108,11 +108,7 @@ impl ProofInstrumentor<'_> {
         if let Some(name) = self.egraph.proof_state.uf_function.get(sort) {
             name.clone()
         } else {
-            let fresh_name = self
-                .egraph
-                .parser
-                .symbol_gen
-                .fresh(&format!("UF_{sort}f"));
+            let fresh_name = self.egraph.parser.symbol_gen.fresh(&format!("UF_{sort}f"));
             self.egraph
                 .proof_state
                 .uf_function

--- a/src/proofs/proof_encoding_helpers.rs
+++ b/src/proofs/proof_encoding_helpers.rs
@@ -32,6 +32,7 @@ pub(crate) struct EncodingNames {
     pub(crate) fn_to_term_sort: HashMap<String, String>,
     pub(crate) uf_proof_name: HashMap<String, String>,
     pub(crate) single_parent_ruleset_name: String,
+    pub(crate) uf_function_index_ruleset_name: String,
     pub(crate) pcons: String,
     pub(crate) pnil: String,
     // Ruleset names
@@ -73,6 +74,7 @@ impl EncodingNames {
             fn_to_term_sort: HashMap::default(),
             uf_proof_name: HashMap::default(),
             single_parent_ruleset_name: symbol_gen.fresh("single_parent"),
+            uf_function_index_ruleset_name: symbol_gen.fresh("uf_function_index"),
             pcons: symbol_gen.fresh("PCons"),
             pnil: symbol_gen.fresh("PNil"),
             path_compress_ruleset_name: symbol_gen.fresh("parent"),
@@ -97,6 +99,23 @@ impl ProofInstrumentor<'_> {
             self.egraph
                 .proof_state
                 .uf_parent
+                .insert(sort.to_string(), fresh_name.clone());
+            fresh_name
+        }
+    }
+
+    pub(crate) fn uf_function_name(&mut self, sort: &str) -> String {
+        if let Some(name) = self.egraph.proof_state.uf_function.get(sort) {
+            name.clone()
+        } else {
+            let fresh_name = self
+                .egraph
+                .parser
+                .symbol_gen
+                .fresh(&format!("UF_{sort}f"));
+            self.egraph
+                .proof_state
+                .uf_function
                 .insert(sort.to_string(), fresh_name.clone());
             fresh_name
         }
@@ -148,9 +167,11 @@ impl ProofInstrumentor<'_> {
              (ruleset {})
              (ruleset {})
              (ruleset {})
+             (ruleset {})
              (ruleset {})",
             self.proof_names().path_compress_ruleset_name,
             self.proof_names().single_parent_ruleset_name,
+            self.proof_names().uf_function_index_ruleset_name,
             self.proof_names().rebuilding_ruleset_name,
             self.proof_names().rebuilding_cleanup_ruleset_name,
             self.proof_names().delete_subsume_ruleset_name

--- a/src/proofs/snapshots/egglog__proofs__proof_tests__tests__doc_example_add_function1.snap
+++ b/src/proofs/snapshots/egglog__proofs__proof_tests__tests__doc_example_add_function1.snap
@@ -1,16 +1,17 @@
 ---
 source: src/proofs/proof_tests.rs
-assertion_line: 48
 expression: snapshot
 ---
 (ruleset __parent)
 (ruleset __single_parent)
+(ruleset __uf_function_index)
 (ruleset __rebuilding)
 (ruleset __rebuilding_cleanup)
 (ruleset __delete_subsume_ruleset)
 (sort Math :internal-uf __UF_Math)
 (sort __uf)
 (constructor __UF_Math (Math Math) __uf :internal-hidden)
+(function __UF_Mathf (Math) Math :merge new :internal-hidden)
 (rule ((__UF_Math a b)
        (__UF_Math b c)
        (!= b c))
@@ -24,6 +25,9 @@ expression: snapshot
       ((delete (__UF_Math a b))
        (__UF_Math b c))
         :ruleset __single_parent :name "singleparent__uf_update")
+(rule ((__UF_Math a b))
+      ((set (__UF_Mathf a) b))
+        :ruleset __uf_function_index :name "__uf_function_index1")
 (sort __view)
 (constructor Add (i64 i64) Math :unextractable :internal-hidden)
 (constructor __AddView (i64 i64 Math) __view :term-constructor Add)
@@ -45,7 +49,7 @@ expression: snapshot
       ((subsume (__AddView c0_ c1_ out)))
         :ruleset __delete_subsume_ruleset :name "__delete_rule_subsume")
 (rule ((__AddView c0_ c1_ c2_)
-       (__UF_Math c2_ c2_leader_)
+       (= c2_leader_ (__UF_Mathf c2_))
        (guard (or (bool-!= c2_ c2_leader_))))
       ((__AddView c0_ c1_ c2_leader_)
        (delete (__AddView c0_ c1_ c2_)))
@@ -54,7 +58,7 @@ expression: snapshot
 (set (__v) (Add 1 2))
 (__AddView 1 2 (__v ))
 (__UF_Math (ordering-max (__v ) (__v )) (ordering-min (__v ) (__v )))
-(run-schedule (seq (saturate (seq (run __rebuilding_cleanup) (saturate (run __single_parent)) (saturate (run __parent)) (run __rebuilding))) (run __delete_subsume_ruleset)))
+(run-schedule (seq (saturate (seq (run __rebuilding_cleanup) (saturate (run __single_parent)) (saturate (run __parent)) (saturate (run __uf_function_index)) (run __rebuilding))) (run __delete_subsume_ruleset)))
 (rule ((__AddView a b __v1))
       ((let __v3 (Add a b))
        (__AddView a b __v3)
@@ -67,4 +71,4 @@ expression: snapshot
 (check (__AddView 1 2 __v5)
 (__AddView 2 1 __v6)
 (= __v5 __v6))
-(run-schedule (seq (saturate (seq (run __rebuilding_cleanup) (saturate (run __single_parent)) (saturate (run __parent)) (run __rebuilding))) (run __delete_subsume_ruleset)))
+(run-schedule (seq (saturate (seq (run __rebuilding_cleanup) (saturate (run __single_parent)) (saturate (run __parent)) (saturate (run __uf_function_index)) (run __rebuilding))) (run __delete_subsume_ruleset)))

--- a/src/proofs/snapshots/egglog__proofs__proof_tests__tests__doc_example_add_function2.snap
+++ b/src/proofs/snapshots/egglog__proofs__proof_tests__tests__doc_example_add_function2.snap
@@ -4,6 +4,7 @@ expression: snapshot
 ---
 (ruleset __parent)
 (ruleset __single_parent)
+(ruleset __uf_function_index)
 (ruleset __rebuilding)
 (ruleset __rebuilding_cleanup)
 (ruleset __delete_subsume_ruleset)
@@ -39,4 +40,4 @@ expression: snapshot
         :ruleset __delete_subsume_ruleset :name "__delete_rule_subsume")
 (check (__addView 0 0 __n)
 (= __n 0))
-(run-schedule (seq (saturate (seq (run __rebuilding_cleanup) (saturate (run __single_parent)) (saturate (run __parent)) (run __rebuilding))) (run __delete_subsume_ruleset)))
+(run-schedule (seq (saturate (seq (run __rebuilding_cleanup) (saturate (run __single_parent)) (saturate (run __parent)) (saturate (run __uf_function_index)) (run __rebuilding))) (run __delete_subsume_ruleset)))


### PR DESCRIPTION
Optimize proof mode by adding a function index.

This makes bigger benchmarks dramatically faster, looks like it's slower for a couple small ones