### PR TITLE
Move the thread pool field to core-relations

### DIFF
--- a/core-relations/benches/writes.rs
+++ b/core-relations/benches/writes.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use divan::{Bencher, counter::ItemsCount};
-use egglog_core_relations::{Database, SortedWritesTable, Table, Value};
+use egglog_core_relations::{Database, SortedWritesTable, Table, ThreadPool, Value};
 use egglog_numeric_id::NumericId;
 use rand::{Rng, rng};
 use rayon::{
@@ -110,6 +112,7 @@ fn bench_workload<const K: usize, const C: usize>(
         .num_threads(threads)
         .build()
         .unwrap();
+    let index_building_pool = Arc::new(ThreadPool::new(threads));
     let workload_size = workload.len();
     bench
         .with_inputs(|| {
@@ -124,6 +127,7 @@ fn bench_workload<const K: usize, const C: usize>(
                         out.extend_from_slice(new);
                         old != new
                     }),
+                    index_building_pool.clone(),
                 ),
             )
         })

--- a/core-relations/src/common.rs
+++ b/core-relations/src/common.rs
@@ -211,3 +211,63 @@ impl SubsetTracker {
         res
     }
 }
+
+/// A WASM-compatible thread pool wrapper.
+pub struct ThreadPool {
+    #[cfg(not(target_family = "wasm"))]
+    pool: Arc<rayon::ThreadPool>,
+}
+
+impl ThreadPool {
+    pub fn new(n_threads: usize) -> Self {
+        #[cfg(target_family = "wasm")]
+        if n_threads > 1 {
+            panic!("cannot use more than 1 thread on wasm");
+        }
+        #[cfg(not(target_family = "wasm"))]
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(n_threads)
+                .build()
+                .unwrap(),
+        );
+        ThreadPool {
+            #[cfg(not(target_family = "wasm"))]
+            pool,
+        }
+    }
+
+    pub(crate) fn install<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R + Send,
+        R: Send,
+    {
+        #[cfg(not(target_family = "wasm"))]
+        return self.pool.install(f);
+        #[cfg(target_family = "wasm")]
+        return f();
+    }
+
+    pub(crate) fn num_threads(&self) -> usize {
+        #[cfg(not(target_family = "wasm"))]
+        return self.pool.current_num_threads();
+        #[cfg(target_family = "wasm")]
+        return 1;
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    pub(crate) fn rayon_pool(&self) -> &rayon::ThreadPool {
+        &self.pool
+    }
+
+    pub(crate) fn broadcast<F, R>(&self, f: F) -> Vec<R>
+    where
+        F: Fn() -> R + Sync,
+        R: Send,
+    {
+        #[cfg(not(target_family = "wasm"))]
+        return self.pool.broadcast(|_| f());
+        #[cfg(target_family = "wasm")]
+        return vec![f()];
+    }
+}

--- a/core-relations/src/containers/mod.rs
+++ b/core-relations/src/containers/mod.rs
@@ -115,7 +115,9 @@ impl ContainerValues {
     }
 
     /// Apply the given rebuild to the contents of each container.
-    pub fn rebuild_all(
+    ///
+    /// Private to this crate because it needs to be run in the e-graph's thread pool.
+    pub(crate) fn rebuild_all(
         &mut self,
         table_id: TableId,
         table: &WrappedTable,

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -309,7 +309,12 @@ impl TrieNode {
     fn size(&self) -> usize {
         self.subset.size()
     }
-    fn get_cached_index(&self, col: ColumnId, info: &TableInfo) -> Arc<ColumnIndex> {
+    fn get_cached_index(
+        &self,
+        col: ColumnId,
+        info: &TableInfo,
+        pool: &Arc<crate::ThreadPool>,
+    ) -> Arc<ColumnIndex> {
         self.cached_subsets.get_or_init(|| {
             // Pre-size the vector so we do not need to borrow it mutably to initialize the index.
             let mut vec: Pooled<ColumnIndexes> = with_pool_set(|ps| ps.get());
@@ -317,7 +322,9 @@ impl TrieNode {
             Arc::new(vec)
         })[col]
             .get_or_init(|| {
-                let col_index = info.table.group_by_col(self.subset.as_ref(), col);
+                let col_index = info
+                    .table
+                    .group_by_col(self.subset.as_ref(), col, pool.clone());
                 Arc::new(col_index)
             })
             .clone()
@@ -411,19 +418,33 @@ impl<'a> JoinState<'a> {
                 if cols.len() != 1 {
                     DynamicIndex::Cached {
                         intersect_outer,
-                        table: get_index_from_tableinfo(info, &cols).clone(),
+                        table: get_index_from_tableinfo(info, &cols, &self.db.index_building_pool)
+                            .clone(),
                     }
                 } else {
                     DynamicIndex::CachedColumn {
                         intersect_outer,
-                        table: get_column_index_from_tableinfo(info, cols[0]).clone(),
+                        table: get_column_index_from_tableinfo(
+                            info,
+                            cols[0],
+                            &self.db.index_building_pool,
+                        )
+                        .clone(),
                     }
                 }
             } else if cols.len() != 1 {
                 // NB: we should have a caching strategy for non-column indexes.
-                DynamicIndex::Dynamic(info.table.group_by_key(subset.as_ref(), &cols))
+                DynamicIndex::Dynamic(info.table.group_by_key(
+                    subset.as_ref(),
+                    &cols,
+                    self.db.index_building_pool.clone(),
+                ))
             } else {
-                DynamicIndex::DynamicColumn(trie_node.get_cached_index(cols[0], info))
+                DynamicIndex::DynamicColumn(trie_node.get_cached_index(
+                    cols[0],
+                    info,
+                    &self.db.index_building_pool,
+                ))
             };
         Prober {
             node: trie_node,

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -153,6 +153,15 @@ impl Prober {
 
 impl Database {
     pub fn run_rule_set(&mut self, rule_set: &RuleSet, report_level: ReportLevel) -> RuleSetReport {
+        let pool = self.pool.clone();
+        pool.install(|| self.run_rule_set_impl(rule_set, report_level))
+    }
+
+    fn run_rule_set_impl(
+        &mut self,
+        rule_set: &RuleSet,
+        report_level: ReportLevel,
+    ) -> RuleSetReport {
         if rule_set.plans.is_empty() {
             return RuleSetReport::default();
         }
@@ -256,7 +265,7 @@ impl Database {
         let search_and_apply_time = search_and_apply_timer.elapsed();
 
         let merge_timer = Instant::now();
-        let changed = self.merge_all();
+        let changed = self.merge_all_impl();
         let merge_time = merge_timer.elapsed();
 
         RuleSetReport {

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -247,7 +247,7 @@ impl Clone for Counters {
         let mut map = DenseIdMap::new();
         for (k, v) in self.0.iter() {
             // NB: we may want to experiment with Ordering::Relaxed here.
-            map.insert(k, AtomicUsize::new(v.load(Ordering::SeqCst)))
+            map.insert(k, AtomicUsize::new(v.load(Ordering::SeqCst)));
         }
         Counters(map)
     }
@@ -267,7 +267,7 @@ impl Counters {
 /// A collection of tables and indexes over them.
 ///
 /// A database also owns the memory pools used by its tables.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Database {
     // NB: some fields are pub(crate) to allow some internal modules to avoid
     // borrowing the whole table.
@@ -290,15 +290,65 @@ pub struct Database {
     /// This is primarily used to determine whether or not to attempt to do some operations in
     /// parallel.
     total_size_estimate: usize,
+    /// Thread pools for parallel operations.
+    pool: Arc<crate::ThreadPool>,
+    /// A thread pool specifically for parallel hash index construction.
+    ///
+    /// We use a separate thread pool here because callers can construct an index under a lock,
+    /// and we do not want to take a long-running lock in the global thread pool without another
+    /// way to get parallelism.
+    ///
+    /// Earlier solutions using rayon::yield_now() were unreliable.
+    index_building_pool: Arc<crate::ThreadPool>,
+}
+
+impl Default for Database {
+    fn default() -> Self {
+        Database {
+            tables: Default::default(),
+            counters: Default::default(),
+            external_functions: Default::default(),
+            container_values: Default::default(),
+            notification_list: Default::default(),
+            deps: Default::default(),
+            base_values: Default::default(),
+            total_size_estimate: 0,
+            pool: Arc::new(crate::ThreadPool::new(1)),
+            index_building_pool: Arc::new(crate::ThreadPool::new(1)),
+        }
+    }
 }
 
 impl Database {
     /// Create an empty Database.
-    ///
-    /// Queries are executed using the current rayon thread pool, which defaults to the global
-    /// thread pool.
     pub fn new() -> Database {
         Database::default()
+    }
+
+    /// Set the number of threads used for parallel operations.
+    ///
+    /// # Panics
+    ///
+    /// Panics on wasm if `num_threads > 1`.
+    pub fn with_num_threads(mut self, num_threads: usize) -> Self {
+        self.pool = Arc::new(crate::ThreadPool::new(num_threads));
+        self.index_building_pool = Arc::new(crate::ThreadPool::new(num_threads));
+        self
+    }
+
+    /// Return the number of threads in this Database's thread pool.
+    pub fn num_threads(&self) -> usize {
+        return self.pool.num_threads();
+    }
+
+    /// Get a reference to the thread pool used for parallel operations.
+    pub fn thread_pool(&self) -> &Arc<crate::ThreadPool> {
+        &self.pool
+    }
+
+    /// Get a reference to the thread pool used for parallel hash index construction.
+    pub fn index_building_thread_pool(&self) -> &Arc<crate::ThreadPool> {
+        &self.index_building_pool
     }
 
     /// Initialize a new rulse set to run against this database.
@@ -361,15 +411,19 @@ impl Database {
             for id in to_rebuild {
                 tables.push((*id, self.tables.take(*id).unwrap()));
             }
-            tables.par_iter_mut().for_each(|(id, info)| {
-                if info.table.apply_rebuild(
-                    func_id,
-                    &func.table,
-                    next_ts,
-                    &mut ExecutionState::new(self.read_only_view(), Default::default()),
-                ) {
-                    self.notification_list.notify(*id);
-                }
+            let pool = self.pool.clone();
+
+            pool.install(|| {
+                tables.par_iter_mut().for_each(|(id, info)| {
+                    if info.table.apply_rebuild(
+                        func_id,
+                        &func.table,
+                        next_ts,
+                        &mut ExecutionState::new(self.read_only_view(), Default::default()),
+                    ) {
+                        self.notification_list.notify(*id);
+                    }
+                });
             });
             for (id, info) in tables {
                 self.tables.insert(id, info);
@@ -454,6 +508,7 @@ impl Database {
     ///
     /// Useful for out-of-band insertions into the database.
     pub fn merge_all(&mut self) -> bool {
+        let pool = self.pool.clone();
         let mut ever_changed = false;
         let do_parallel = parallelize_db_level_op(self.total_size_estimate);
         let mut to_merge = IndexSet::default();
@@ -497,14 +552,17 @@ impl Database {
                 }
                 let db = self.read_only_view();
                 changed |= if do_parallel {
-                    tables_merging
-                        .par_iter_mut()
-                        .map(|(_, (info, buffers))| {
-                            let mut es = ExecutionState::new(db, mem::take(buffers));
-                            info.as_mut().unwrap().table.merge(&mut es).added || es.changed
-                        })
-                        .max()
-                        .unwrap_or(false)
+                    let result = pool.install(|| {
+                        tables_merging
+                            .par_iter_mut()
+                            .map(|(_, (info, buffers))| {
+                                let mut es = ExecutionState::new(db, mem::take(buffers));
+                                info.as_mut().unwrap().table.merge(&mut es).added || es.changed
+                            })
+                            .max()
+                            .unwrap_or(false)
+                    });
+                    result
                 } else {
                     tables_merging
                         .iter_mut()
@@ -693,7 +751,7 @@ impl Database {
             // We have or will build an index: upgrade this constraint to
             // 'fast'.
             fast.push(c.clone());
-            let index = get_column_index_from_tableinfo(table_info, col);
+            let index = get_column_index_from_tableinfo(table_info, col, &self.index_building_pool);
             match index.get().unwrap().get_subset(&val) {
                 Some(s) => {
                     with_pool_set(|ps| subset.intersect(s, &ps.get_pool()));
@@ -734,7 +792,7 @@ impl Drop for Database {
         //
         // Calling mem::forget on the egraph can result in much faster execution times.
         with_pool_set(PoolSet::clear);
-        rayon::broadcast(|_| with_pool_set(PoolSet::clear));
+        self.pool.broadcast(|| with_pool_set(PoolSet::clear));
     }
 }
 
@@ -742,11 +800,15 @@ impl Drop for Database {
 ///
 /// This is in a separate function to allow us to reuse it while already
 /// borrowing a `TableInfo`.
-fn get_index_from_tableinfo(table_info: &TableInfo, cols: &[ColumnId]) -> HashIndex {
+fn get_index_from_tableinfo(
+    table_info: &TableInfo,
+    cols: &[ColumnId],
+    pool: &Arc<crate::ThreadPool>,
+) -> HashIndex {
     let index: Arc<_> = table_info.indexes.get_or_insert(cols.into(), || {
         Arc::new(ResettableOnceLock::new(Index::new(
             cols.to_vec(),
-            TupleIndex::new(cols.len()),
+            TupleIndex::new(cols.len(), pool.clone()),
         )))
     });
     index.get_or_update(|index| {
@@ -764,11 +826,15 @@ fn get_index_from_tableinfo(table_info: &TableInfo, cols: &[ColumnId]) -> HashIn
 /// The core logic behind getting and updating a column index.
 ///
 /// This is the single-column analog to [`get_index_from_tableinfo`].
-fn get_column_index_from_tableinfo(table_info: &TableInfo, col: ColumnId) -> HashColumnIndex {
+fn get_column_index_from_tableinfo(
+    table_info: &TableInfo,
+    col: ColumnId,
+    pool: &Arc<crate::ThreadPool>,
+) -> HashColumnIndex {
     let index: Arc<_> = table_info.column_indexes.get_or_insert(col, || {
         Arc::new(ResettableOnceLock::new(Index::new(
             vec![col],
-            ColumnIndex::new(),
+            ColumnIndex::new(pool.clone()),
         )))
     });
     index.get_or_update(|index| {

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -552,7 +552,6 @@ impl Database {
                 }
                 let db = self.read_only_view();
                 changed |= if do_parallel {
-                    
                     pool.install(|| {
                         tables_merging
                             .par_iter_mut()

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -388,7 +388,10 @@ impl Database {
     pub fn rebuild_containers(&mut self, table_id: TableId) -> bool {
         let mut containers = mem::take(&mut self.container_values);
         let table = &self.tables[table_id].table;
-        let res = self.with_execution_state(|state| containers.rebuild_all(table_id, table, state));
+        let pool = self.pool.clone();
+        let res = pool.install(|| {
+            self.with_execution_state(|state| containers.rebuild_all(table_id, table, state))
+        });
         self.container_values = containers;
         res
     }
@@ -405,25 +408,31 @@ impl Database {
         to_rebuild: &[TableId],
         next_ts: Value,
     ) -> bool {
+        let pool = self.pool.clone();
+        pool.install(|| self.apply_rebuild_impl(func_id, to_rebuild, next_ts))
+    }
+
+    fn apply_rebuild_impl(
+        &mut self,
+        func_id: TableId,
+        to_rebuild: &[TableId],
+        next_ts: Value,
+    ) -> bool {
         let func = self.tables.take(func_id).unwrap();
         if parallelize_db_level_op(self.total_size_estimate) {
             let mut tables = Vec::with_capacity(to_rebuild.len());
             for id in to_rebuild {
                 tables.push((*id, self.tables.take(*id).unwrap()));
             }
-            let pool = self.pool.clone();
-
-            pool.install(|| {
-                tables.par_iter_mut().for_each(|(id, info)| {
-                    if info.table.apply_rebuild(
-                        func_id,
-                        &func.table,
-                        next_ts,
-                        &mut ExecutionState::new(self.read_only_view(), Default::default()),
-                    ) {
-                        self.notification_list.notify(*id);
-                    }
-                });
+            tables.par_iter_mut().for_each(|(id, info)| {
+                if info.table.apply_rebuild(
+                    func_id,
+                    &func.table,
+                    next_ts,
+                    &mut ExecutionState::new(self.read_only_view(), Default::default()),
+                ) {
+                    self.notification_list.notify(*id);
+                }
             });
             for (id, info) in tables {
                 self.tables.insert(id, info);
@@ -443,7 +452,7 @@ impl Database {
             }
         }
         self.tables.insert(func_id, func);
-        self.merge_all()
+        self.merge_all_impl()
     }
 
     /// Run `f` with access to an `ExecutionState` mapped to this database.
@@ -509,6 +518,10 @@ impl Database {
     /// Useful for out-of-band insertions into the database.
     pub fn merge_all(&mut self) -> bool {
         let pool = self.pool.clone();
+        pool.install(|| self.merge_all_impl())
+    }
+
+    fn merge_all_impl(&mut self) -> bool {
         let mut ever_changed = false;
         let do_parallel = parallelize_db_level_op(self.total_size_estimate);
         let mut to_merge = IndexSet::default();
@@ -552,16 +565,14 @@ impl Database {
                 }
                 let db = self.read_only_view();
                 changed |= if do_parallel {
-                    pool.install(|| {
-                        tables_merging
-                            .par_iter_mut()
-                            .map(|(_, (info, buffers))| {
-                                let mut es = ExecutionState::new(db, mem::take(buffers));
-                                info.as_mut().unwrap().table.merge(&mut es).added || es.changed
-                            })
-                            .max()
-                            .unwrap_or(false)
-                    })
+                    tables_merging
+                        .par_iter_mut()
+                        .map(|(_, (info, buffers))| {
+                            let mut es = ExecutionState::new(db, mem::take(buffers));
+                            info.as_mut().unwrap().table.merge(&mut es).added || es.changed
+                        })
+                        .max()
+                        .unwrap_or(false)
                 } else {
                     tables_merging
                         .iter_mut()
@@ -617,6 +628,11 @@ impl Database {
     /// elesewhere. The `merge_all` method runs merges to a fixed point to avoid
     /// surprises here.
     pub fn merge_table(&mut self, table: TableId) -> bool {
+        let pool = self.pool.clone();
+        pool.install(|| self.merge_table_impl(table))
+    }
+
+    fn merge_table_impl(&mut self, table: TableId) -> bool {
         let mut info = self.tables.unwrap_val(table);
         self.total_size_estimate = self.total_size_estimate.wrapping_sub(info.table.len());
         let table_changed = info.table.merge(&mut ExecutionState::new(

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -338,7 +338,7 @@ impl Database {
 
     /// Return the number of threads in this Database's thread pool.
     pub fn num_threads(&self) -> usize {
-        return self.pool.num_threads();
+        self.pool.num_threads()
     }
 
     /// Get a reference to the thread pool used for parallel operations.
@@ -552,7 +552,8 @@ impl Database {
                 }
                 let db = self.read_only_view();
                 changed |= if do_parallel {
-                    let result = pool.install(|| {
+                    
+                    pool.install(|| {
                         tables_merging
                             .par_iter_mut()
                             .map(|(_, (info, buffers))| {
@@ -561,8 +562,7 @@ impl Database {
                             })
                             .max()
                             .unwrap_or(false)
-                    });
-                    result
+                    })
                 } else {
                     tables_merging
                         .iter_mut()

--- a/core-relations/src/hash_index/mod.rs
+++ b/core-relations/src/hash_index/mod.rs
@@ -8,7 +8,6 @@ use std::{
 use crate::numeric_id::{IdVec, NumericId, define_id};
 use egglog_concurrency::{Notification, ReadOptimizedLock};
 use hashbrown::HashTable;
-use once_cell::sync::Lazy;
 use rayon::iter::ParallelIterator;
 use rustc_hash::FxHasher;
 
@@ -110,6 +109,10 @@ impl<TI: IndexBase> Index<TI> {
     pub(crate) fn len(&self) -> usize {
         self.table.len()
     }
+
+    pub(crate) fn thread_pool(&self) -> &Arc<crate::ThreadPool> {
+        self.table.thread_pool()
+    }
 }
 
 pub(crate) struct SubsetTable {
@@ -158,6 +161,8 @@ pub(crate) trait IndexBase {
     fn for_each(&self, f: impl FnMut(&Self::Key, SubsetRef));
     /// The number of keys in the index.
     fn len(&self) -> usize;
+    /// The thread pool used for parallel index building. Used when cloning an index.
+    fn thread_pool(&self) -> &Arc<crate::ThreadPool>;
 
     fn merge_parallel(&mut self, cols: &[ColumnId], table: WrappedTableRef, subset: SubsetRef);
 }
@@ -181,6 +186,7 @@ pub struct ColumnIndex {
     // A specialized index used when we are indexing on a single column.
     shard_data: ShardData,
     shards: IdVec<ShardId, ColumnIndexShard>,
+    pool: Arc<crate::ThreadPool>,
 }
 
 impl IndexBase for ColumnIndex {
@@ -262,7 +268,7 @@ impl IndexBase for ColumnIndex {
             }
         };
 
-        run_in_thread_pool_and_block(&THREAD_POOL, || {
+        run_in_thread_pool_and_block(&self.pool, || {
             rayon::in_place_scope(|inner| {
                 let mut cur = Offset::new(0);
                 loop {
@@ -303,6 +309,10 @@ impl IndexBase for ColumnIndex {
             });
         });
     }
+
+    fn thread_pool(&self) -> &Arc<crate::ThreadPool> {
+        &self.pool
+    }
 }
 
 /// This function is an alternative for [`rayon::ThreadPool::install`] that doesn't steal work from
@@ -316,7 +326,18 @@ impl IndexBase for ColumnIndex {
 /// held. In particular, if another task on the thread pool _itself_ attempts to aquire the same
 /// lock, this can cause a deadlock. We saw this in the tests for this crate. The relevant lock
 /// are those around individual indexes stored in the database-level index cache.
-fn run_in_thread_pool_and_block<'a>(pool: &rayon::ThreadPool, f: impl FnMut() + Send + 'a) {
+fn run_in_thread_pool_and_block<'a>(pool: &crate::ThreadPool, f: impl FnMut() + Send + 'a) {
+    #[cfg(not(target_family = "wasm"))]
+    run_in_rayon_pool_and_block(pool.rayon_pool(), f);
+    #[cfg(target_family = "wasm")]
+    {
+        let mut f = f;
+        f();
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn run_in_rayon_pool_and_block<'a>(pool: &rayon::ThreadPool, f: impl FnMut() + Send + 'a) {
     // NB: We don't need the heap allocations here. But we are only calling this function if
     // we are about to do a bunch of work, so clarify is probably going to be better than (even
     // more) unsafe code.
@@ -343,7 +364,7 @@ fn run_in_thread_pool_and_block<'a>(pool: &rayon::ThreadPool, f: impl FnMut() + 
 }
 
 impl ColumnIndex {
-    pub(crate) fn new() -> ColumnIndex {
+    pub(crate) fn new(pool: Arc<crate::ThreadPool>) -> ColumnIndex {
         with_pool_set(|ps| {
             let shard_data = ShardData::new(num_shards());
             let mut shards = IdVec::with_capacity(shard_data.n_shards());
@@ -351,7 +372,11 @@ impl ColumnIndex {
                 table: ps.get(),
                 subsets: SubsetBuffer::default(),
             });
-            ColumnIndex { shard_data, shards }
+            ColumnIndex {
+                shard_data,
+                shards,
+                pool,
+            }
         })
     }
 }
@@ -369,17 +394,22 @@ pub struct TupleIndex {
     // (u32, RowId) instead of RowId. Trades copying off for indirections.
     shard_data: ShardData,
     shards: IdVec<ShardId, TupleIndexShard>,
+    pool: Arc<crate::ThreadPool>,
 }
 
 impl TupleIndex {
-    pub(crate) fn new(key_arity: usize) -> TupleIndex {
+    pub(crate) fn new(key_arity: usize, pool: Arc<crate::ThreadPool>) -> TupleIndex {
         let shard_data = ShardData::new(num_shards());
         let mut shards = IdVec::with_capacity(shard_data.n_shards());
         shards.resize_with(shard_data.n_shards(), || TupleIndexShard {
             table: SubsetTable::new(key_arity),
             subsets: SubsetBuffer::default(),
         });
-        TupleIndex { shard_data, shards }
+        TupleIndex {
+            shard_data,
+            shards,
+            pool,
+        }
     }
 }
 
@@ -487,7 +517,7 @@ impl IndexBase for TupleIndex {
                 queues[shard_id].lock().unwrap().push((first, buf));
             }
         };
-        run_in_thread_pool_and_block(&THREAD_POOL, || {
+        run_in_thread_pool_and_block(&self.pool, || {
             rayon::scope(|scope| {
                 let mut cur = Offset::new(0);
                 loop {
@@ -541,6 +571,10 @@ impl IndexBase for TupleIndex {
                 }
             });
         });
+    }
+
+    fn thread_pool(&self) -> &Arc<crate::ThreadPool> {
+        &self.pool
     }
 }
 
@@ -791,20 +825,6 @@ fn num_shards() -> usize {
     let n_threads = rayon::current_num_threads();
     if n_threads == 1 { 1 } else { n_threads * 2 }
 }
-
-/// A thread pool specifically for parallel hash index construction.
-///
-/// We use a separate thread pool here because callers can construct an index under a lock,
-/// and we do not want to take a long-running lock in the global thread pool without another
-/// way to get parallelism.
-///
-/// Earlier solutions using rayon::yield_now() were unreliable.
-static THREAD_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
-    rayon::ThreadPoolBuilder::new()
-        .num_threads(rayon::current_num_threads())
-        .build()
-        .unwrap()
-});
 
 /// A simple free list used to reuse slots in a [`SubsetBuffer`].
 ///

--- a/core-relations/src/hash_index/mod.rs
+++ b/core-relations/src/hash_index/mod.rs
@@ -72,7 +72,7 @@ impl<TI: IndexBase> Index<TI> {
         } else {
             table.updates_since(self.updated_to.minor)
         };
-        if parallelize_index_construction(subset.size()) {
+        if parallelize_index_construction(subset.size(), self.thread_pool().num_threads()) {
             self.table.merge_parallel(&self.key, table, subset.as_ref());
         } else {
             self.refresh_serial(table, subset);
@@ -366,7 +366,7 @@ fn run_in_rayon_pool_and_block<'a>(pool: &rayon::ThreadPool, f: impl FnMut() + S
 impl ColumnIndex {
     pub(crate) fn new(pool: Arc<crate::ThreadPool>) -> ColumnIndex {
         with_pool_set(|ps| {
-            let shard_data = ShardData::new(num_shards());
+            let shard_data = ShardData::new(num_shards(pool.num_threads()));
             let mut shards = IdVec::with_capacity(shard_data.n_shards());
             shards.resize_with(shard_data.n_shards(), || ColumnIndexShard {
                 table: ps.get(),
@@ -399,7 +399,7 @@ pub struct TupleIndex {
 
 impl TupleIndex {
     pub(crate) fn new(key_arity: usize, pool: Arc<crate::ThreadPool>) -> TupleIndex {
-        let shard_data = ShardData::new(num_shards());
+        let shard_data = ShardData::new(num_shards(pool.num_threads()));
         let mut shards = IdVec::with_capacity(shard_data.n_shards());
         shards.resize_with(shard_data.n_shards(), || TupleIndexShard {
             table: SubsetTable::new(key_arity),
@@ -821,8 +821,7 @@ impl BufferedSubset {
     }
 }
 
-fn num_shards() -> usize {
-    let n_threads = rayon::current_num_threads();
+fn num_shards(n_threads: usize) -> usize {
     if n_threads == 1 { 1 } else { n_threads * 2 }
 }
 

--- a/core-relations/src/hash_index/tests.rs
+++ b/core-relations/src/hash_index/tests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::numeric_id::NumericId;
 
 use crate::{
@@ -10,6 +12,7 @@ use super::Index;
 
 #[test]
 fn basic_updates() {
+    let index_building_pool = Arc::new(crate::ThreadPool::new(rayon::current_num_threads()));
     // Get slightly higher coverage with nondeterministic parallelism.
     for _ in 0..10 {
         // fill a SortedWritesTable with some data. confirm that an index built on
@@ -29,9 +32,13 @@ fn basic_updates() {
                 assert_eq!(old, new, "no conflicts in this test");
                 None
             },
+            index_building_pool.clone(),
         ));
 
-        let mut index = Index::new(vec![ColumnId::new(0), ColumnId::new(2)], TupleIndex::new(2));
+        let mut index = Index::new(
+            vec![ColumnId::new(0), ColumnId::new(2)],
+            TupleIndex::new(2, index_building_pool.clone()),
+        );
         assert!(index.get_subset(&[v(0), v(2)]).is_none());
         index.refresh(table.as_ref());
         for i in 0..=4 {

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -24,6 +24,7 @@ mod tests;
 
 pub use action::{ExecutionState, MergeVal, QueryEntry, WriteVal};
 pub use base_values::{BaseValue, BaseValueId, BaseValuePrinter, BaseValues, Boxed};
+pub use common::ThreadPool;
 pub use common::Value;
 pub use containers::{ContainerValue, ContainerValueId, ContainerValues};
 pub use free_join::{

--- a/core-relations/src/parallel_heuristics.rs
+++ b/core-relations/src/parallel_heuristics.rs
@@ -11,8 +11,8 @@ pub(crate) fn parallelize_db_level_op(db_size: usize) -> bool {
 }
 
 /// Whether or not to use a parallel algorithm to construct a hash index.
-pub(crate) fn parallelize_index_construction(items_to_insert: usize) -> bool {
-    items_to_insert > 20_000 && rayon::current_num_threads() > 1
+pub(crate) fn parallelize_index_construction(items_to_insert: usize, num_threads: usize) -> bool {
+    items_to_insert > 20_000 && num_threads > 1
 }
 
 /// Whether or not to use a parallel algorithm to rebuild a [`crate::table::SortedWritesTable`].

--- a/core-relations/src/table/mod.rs
+++ b/core-relations/src/table/mod.rs
@@ -535,7 +535,7 @@ impl SortedWritesTable {
         merge_fn: Box<MergeFn>,
         index_thread_pool: Arc<crate::ThreadPool>,
     ) -> Self {
-        let hash = ShardedHashTable::<TableEntry>::default();
+        let hash = ShardedHashTable::<TableEntry>::new(index_thread_pool.num_threads());
         let shard_data = hash.shard_data();
         let rebuild_index = Index::new(to_rebuild.clone(), ColumnIndex::new(index_thread_pool));
         SortedWritesTable {

--- a/core-relations/src/table/mod.rs
+++ b/core-relations/src/table/mod.rs
@@ -164,7 +164,10 @@ impl Clone for SortedWritesTable {
             pending_state: Arc::new(self.pending_state.deep_copy()),
             merge: self.merge.clone(),
             to_rebuild: self.to_rebuild.clone(),
-            rebuild_index: Index::new(self.to_rebuild.clone(), ColumnIndex::new()),
+            rebuild_index: Index::new(
+                self.to_rebuild.clone(),
+                ColumnIndex::new(self.rebuild_index.thread_pool().clone()),
+            ),
             subset_tracker: Default::default(),
         }
     }
@@ -530,10 +533,11 @@ impl SortedWritesTable {
         sort_by: Option<ColumnId>,
         to_rebuild: Vec<ColumnId>,
         merge_fn: Box<MergeFn>,
+        index_thread_pool: Arc<crate::ThreadPool>,
     ) -> Self {
         let hash = ShardedHashTable::<TableEntry>::default();
         let shard_data = hash.shard_data();
-        let rebuild_index = Index::new(to_rebuild.clone(), ColumnIndex::new());
+        let rebuild_index = Index::new(to_rebuild.clone(), ColumnIndex::new(index_thread_pool));
         SortedWritesTable {
             generation: Generation::new(0),
             data: Rows::new(RowBuffer::new(n_columns)),

--- a/core-relations/src/table/rebuild.rs
+++ b/core-relations/src/table/rebuild.rs
@@ -1,6 +1,6 @@
 //! Apply value-level rebuilds to a table.
 
-use std::{cmp, mem};
+use std::{cmp, mem, sync::Arc};
 
 use crate::numeric_id::NumericId;
 use rayon::prelude::*;
@@ -70,10 +70,11 @@ impl SortedWritesTable {
         next_ts: Value,
         exec_state: &mut ExecutionState,
     ) -> bool {
-        let mut index = mem::replace(
-            &mut self.rebuild_index,
-            Index::new(vec![], ColumnIndex::new()),
+        let dummy_index = Index::new(
+            vec![],
+            ColumnIndex::new(self.rebuild_index.thread_pool().clone()),
         );
+        let mut index = mem::replace(&mut self.rebuild_index, dummy_index);
         // Update the index.
         WrappedTableRef::with_wrapper(self, |wrapped| {
             index.refresh(wrapped);
@@ -221,10 +222,10 @@ impl SortedWritesTable {
     }
 }
 
-fn incremental_rebuild(_uf_size: usize, _table_size: usize, _parallel: bool) -> bool {
-    if _parallel {
-        _table_size > 10_000 && _uf_size * 8192 <= _table_size
+fn incremental_rebuild(uf_size: usize, table_size: usize, parallel: bool) -> bool {
+    if parallel {
+        table_size > 10_000 && uf_size * 8192 <= table_size
     } else {
-        _table_size > 10000 && _uf_size * 8 <= _table_size
+        table_size > 10000 && uf_size * 8 <= table_size
     }
 }

--- a/core-relations/src/table/rebuild.rs
+++ b/core-relations/src/table/rebuild.rs
@@ -1,6 +1,6 @@
 //! Apply value-level rebuilds to a table.
 
-use std::{cmp, mem, sync::Arc};
+use std::{cmp, mem};
 
 use crate::numeric_id::NumericId;
 use rayon::prelude::*;

--- a/core-relations/src/table/sharded_hash_table.rs
+++ b/core-relations/src/table/sharded_hash_table.rs
@@ -11,21 +11,19 @@ pub(crate) struct ShardedHashTable<T> {
     shards: Vec<HashTable<T>>,
 }
 
-impl<T> Default for ShardedHashTable<T> {
-    fn default() -> Self {
-        let cur_threads = rayon::current_num_threads();
+impl<T> ShardedHashTable<T> {
+    pub(crate) fn new(cur_threads: usize) -> Self {
         if cur_threads == 1 {
             Self::with_shards(1)
         } else {
             Self::with_shards(cur_threads * 2)
         }
     }
-}
 
-impl<T> ShardedHashTable<T> {
     pub(crate) fn clear(&mut self) {
         self.shards.iter_mut().for_each(|s| s.clear());
     }
+
     pub(crate) fn with_shards(shards: usize) -> Self {
         let shard_data = ShardData::new(shards);
         let shards = (0..shard_data.n_shards())

--- a/core-relations/src/table/tests.rs
+++ b/core-relations/src/table/tests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::numeric_id::NumericId;
 use rand::{Rng, rng};
 
@@ -35,6 +37,7 @@ fn empty_key() {
         0,
         None,
         |_, new| Some(new.to_vec()),
+        Arc::new(crate::ThreadPool::new(rayon::current_num_threads())),
     );
     let row = table.get_row(&[]).expect("empty key should be present");
     assert_eq!(*row.vals, vec![v(2), v(3)]);
@@ -60,6 +63,7 @@ fn insert_scan() {
         2,
         None,
         |_, new| Some(new.to_vec()),
+        Arc::new(crate::ThreadPool::new(rayon::current_num_threads())),
     );
 
     let all = table.all();
@@ -112,6 +116,7 @@ fn insert_scan_sorted() {
         2,
         Some(ColumnId::new(2)),
         |_, new| Some(new.to_vec()),
+        Arc::new(crate::ThreadPool::new(rayon::current_num_threads())),
     );
 
     let all = table.all();

--- a/core-relations/src/table_shortcuts.rs
+++ b/core-relations/src/table_shortcuts.rs
@@ -1,5 +1,7 @@
 //! Utilities helpful in unit tests for manipulating tables.
 
+use std::sync::Arc;
+
 use crate::numeric_id::NumericId;
 
 use crate::{
@@ -32,6 +34,7 @@ pub(crate) fn fill_table(
     n_keys: usize,
     sort_by: Option<ColumnId>,
     merge_fn: impl Fn(&[Value], &[Value]) -> Option<Vec<Value>> + 'static + Send + Sync,
+    index_building_pool: Arc<crate::ThreadPool>,
 ) -> SortedWritesTable {
     empty_execution_state!(e);
     let mut iter = rows.into_iter();
@@ -51,6 +54,7 @@ pub(crate) fn fill_table(
                 false
             }
         }),
+        index_building_pool,
     );
 
     // We write tests that assume that assume rows are inserted in order.

--- a/core-relations/src/table_spec.rs
+++ b/core-relations/src/table_spec.rs
@@ -8,6 +8,7 @@ use std::{
     any::Any,
     marker::PhantomData,
     ops::{Deref, DerefMut},
+    sync::Arc,
 };
 
 use crate::numeric_id::{DenseIdMap, NumericId, define_id};
@@ -381,17 +382,29 @@ impl<T: Table> TableWrapper for WrapperImpl<T> {
             out.add_row(row_id, row);
         })
     }
-    fn group_by_col(&self, table: &dyn Table, subset: SubsetRef, col: ColumnId) -> ColumnIndex {
+    fn group_by_col(
+        &self,
+        table: &dyn Table,
+        subset: SubsetRef,
+        col: ColumnId,
+        pool: Arc<crate::ThreadPool>,
+    ) -> ColumnIndex {
         let table = table.as_any().downcast_ref::<T>().unwrap();
-        let mut res = ColumnIndex::new();
+        let mut res = ColumnIndex::new(pool);
         table.scan_generic(subset, |row_id, row| {
             res.add_row(&[row[col.index()]], row_id);
         });
         res
     }
-    fn group_by_key(&self, table: &dyn Table, subset: SubsetRef, cols: &[ColumnId]) -> TupleIndex {
+    fn group_by_key(
+        &self,
+        table: &dyn Table,
+        subset: SubsetRef,
+        cols: &[ColumnId],
+        pool: Arc<crate::ThreadPool>,
+    ) -> TupleIndex {
         let table = table.as_any().downcast_ref::<T>().unwrap();
-        let mut res = TupleIndex::new(cols.len());
+        let mut res = TupleIndex::new(cols.len(), pool);
         match cols {
             [] => {}
             [col] => table.scan_generic(subset, |row_id, row| {
@@ -556,13 +569,23 @@ impl WrappedTable {
     }
 
     /// Group the contents of the given subset by the given column.
-    pub(crate) fn group_by_col(&self, subset: SubsetRef, col: ColumnId) -> ColumnIndex {
-        self.as_ref().group_by_col(subset, col)
+    pub(crate) fn group_by_col(
+        &self,
+        subset: SubsetRef,
+        col: ColumnId,
+        pool: Arc<crate::ThreadPool>,
+    ) -> ColumnIndex {
+        self.as_ref().group_by_col(subset, col, pool)
     }
 
     /// A multi-column vairant of [`WrappedTable::group_by_col`].
-    pub(crate) fn group_by_key(&self, subset: SubsetRef, cols: &[ColumnId]) -> TupleIndex {
-        self.as_ref().group_by_key(subset, cols)
+    pub(crate) fn group_by_key(
+        &self,
+        subset: SubsetRef,
+        cols: &[ColumnId],
+        pool: Arc<crate::ThreadPool>,
+    ) -> TupleIndex {
+        self.as_ref().group_by_key(subset, cols, pool)
     }
 
     /// A variant fo [`WrappedTable::scan_bounded`] that projects a subset of
@@ -645,8 +668,20 @@ pub(crate) trait TableWrapper: Send + Sync {
         n: usize,
         out: &mut TaggedRowBuffer,
     ) -> Option<Offset>;
-    fn group_by_col(&self, table: &dyn Table, subset: SubsetRef, col: ColumnId) -> ColumnIndex;
-    fn group_by_key(&self, table: &dyn Table, subset: SubsetRef, cols: &[ColumnId]) -> TupleIndex;
+    fn group_by_col(
+        &self,
+        table: &dyn Table,
+        subset: SubsetRef,
+        col: ColumnId,
+        pool: Arc<crate::ThreadPool>,
+    ) -> ColumnIndex;
+    fn group_by_key(
+        &self,
+        table: &dyn Table,
+        subset: SubsetRef,
+        cols: &[ColumnId],
+        pool: Arc<crate::ThreadPool>,
+    ) -> TupleIndex;
 
     #[allow(clippy::too_many_arguments)]
     fn scan_project(
@@ -729,13 +764,23 @@ impl WrappedTableRef<'_> {
     }
 
     /// Group the contents of the given subset by the given column.
-    pub(crate) fn group_by_col(&self, subset: SubsetRef, col: ColumnId) -> ColumnIndex {
-        self.wrapper.group_by_col(self.inner, subset, col)
+    pub(crate) fn group_by_col(
+        &self,
+        subset: SubsetRef,
+        col: ColumnId,
+        pool: Arc<crate::ThreadPool>,
+    ) -> ColumnIndex {
+        self.wrapper.group_by_col(self.inner, subset, col, pool)
     }
 
     /// A multi-column vairant of [`WrappedTable::group_by_col`].
-    pub(crate) fn group_by_key(&self, subset: SubsetRef, cols: &[ColumnId]) -> TupleIndex {
-        self.wrapper.group_by_key(self.inner, subset, cols)
+    pub(crate) fn group_by_key(
+        &self,
+        subset: SubsetRef,
+        cols: &[ColumnId],
+        pool: Arc<crate::ThreadPool>,
+    ) -> TupleIndex {
+        self.wrapper.group_by_key(self.inner, subset, cols, pool)
     }
 
     /// A variant fo [`WrappedTable::scan_bounded`] that projects a subset of

--- a/core-relations/src/tests.rs
+++ b/core-relations/src/tests.rs
@@ -27,13 +27,9 @@ use crate::{
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 /// Run a test closure both single-threaded and with 4 threads.
-fn run_serial_and_parallel(f: impl Fn() + Send + Sync) {
-    for num_threads in [1, 4] {
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(num_threads)
-            .build()
-            .unwrap();
-        pool.install(&f);
+fn run_serial_and_parallel(f: impl Fn(usize) + Send + Sync) {
+    for num_threads in [1, 32] {
+        f(num_threads);
     }
 }
 
@@ -42,14 +38,14 @@ fn basic_query() {
     run_serial_and_parallel(basic_query_inner);
 }
 
-fn basic_query_inner() {
+fn basic_query_inner(num_threads: usize) {
     let MathEgraph {
         num,
         add,
         id_counter,
         mut db,
         ..
-    } = basic_math_egraph();
+    } = basic_math_egraph(num_threads);
 
     db.base_values_mut().register_type::<i64>();
     let add_int = db.add_external_function(Box::new(make_external_func(|exec_state, args| {
@@ -139,21 +135,21 @@ fn basic_query_inner() {
 
 #[test]
 fn line_graph_1_fj_puresize() {
-    run_serial_and_parallel(|| line_graph_1_test(PlanStrategy::PureSize));
+    run_serial_and_parallel(|num_threads| line_graph_1_test(PlanStrategy::PureSize, num_threads));
 }
 
 #[test]
 fn line_graph_1_fj_mincover() {
-    run_serial_and_parallel(|| line_graph_1_test(PlanStrategy::MinCover));
+    run_serial_and_parallel(|num_threads| line_graph_1_test(PlanStrategy::MinCover, num_threads));
 }
 
 #[test]
 fn line_graph_1_gj() {
-    run_serial_and_parallel(|| line_graph_1_test(PlanStrategy::Gj));
+    run_serial_and_parallel(|num_threads| line_graph_1_test(PlanStrategy::Gj, num_threads));
 }
 
-fn line_graph_1_test(strat: PlanStrategy) {
-    let mut db = Database::default();
+fn line_graph_1_test(strat: PlanStrategy, num_threads: usize) {
+    let mut db = Database::default().with_num_threads(num_threads);
     let edge_impl = SortedWritesTable::new(
         2,
         2,
@@ -166,6 +162,7 @@ fn line_graph_1_test(strat: PlanStrategy) {
                 false
             }
         }),
+        db.index_building_thread_pool().clone(),
     );
     let edges = db.add_table(edge_impl, iter::empty(), iter::empty());
     let nodes = Vec::from_iter((0..10).map(Value::new));
@@ -211,21 +208,21 @@ fn line_graph_1_test(strat: PlanStrategy) {
 
 #[test]
 fn line_graph_2_fj_puresize() {
-    run_serial_and_parallel(|| line_graph_2_test(PlanStrategy::PureSize));
+    run_serial_and_parallel(|num_threads| line_graph_2_test(PlanStrategy::PureSize, num_threads));
 }
 
 #[test]
 fn line_graph_2_fj_mincover() {
-    run_serial_and_parallel(|| line_graph_2_test(PlanStrategy::MinCover));
+    run_serial_and_parallel(|num_threads| line_graph_2_test(PlanStrategy::MinCover, num_threads));
 }
 
 #[test]
 fn line_graph_2_gj() {
-    run_serial_and_parallel(|| line_graph_2_test(PlanStrategy::Gj));
+    run_serial_and_parallel(|num_threads| line_graph_2_test(PlanStrategy::Gj, num_threads));
 }
 
-fn line_graph_2_test(strat: PlanStrategy) {
-    let mut db = Database::default();
+fn line_graph_2_test(strat: PlanStrategy, num_threads: usize) {
+    let mut db = Database::default().with_num_threads(num_threads);
     let edge_impl = SortedWritesTable::new(
         2,
         2,
@@ -238,6 +235,7 @@ fn line_graph_2_test(strat: PlanStrategy) {
                 false
             }
         }),
+        db.index_building_thread_pool().clone(),
     );
     let edges = db.add_table(edge_impl, iter::empty(), iter::empty());
     let nodes = Vec::from_iter((0..10).map(Value::new));
@@ -292,8 +290,9 @@ fn line_graph_2_test(strat: PlanStrategy) {
     assert_eq!(expected, got);
 }
 
-fn intersection_test(strat: PlanStrategy) {
-    let mut db = Database::default();
+fn intersection_test(strat: PlanStrategy, num_threads: usize) {
+    let mut db = Database::default().with_num_threads(num_threads);
+    let index_building_pool = db.index_building_thread_pool().clone();
     let rst = (0..3).map(|_| {
         SortedWritesTable::new(
             2,
@@ -307,6 +306,7 @@ fn intersection_test(strat: PlanStrategy) {
                     false
                 }
             }),
+            index_building_pool.clone(),
         )
     });
     let u = SortedWritesTable::new(
@@ -321,6 +321,7 @@ fn intersection_test(strat: PlanStrategy) {
                 false
             }
         }),
+        index_building_pool.clone(),
     );
     let rst_ids = rst
         .map(|r| db.add_table(r, iter::empty(), iter::empty()))
@@ -371,31 +372,31 @@ fn intersection_test(strat: PlanStrategy) {
 
 #[test]
 fn intersection_test_fj_puresize() {
-    run_serial_and_parallel(|| intersection_test(PlanStrategy::PureSize));
+    run_serial_and_parallel(|num_threads| intersection_test(PlanStrategy::PureSize, num_threads));
 }
 
 #[test]
 fn intersection_test_fj_mincover() {
-    run_serial_and_parallel(|| intersection_test(PlanStrategy::MinCover));
+    run_serial_and_parallel(|num_threads| intersection_test(PlanStrategy::MinCover, num_threads));
 }
 
 #[test]
 fn intersection_test_gj() {
-    run_serial_and_parallel(|| intersection_test(PlanStrategy::Gj));
+    run_serial_and_parallel(|num_threads| intersection_test(PlanStrategy::Gj, num_threads));
 }
 
 #[test]
 fn minimal_ac() {
-    run_serial_and_parallel(minimal_ac_inner);
+    run_serial_and_parallel(|num_threads| minimal_ac_inner(num_threads));
 }
 
-fn minimal_ac_inner() {
+fn minimal_ac_inner(num_threads: usize) {
     let MathEgraph {
         add,
         id_counter,
         mut db,
         ..
-    } = basic_math_egraph();
+    } = basic_math_egraph(num_threads);
     {
         {
             let mut add_buf = db.new_buffer(add);
@@ -497,20 +498,20 @@ fn minimal_ac_inner() {
 
 #[test]
 fn ac_gj() {
-    run_serial_and_parallel(|| ac_test_inner(PlanStrategy::Gj));
+    run_serial_and_parallel(|num_threads| ac_test_inner(PlanStrategy::Gj, num_threads));
 }
 
 #[test]
 fn ac_fj_mincover() {
-    run_serial_and_parallel(|| ac_test_inner(PlanStrategy::MinCover));
+    run_serial_and_parallel(|num_threads| ac_test_inner(PlanStrategy::MinCover, num_threads));
 }
 
 #[test]
 fn ac_fj_puresize() {
-    run_serial_and_parallel(|| ac_test_inner(PlanStrategy::PureSize));
+    run_serial_and_parallel(|num_threads| ac_test_inner(PlanStrategy::PureSize, num_threads));
 }
 
-fn ac_test_inner(strat: PlanStrategy) {
+fn ac_test_inner(strat: PlanStrategy, num_threads: usize) {
     // This test is very involved. It reimplements major egglog features on top
     // of this library:
     // 1. rebuilding, including heuristics for incremental vs. nonincremental.
@@ -525,7 +526,7 @@ fn ac_test_inner(strat: PlanStrategy) {
         id_counter,
         mut db,
         uf,
-    } = basic_math_egraph();
+    } = basic_math_egraph(num_threads);
 
     // Add the numbers 1 through 10 to the num table at timestamp 0.
     let mut ids = Vec::new();
@@ -958,8 +959,8 @@ struct MathEgraph {
     db: Database,
 }
 
-fn basic_math_egraph() -> MathEgraph {
-    let mut db = Database::default();
+fn basic_math_egraph(num_threads: usize) -> MathEgraph {
+    let mut db = Database::default().with_num_threads(num_threads);
     let uf = db.add_table(DisplacedTable::default(), iter::empty(), iter::empty());
     let num_impl = SortedWritesTable::new(
         1,
@@ -976,6 +977,7 @@ fn basic_math_egraph() -> MathEgraph {
                 false
             }
         }),
+        db.index_building_thread_pool().clone(),
     );
 
     let id_counter = db.add_counter();
@@ -996,6 +998,7 @@ fn basic_math_egraph() -> MathEgraph {
                 false
             }
         }),
+        db.index_building_thread_pool().clone(),
     );
 
     let add = db.add_table(add_impl, iter::once(uf), iter::empty());
@@ -1018,12 +1021,13 @@ fn lookup_with_fallback_partial_success() {
     run_serial_and_parallel(lookup_with_fallback_partial_success_inner);
 }
 
-fn lookup_with_fallback_partial_success_inner() {
+fn lookup_with_fallback_partial_success_inner(num_threads: usize) {
     // Insert (f 1) (f 2), (g 1) (g 3) (g 4).
     // Run a query that iterates over g, binding x to 1, 3, 4.
     // Insert (h (lookup f x, with fallback assert-even))
     // Should get h 1, h 4
-    let mut db = Database::default();
+    let mut db = Database::default().with_num_threads(num_threads);
+    let index_building_pool = db.index_building_thread_pool().clone();
     let [f, g, h] = (0..3)
         .map(|_| {
             db.add_table(
@@ -1039,6 +1043,7 @@ fn lookup_with_fallback_partial_success_inner() {
                             false
                         }
                     }),
+                    index_building_pool.clone(),
                 ),
                 iter::empty(),
                 iter::empty(),
@@ -1118,7 +1123,7 @@ fn call_external_with_fallback() {
     run_serial_and_parallel(call_external_with_fallback_inner);
 }
 
-fn call_external_with_fallback_inner() {
+fn call_external_with_fallback_inner(num_threads: usize) {
     // Insert (f 1) (f 2) (f 3) (f 5).
     // Iterate over f, binding x to 1, 2, 3.
     // Have two external functions:
@@ -1126,7 +1131,7 @@ fn call_external_with_fallback_inner() {
     // 2. inc, which increments the input value and only fails on the number 5
     // Insert (h (call assert_even x, with fallback inc x))
     // We should get h 2, h 4.
-    let mut db = Database::default();
+    let mut db = Database::default().with_num_threads(num_threads);
     let [f, h] = (0..2)
         .map(|_| {
             db.add_table(
@@ -1142,6 +1147,7 @@ fn call_external_with_fallback_inner() {
                             false
                         }
                     }),
+                    db.index_building_thread_pool().clone(),
                 ),
                 iter::empty(),
                 iter::empty(),
@@ -1204,12 +1210,19 @@ fn early_stop() {
     run_serial_and_parallel(early_stop_inner);
 }
 
-fn early_stop_inner() {
-    let mut db = Database::default();
+fn early_stop_inner(num_threads: usize) {
+    let mut db = Database::default().with_num_threads(num_threads);
 
     // Create a table with 1M rows.
     let data_table = db.add_table(
-        SortedWritesTable::new(1, 2, None, vec![], Box::new(|_, _, _, _| false)),
+        SortedWritesTable::new(
+            1,
+            2,
+            None,
+            vec![],
+            Box::new(|_, _, _, _| false),
+            db.index_building_thread_pool().clone(),
+        ),
         iter::empty(),
         iter::empty(),
     );

--- a/core-relations/src/tests.rs
+++ b/core-relations/src/tests.rs
@@ -387,7 +387,7 @@ fn intersection_test_gj() {
 
 #[test]
 fn minimal_ac() {
-    run_serial_and_parallel(|num_threads| minimal_ac_inner(num_threads));
+    run_serial_and_parallel(minimal_ac_inner);
 }
 
 fn minimal_ac_inner(num_threads: usize) {

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -373,6 +373,7 @@ impl EGraph {
                             false
                         }
                     }),
+                    self.db.index_building_thread_pool().clone(),
                 );
                 let table_id =
                     self.db
@@ -393,6 +394,7 @@ impl EGraph {
                     None,
                     vec![], // no rebuilding needed for reason tables
                     Box::new(|_, _, _, _| false),
+                    self.db.index_building_thread_pool().clone(),
                 );
                 let table_id = self.db.add_table(table, iter::empty(), iter::empty());
                 *v.insert(table_id)
@@ -751,6 +753,7 @@ impl EGraph {
             Some(ColumnId::from_usize(schema.len())),
             to_rebuild,
             merge_fn,
+            self.db.index_building_thread_pool().clone(),
         );
         let name: Arc<str> = name.into();
         let table_id = self.db.add_table_named(
@@ -813,8 +816,19 @@ impl EGraph {
         Ok(iteration_report)
     }
 
+    /// Set the number of threads used for parallel operations.
+    pub fn with_num_threads(mut self, num_threads: usize) -> Self {
+        self.db = self.db.with_num_threads(num_threads);
+        self
+    }
+
+    /// Return the number of threads in this EGraph's thread pool.
+    pub fn num_threads(&self) -> usize {
+        self.db.num_threads()
+    }
+
     fn rebuild(&mut self) -> Result<()> {
-        let do_parallel = rayon::current_num_threads() > 1;
+        let do_parallel = self.db.num_threads() > 1;
         if self.db.get_table(self.uf_table).rebuilder(&[]).is_some() {
             // The UF implementation supports "native"  rebuilding.
             let mut tables = Vec::with_capacity(self.funcs.next_id().index());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,10 +260,6 @@ pub struct EGraph {
     proof_state: EncodingState,
     /// In proof mode, this is the program before proof instrumentation and the version we use for proof checking.
     proof_check_program: Vec<ResolvedNCommand>,
-    /// Thread pool used for parallel operations.
-    /// Does not exist on wasm, where spawning threads is unsupported.
-    #[cfg(not(target_family = "wasm"))]
-    pool: Arc<rayon::ThreadPool>,
 }
 
 /// A user-defined command allows users to inject custom command that can be called
@@ -353,13 +349,6 @@ impl Default for EGraph {
             command_macros: Default::default(),
             proof_state,
             proof_check_program: vec![],
-            #[cfg(not(target_family = "wasm"))]
-            pool: Arc::new(
-                rayon::ThreadPoolBuilder::new()
-                    .num_threads(1)
-                    .build()
-                    .expect("failed to build rayon thread pool"),
-            ),
         };
 
         add_base_sort(&mut eg, UnitSort, span!()).unwrap();
@@ -491,43 +480,13 @@ impl EGraph {
     ///
     /// Panics on wasm if `num_threads > 1`.
     pub fn with_num_threads(mut self, num_threads: usize) -> Self {
-        #[cfg(target_family = "wasm")]
-        if num_threads > 1 {
-            panic!("cannot use more than 1 thread on wasm");
-        }
-        #[cfg(not(target_family = "wasm"))]
-        {
-            self.pool = Arc::new(
-                rayon::ThreadPoolBuilder::new()
-                    .num_threads(num_threads)
-                    .build()
-                    .expect("failed to build rayon thread pool"),
-            );
-        }
+        self.backend = self.backend.with_num_threads(num_threads);
         self
     }
 
     /// Return the number of threads in this EGraph's thread pool.
     pub fn num_threads(&self) -> usize {
-        #[cfg(not(target_family = "wasm"))]
-        return self.pool.current_num_threads();
-        #[cfg(target_family = "wasm")]
-        1
-    }
-
-    /// Run `f` on the configured thread pool.
-    ///
-    /// This ensures `rayon::current_num_threads()` inside the closure reflects
-    /// this EGraph's pool, so parallel heuristics in core-relations behave
-    /// correctly.
-    fn with_pool<R: Send>(&mut self, f: impl FnOnce(&mut Self) -> R + Send) -> R {
-        #[cfg(not(target_family = "wasm"))]
-        {
-            let pool = self.pool.clone();
-            return pool.install(|| f(self));
-        }
-        #[cfg(target_family = "wasm")]
-        f(self)
+        self.backend.num_threads()
     }
 
     /// Add a user-defined command to the e-graph
@@ -1640,14 +1599,6 @@ impl EGraph {
         program: Vec<Command>,
         run_commands: bool,
     ) -> Result<ResolvedNCommandsWithOutput, Error> {
-        self.with_pool(|this| this.process_program_internal_helper(program, run_commands))
-    }
-
-    fn process_program_internal_helper(
-        &mut self,
-        program: Vec<Command>,
-        run_commands: bool,
-    ) -> Result<ResolvedNCommandsWithOutput, Error> {
         let mut outputs = Vec::new();
         let mut desugared_before_proofs = Vec::new();
         let mut desugared = Vec::new();
@@ -1670,8 +1621,7 @@ impl EGraph {
                         .parser
                         .get_program_from_string(Some(file.clone()), &s)?;
                     // run program internal on these include commands
-                    let resolved =
-                        self.process_program_internal_helper(included_program, run_commands)?;
+                    let resolved = self.process_program_internal(included_program, run_commands)?;
                     outputs.extend(resolved.outputs);
                     desugared.extend(resolved.resolved);
                     desugared_before_proofs.extend(resolved.resolved_before_proofs);

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -314,7 +314,7 @@ fn generate_tests(glob: &str) -> Vec<Trial> {
             push_trial(run.clone());
 
             push_trial(Run {
-                threads: 4,
+                threads: 32,
                 ..run.clone()
             });
         }


### PR DESCRIPTION
* Made the index-building thread pool part of the e-graph 
* Addressed some review comments

One relatively invasive change is that now when we build an index or a SortedWritesTable we also need to pass in the thread pool for index building, which used to be a global variable.