### PR TITLE
[codex] perf(rust_rule): share table actions across matches

### DIFF
--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -1442,25 +1442,12 @@ impl ResolvedMergeFn {
 /// This is an intern-able struct that holds all the data needed
 /// to do table operations with an [`ExecutionState`], assuming
 /// that the [`FunctionId`] for the table is known ahead of time.
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct TableAction {
     table: TableId,
     table_math: SchemaMath,
     default: Option<MergeVal>,
     timestamp: CounterId,
-    scratch: Vec<Value>,
-}
-
-impl Clone for TableAction {
-    fn clone(&self) -> Self {
-        Self {
-            table: self.table,
-            table_math: self.table_math,
-            default: self.default,
-            timestamp: self.timestamp,
-            scratch: Vec::new(),
-        }
-    }
 }
 
 impl TableAction {
@@ -1483,7 +1470,6 @@ impl TableAction {
                 DefaultVal::Const(val) => Some(MergeVal::Constant(*val)),
             },
             timestamp: egraph.timestamp_counter,
-            scratch: Vec::new(),
         }
     }
 
@@ -1525,12 +1511,11 @@ impl TableAction {
     }
 
     /// Insert a row into this table.
-    pub fn insert(&mut self, state: &mut ExecutionState, row: impl Iterator<Item = Value>) {
+    pub fn insert(&self, state: &mut ExecutionState, row: impl Iterator<Item = Value>) {
         let ts = Value::from_usize(state.read_counter(self.timestamp));
-        self.scratch.clear();
-        self.scratch.extend(row);
+        let mut scratch = row.collect::<Vec<_>>();
         self.table_math.write_table_row(
-            &mut self.scratch,
+            &mut scratch,
             RowVals {
                 timestamp: ts,
                 proof: None,
@@ -1538,7 +1523,7 @@ impl TableAction {
                 ret_val: None,
             },
         );
-        state.stage_insert(self.table, &self.scratch);
+        state.stage_insert(self.table, &scratch);
     }
 
     /// Delete a row from this table.
@@ -1547,17 +1532,14 @@ impl TableAction {
     }
 
     /// Subsume a row in this table.
-    pub fn subsume(&mut self, state: &mut ExecutionState, key: impl Iterator<Item = Value>) {
+    pub fn subsume(&self, state: &mut ExecutionState, key: impl Iterator<Item = Value>) {
         let ts = Value::from_usize(state.read_counter(self.timestamp));
-        self.scratch.clear();
-        self.scratch.extend(key);
+        let mut scratch = key.collect::<Vec<_>>();
 
-        let ret_val = self
-            .lookup(state, &self.scratch)
-            .expect("subsume lookup failed");
+        let ret_val = self.lookup(state, &scratch).expect("subsume lookup failed");
 
         self.table_math.write_table_row(
-            &mut self.scratch,
+            &mut scratch,
             RowVals {
                 timestamp: ts,
                 proof: None,
@@ -1565,7 +1547,7 @@ impl TableAction {
                 ret_val: Some(ret_val),
             },
         );
-        state.stage_insert(self.table, &self.scratch);
+        state.stage_insert(self.table, &scratch);
     }
 }
 

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -1513,7 +1513,7 @@ impl TableAction {
     /// Insert a row into this table.
     pub fn insert(&self, state: &mut ExecutionState, row: impl Iterator<Item = Value>) {
         let ts = Value::from_usize(state.read_counter(self.timestamp));
-        let mut scratch = row.collect::<Vec<_>>();
+        let mut scratch = row.collect::<SmallVec<[_; 8]>>();
         self.table_math.write_table_row(
             &mut scratch,
             RowVals {
@@ -1534,7 +1534,7 @@ impl TableAction {
     /// Subsume a row in this table.
     pub fn subsume(&self, state: &mut ExecutionState, key: impl Iterator<Item = Value>) {
         let ts = Value::from_usize(state.read_counter(self.timestamp));
-        let mut scratch = key.collect::<Vec<_>>();
+        let mut scratch = key.collect::<SmallVec<[_; 8]>>();
 
         let ret_val = self.lookup(state, &scratch).expect("subsume lookup failed");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1492,7 +1492,7 @@ impl EGraph {
 
         let num_facts = parsed_contents.len();
 
-        let mut table_action = egglog_bridge::TableAction::new(&self.backend, func.backend_id);
+        let table_action = egglog_bridge::TableAction::new(&self.backend, func.backend_id);
 
         if function_type.subtype != FunctionSubtype::Constructor {
             self.backend.with_execution_state(|es| {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -419,7 +419,7 @@ struct RustRuleRhs<F: Fn(&mut RustRuleContext, &[Value]) -> Option<()>> {
     name: String,
     inputs: Vec<ArcSort>,
     union_action: egglog_bridge::UnionAction,
-    table_actions: std::sync::Arc<HashMap<String, egglog_bridge::TableAction>>,
+    table_actions: HashMap<String, egglog_bridge::TableAction>,
     panic_id: ExternalFunctionId,
     func: F,
 }
@@ -443,7 +443,7 @@ impl<F: Fn(&mut RustRuleContext, &[Value]) -> Option<()>> Primitive for RustRule
         let mut context = RustRuleContext {
             exec_state,
             union_action: self.union_action,
-            table_actions: self.table_actions.as_ref(),
+            table_actions: &self.table_actions,
             panic_id: self.panic_id,
         };
         (self.func)(&mut context, values)?;
@@ -542,18 +542,17 @@ pub fn rust_rule(
         name: prim_name.clone(),
         inputs: vars.iter().map(|(_, s)| s.clone()).collect(),
         union_action: egglog_bridge::UnionAction::new(&egraph.backend),
-        table_actions: std::sync::Arc::new(
-            egraph
-                .functions
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        k.clone(),
-                        egglog_bridge::TableAction::new(&egraph.backend, v.backend_id),
-                    )
-                })
-                .collect(),
-        ),
+        table_actions: egraph
+            .functions
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    egglog_bridge::TableAction::new(&egraph.backend, v.backend_id),
+                )
+            })
+            .collect(),
+
         panic_id,
         func,
     });

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -322,7 +322,7 @@ pub fn rule(
 pub struct RustRuleContext<'a, 'b> {
     exec_state: &'a mut ExecutionState<'b>,
     union_action: egglog_bridge::UnionAction,
-    table_actions: HashMap<String, egglog_bridge::TableAction>,
+    table_actions: &'a HashMap<String, egglog_bridge::TableAction>,
     panic_id: ExternalFunctionId,
 }
 
@@ -354,14 +354,24 @@ impl RustRuleContext<'_, '_> {
             .register_val::<T>(x, self.exec_state)
     }
 
-    fn get_table_action(&self, table: &str) -> egglog_bridge::TableAction {
-        self.table_actions[table].clone()
+    fn get_table_action<'a>(
+        table_actions: &'a HashMap<String, egglog_bridge::TableAction>,
+        table: &str,
+    ) -> &'a egglog_bridge::TableAction {
+        table_actions
+            .get(table)
+            .unwrap_or_else(|| panic!("missing table action for table: {table}"))
     }
 
     /// Do a table lookup. This is potentially a mutable operation!
     /// For more information, see `egglog_bridge::TableAction::lookup`.
     pub fn lookup(&mut self, table: &str, key: &[Value]) -> Option<Value> {
-        self.get_table_action(table).lookup(self.exec_state, key)
+        let RustRuleContext {
+            exec_state,
+            table_actions,
+            ..
+        } = self;
+        Self::get_table_action(table_actions, table).lookup(exec_state, key)
     }
 
     /// Union two values in the e-graph.
@@ -373,19 +383,24 @@ impl RustRuleContext<'_, '_> {
     /// Insert a row into a table.
     /// For more information, see `egglog_bridge::TableAction::insert`.
     pub fn insert(&mut self, table: &str, row: impl Iterator<Item = Value>) {
-        self.get_table_action(table).insert(self.exec_state, row)
+        Self::get_table_action(self.table_actions, table).insert(self.exec_state, row)
     }
 
     /// Remove a row from a table.
     /// For more information, see `egglog_bridge::TableAction::remove`.
     pub fn remove(&mut self, table: &str, key: &[Value]) {
-        self.get_table_action(table).remove(self.exec_state, key)
+        let RustRuleContext {
+            exec_state,
+            table_actions,
+            ..
+        } = self;
+        Self::get_table_action(table_actions, table).remove(exec_state, key)
     }
 
     /// Subsume a row in a table.
     /// For more information, see `egglog_bridge::TableAction::subsume`.
     pub fn subsume(&mut self, table: &str, key: &[Value]) {
-        self.get_table_action(table)
+        Self::get_table_action(self.table_actions, table)
             .subsume(self.exec_state, key.iter().copied())
     }
 
@@ -404,7 +419,7 @@ struct RustRuleRhs<F: Fn(&mut RustRuleContext, &[Value]) -> Option<()>> {
     name: String,
     inputs: Vec<ArcSort>,
     union_action: egglog_bridge::UnionAction,
-    table_actions: HashMap<String, egglog_bridge::TableAction>,
+    table_actions: std::sync::Arc<HashMap<String, egglog_bridge::TableAction>>,
     panic_id: ExternalFunctionId,
     func: F,
 }
@@ -428,7 +443,7 @@ impl<F: Fn(&mut RustRuleContext, &[Value]) -> Option<()>> Primitive for RustRule
         let mut context = RustRuleContext {
             exec_state,
             union_action: self.union_action,
-            table_actions: self.table_actions.clone(),
+            table_actions: self.table_actions.as_ref(),
             panic_id: self.panic_id,
         };
         (self.func)(&mut context, values)?;
@@ -527,16 +542,18 @@ pub fn rust_rule(
         name: prim_name.clone(),
         inputs: vars.iter().map(|(_, s)| s.clone()).collect(),
         union_action: egglog_bridge::UnionAction::new(&egraph.backend),
-        table_actions: egraph
-            .functions
-            .iter()
-            .map(|(k, v)| {
-                (
-                    k.clone(),
-                    egglog_bridge::TableAction::new(&egraph.backend, v.backend_id),
-                )
-            })
-            .collect(),
+        table_actions: std::sync::Arc::new(
+            egraph
+                .functions
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        egglog_bridge::TableAction::new(&egraph.backend, v.backend_id),
+                    )
+                })
+                .collect(),
+        ),
         panic_id,
         func,
     });

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -105,7 +105,7 @@ impl Matches {
     fn instantiate(
         mut self,
         state: &mut ExecutionState<'_>,
-        table_action: TableAction,
+        table_action: &TableAction,
     ) -> Vec<Value> {
         let tuple_len = self.tuple_len();
         let unit = state.base_values().get(());
@@ -234,7 +234,7 @@ impl EGraph {
                         .scheduler
                         .filter_matches(rule_id, ruleset, &mut matches);
                 let table_action = TableAction::new(&self.backend, rule_info.decided);
-                *rule_info.matches.lock().unwrap() = matches.instantiate(state, table_action);
+                *rule_info.matches.lock().unwrap() = matches.instantiate(state, &table_action);
             }
         });
         self.backend.flush_updates();

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -105,7 +105,7 @@ impl Matches {
     fn instantiate(
         mut self,
         state: &mut ExecutionState<'_>,
-        mut table_action: TableAction,
+        table_action: TableAction,
     ) -> Vec<Value> {
         let tuple_len = self.tuple_len();
         let unit = state.base_values().get(());

--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -417,7 +417,7 @@ impl Primitive for FillIndex {
             .get_val::<MultiSetContainer>(args[0])
             .unwrap()
             .clone();
-        let ResolvedFunctionId::Lookup(mut action) = fc.0 else {
+        let ResolvedFunctionId::Lookup(action) = fc.0 else {
             panic!(
                 "Primitive functions cannot be used with unstable-multiset-fill-index, since they cannot be set"
             );


### PR DESCRIPTION
This follow-up isolates a simpler version of the Rust-rule table action optimization on top of `main`.

Rust rules currently clone the full `table_actions` map on every match because `RustRuleContext` owns that map, and `TableAction::insert` / `TableAction::subsume` require `&mut self`. In practice, that mutable state was only the reusable `scratch` buffer inside `TableAction`; the semantic table metadata (`table`, `table_math`, `default`, `timestamp`) is immutable after construction.

This change removes `scratch` from `TableAction` and replaces its uses with per-call temporary vectors in `insert` and `subsume`. That lets both methods take `&self` instead of `&mut self`. With that API change, `RustRuleRhs` can hold a shared `Arc<HashMap<String, TableAction>>` and `RustRuleContext` can borrow it rather than cloning the entire map for every match.

Effectively, this makes the optimization much smaller and more direct:
- `TableAction` becomes immutable metadata plus behavior
- `RustRuleContext` borrows shared table actions instead of copying them
- the old per-clone scratch-buffer reset logic disappears

I also cleaned up now-unneeded `mut` bindings at the few call sites that were only mutable because `insert` previously required `&mut self`.

Validation performed locally:
- `cargo test -p egglog-bridge`
- `cargo test -p egglog --lib`
- `cargo bench --bench rust_api_benchmarking --no-run`
