### PR TITLE
Reuse sub-tries during query execution

### DIFF
--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -941,7 +941,7 @@ impl<'a> JoinState<'a> {
                             updates.push_binding(*var, val[0]);
 
                             let node = if x.size() <= 16 {
-                                let sub = refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
+                                let sub = refine_subset(x.to_owned(&ps.get_pool()), &a.cs, &table);
                                 Arc::new(TrieNode::new(sub))
                             } else {
                                 prober

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -3,11 +3,11 @@
 use std::{
     cmp, iter, mem,
     ops::Range,
-    sync::{Arc, Mutex, OnceLock, atomic::AtomicUsize},
+    sync::{Arc, OnceLock, atomic::AtomicUsize},
 };
 
 use crate::{
-    common::{HashMap, ShardData, ShardId},
+    common::HashMap,
     free_join::plan::{JoinStages, MatId, MatScanMode, MatSpec},
     numeric_id::{DenseIdMap, IdVec, NumericId},
     query::Atom,
@@ -16,6 +16,7 @@ use crate::{
 use crossbeam::utils::CachePadded;
 use dashmap::mapref::entry::Entry;
 use dashmap::mapref::one::RefMut;
+use egglog_concurrency::ReadOptimizedLock;
 use egglog_reports::{ReportLevel, RuleReport, RuleSetReport};
 use smallvec::SmallVec;
 use web_time::Instant;
@@ -57,6 +58,50 @@ enum DynamicIndex {
     DynamicColumn(Arc<ColumnIndex>),
 }
 
+/// This struct is used to mark subsets that can contain non-stale entries.
+/// Whether a subset can be stale depends on the type of index it came from.
+/// Indices that come from a table may contain stale entries, while
+/// those that are built on the fly will not.
+struct PotentiallyStale<T> {
+    inner: T,
+    can_be_stale: bool,
+}
+
+impl<T> PotentiallyStale<T> {
+    fn maybe_stale(inner: T) -> Self {
+        Self {
+            inner,
+            can_be_stale: true,
+        }
+    }
+
+    fn not_stale(inner: T) -> Self {
+        Self {
+            inner,
+            can_be_stale: false,
+        }
+    }
+}
+
+impl PotentiallyStale<SubsetRef<'_>> {
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+
+    fn to_owned(&self, pool: &Pool<SortedOffsetVector>) -> PotentiallyStale<Subset> {
+        PotentiallyStale {
+            inner: self.inner.to_owned(pool),
+            can_be_stale: self.can_be_stale,
+        }
+    }
+}
+
+impl PotentiallyStale<Subset> {
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+}
+
 struct Prober {
     node: Arc<TrieNode>,
     pool: Pool<SortedOffsetVector>,
@@ -64,7 +109,7 @@ struct Prober {
 }
 
 impl Prober {
-    fn get_subset(&self, key: &[Value]) -> Option<Subset> {
+    fn get_subset(&self, key: &[Value]) -> Option<PotentiallyStale<Subset>> {
         match &self.ix {
             DynamicIndex::Cached {
                 intersect_outer,
@@ -77,7 +122,7 @@ impl Prober {
                         return None;
                     }
                 }
-                Some(sub)
+                Some(PotentiallyStale::maybe_stale(sub))
             }
             DynamicIndex::CachedColumn {
                 intersect_outer,
@@ -95,15 +140,17 @@ impl Prober {
                         return None;
                     }
                 }
-                Some(sub)
+                Some(PotentiallyStale::maybe_stale(sub))
             }
-            DynamicIndex::Dynamic(tab) => tab.get_subset(key).map(|x| x.to_owned(&self.pool)),
-            DynamicIndex::DynamicColumn(tab) => {
-                tab.get_subset(&key[0]).map(|x| x.to_owned(&self.pool))
-            }
+            DynamicIndex::Dynamic(tab) => tab
+                .get_subset(key)
+                .map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool))),
+            DynamicIndex::DynamicColumn(tab) => tab
+                .get_subset(&key[0])
+                .map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool))),
         }
     }
-    fn for_each(&self, mut f: impl FnMut(&[Value], SubsetRef)) {
+    fn for_each(&self, mut f: impl FnMut(&[Value], PotentiallyStale<SubsetRef>)) {
         match &self.ix {
             DynamicIndex::Cached {
                 intersect_outer: true,
@@ -112,13 +159,16 @@ impl Prober {
                 let mut res = v.to_owned(&self.pool);
                 res.intersect(self.node.subset.as_ref(), &self.pool);
                 if !res.is_empty() {
-                    f(k, res.as_ref())
+                    f(k, PotentiallyStale::maybe_stale(res.as_ref()))
                 }
             }),
             DynamicIndex::Cached {
                 intersect_outer: false,
                 table,
-            } => table.get().unwrap().for_each(|k, v| f(k, v)),
+            } => table
+                .get()
+                .unwrap()
+                .for_each(|k, v| f(k, PotentiallyStale::maybe_stale(v))),
             DynamicIndex::CachedColumn {
                 intersect_outer: true,
                 table,
@@ -127,7 +177,7 @@ impl Prober {
                     let mut res = v.to_owned(&self.pool);
                     res.intersect(self.node.subset.as_ref(), &self.pool);
                     if !res.is_empty() {
-                        f(&[*k], res.as_ref())
+                        f(&[*k], PotentiallyStale::maybe_stale(res.as_ref()))
                     }
                 });
             }
@@ -135,13 +185,16 @@ impl Prober {
                 intersect_outer: false,
                 table,
             } => {
-                table.get().unwrap().for_each(|k, v| f(&[*k], v));
+                table
+                    .get()
+                    .unwrap()
+                    .for_each(|k, v| f(&[*k], PotentiallyStale::maybe_stale(v)));
             }
             DynamicIndex::Dynamic(tab) => {
-                tab.for_each(f);
+                tab.for_each(|k, v| f(k, PotentiallyStale::not_stale(v)));
             }
             DynamicIndex::DynamicColumn(tab) => tab.for_each(|k, v| {
-                f(&[*k], v);
+                f(&[*k], PotentiallyStale::not_stale(v));
             }),
         }
     }
@@ -195,22 +248,25 @@ impl Database {
                         let mut action_buf =
                             ScopedActionBuffer::new(rule_scope, rule_set, match_counter.clone());
                         let search_and_apply_timer = Instant::now();
+
                         'eval: {
+                            for JoinHeader { atom, subset, .. } in plan.header() {
+                                if subset.is_empty() {
+                                    break 'eval;
+                                }
+                                let mut cur =
+                                    Arc::try_unwrap(binding_info.unwrap_val(*atom)).unwrap();
+                                debug_assert!(cur.cached_subsets.get().is_none());
+                                cur.subset
+                                    .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
+                                if cur.subset.is_empty() {
+                                    break 'eval;
+                                }
+                                binding_info.move_back_node(*atom, Arc::new(cur));
+                            }
+
                             match plan {
                                 Plan::SinglePlan(plan) => {
-                                    for JoinHeader { atom, subset, .. } in &plan.header {
-                                        if subset.is_empty() {
-                                            break 'eval;
-                                        }
-                                        let mut cur =
-                                            Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
-                                        debug_assert!(cur.cached_subsets.get().is_none());
-                                        cur.subset.intersect(
-                                            subset.as_ref(),
-                                            &with_pool_set(|ps| ps.get_pool()),
-                                        );
-                                        binding_info.move_back_node(*atom, Arc::new(cur));
-                                    }
                                     join_state.run_join_stages(
                                         &plan.stages,
                                         &plan.atoms,
@@ -220,23 +276,6 @@ impl Database {
                                     );
                                 }
                                 Plan::DecomposedPlan(plan) => {
-                                    for JoinHeader { atom, subset, .. } in plan.header.iter() {
-                                        if subset.is_empty() {
-                                            break 'eval;
-                                        }
-                                        let mut cur =
-                                            Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
-                                        debug_assert!(cur.cached_subsets.get().is_none());
-                                        cur.subset.intersect(
-                                            subset.as_ref(),
-                                            &with_pool_set(|ps| ps.get_pool()),
-                                        );
-                                        if cur.subset.is_empty() {
-                                            break 'eval;
-                                        }
-                                        binding_info.move_back_node(*atom, Arc::new(cur));
-                                    }
-
                                     let mut materializations: DenseIdMap<
                                         MatId,
                                         Arc<DashMap<Vec<Value>, RowBuffer>>,
@@ -350,18 +389,21 @@ impl Database {
 
                 let search_and_apply_timer = Instant::now();
                 'eval: {
+                    for JoinHeader { atom, subset, .. } in plan.header() {
+                        if subset.is_empty() {
+                            break 'eval;
+                        }
+                        let mut cur = Arc::try_unwrap(binding_info.unwrap_val(*atom)).unwrap();
+                        debug_assert!(cur.cached_subsets.get().is_none());
+                        cur.subset
+                            .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
+                        if cur.subset.is_empty() {
+                            break 'eval;
+                        }
+                        binding_info.move_back_node(*atom, Arc::new(cur));
+                    }
                     match plan {
                         Plan::SinglePlan(plan) => {
-                            for JoinHeader { atom, subset, .. } in &plan.header {
-                                if subset.is_empty() {
-                                    break 'eval;
-                                }
-                                let mut cur = Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
-                                debug_assert!(cur.cached_subsets.get().is_none());
-                                cur.subset
-                                    .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
-                                binding_info.move_back_node(*atom, Arc::new(cur));
-                            }
                             join_state.run_join_stages(
                                 &plan.stages,
                                 &plan.atoms,
@@ -371,20 +413,6 @@ impl Database {
                             );
                         }
                         Plan::DecomposedPlan(plan) => {
-                            for JoinHeader { atom, subset, .. } in plan.header.iter() {
-                                if subset.is_empty() {
-                                    break 'eval;
-                                }
-                                let mut cur = Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
-                                debug_assert!(cur.cached_subsets.get().is_none());
-                                cur.subset
-                                    .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
-                                if cur.subset.is_empty() {
-                                    break 'eval;
-                                }
-                                binding_info.move_back_node(*atom, Arc::new(cur));
-                            }
-
                             let mut materializations =
                                 DenseIdMap::with_capacity(plan.stages.blocks.len());
                             for i in 0..plan.stages.blocks.len() {
@@ -500,7 +528,7 @@ type ColumnIndexes = IdVec<ColumnId, OnceLock<Arc<ColumnIndex>>>;
 
 // pub(crate) type ChildrenMaps = IdVec<ColumnId, OnceLock<Arc<DashMap<Value, Arc<TrieNode>>>>>;
 // pub(crate) type ChildrenMaps = IdVec<ColumnId, Arc<DashMap<Value, Arc<TrieNode>>>>;
-pub(crate) type ChildrenMaps = IdVec<ColumnId, Arc<Mutex<HashMap<Value, Arc<TrieNode>>>>>;
+pub(crate) type ChildrenMaps = IdVec<ColumnId, ReadOptimizedLock<HashMap<Value, Arc<TrieNode>>>>;
 
 /// Information about the current subset of an atom's relation that is being considered, along with
 /// lazily-initialized, cached indexes on that subset.
@@ -513,8 +541,8 @@ pub(crate) struct TrieNode {
     /// The actual subset of the corresponding atom.
     subset: Subset,
     /// Any cached indexes on this subset.
-    cached_subsets: OnceLock<Arc<Pooled<ColumnIndexes>>>,
-    cached_children: OnceLock<Arc<Pooled<ChildrenMaps>>>,
+    cached_subsets: OnceLock<Pooled<ColumnIndexes>>,
+    cached_children: OnceLock<Pooled<ChildrenMaps>>,
 }
 
 impl std::fmt::Debug for TrieNode {
@@ -542,7 +570,7 @@ impl TrieNode {
             // Pre-size the vector so we do not need to borrow it mutably to initialize the index.
             let mut vec: Pooled<ColumnIndexes> = with_pool_set(|ps| ps.get());
             vec.resize_with(info.spec.arity(), OnceLock::new);
-            Arc::new(vec)
+            vec
         })[col]
             .get_or_init(|| {
                 let col_index = info.table.group_by_col(self.subset.as_ref(), col);
@@ -558,51 +586,23 @@ impl TrieNode {
         info: &TableInfo,
         sub: impl FnOnce() -> Subset,
     ) -> Arc<TrieNode> {
-        let mut map = self.cached_children.get_or_init(|| {
+        let map = &self.cached_children.get_or_init(|| {
             let mut vec: Pooled<ChildrenMaps> = with_pool_set(|ps| ps.get());
-            // vec.resize_with(info.spec.arity(), OnceLock::new);
-            vec.resize_with(info.spec.arity(), || {
-                Arc::new(Mutex::new(HashMap::default()))
-            });
-            Arc::new(vec)
-        })[col]
-            .lock()
-            .unwrap();
-        // .get_or_init(|| Arc::new(DashMap::with_hasher_and_shard_amount(Default::default(), 2)))
-
-        // if map.contains_key(&value) {
-        //     eprintln!(
-        //         "hit cache for column {:?} and value {:?} with {} tuples",
-        //         col,
-        //         value,
-        //         self.size()
-        //     );
-        // }
-        map.entry(value)
-            .or_insert_with(|| {
-                let sub = sub();
-                // eprintln!(
-                //     "Creating new trie node for column {:?} and {} tuples",
-                //     col,
-                //     sub.size()
-                // );
-                Arc::new(TrieNode::new(sub))
-            })
-            // .value()
-            .clone()
-    }
-}
-
-impl Clone for TrieNode {
-    fn clone(&self) -> Self {
-        let cached_subsets = OnceLock::new();
-        if let Some(cached) = self.cached_subsets.get() {
-            cached_subsets.set(cached.clone()).ok().unwrap();
-        }
-        Self {
-            subset: self.subset.clone(),
-            cached_subsets,
-            cached_children: self.cached_children.clone(),
+            vec.resize_with(info.spec.arity(), ReadOptimizedLock::default);
+            vec
+        })[col];
+        let guard = map.read();
+        if let Some(node) = guard.get(&value) {
+            node.clone()
+        } else {
+            drop(guard);
+            let mut guard = map.lock();
+            if let Some(node) = guard.get(&value) {
+                return node.clone();
+            }
+            let new_node = Arc::new(TrieNode::new(sub()));
+            guard.insert(value, new_node.clone());
+            new_node
         }
     }
 }
@@ -878,11 +878,15 @@ impl<'a> JoinState<'a> {
         }
 
         fn refine_subset(
-            sub: Subset,
+            sub: PotentiallyStale<Subset>,
             constraints: &[Constraint],
             table: &WrappedTableRef,
         ) -> Subset {
-            let sub = table.refine_live(sub);
+            let sub = if sub.can_be_stale {
+                table.refine_live(sub.inner)
+            } else {
+                sub.inner
+            };
             table.refine(sub, constraints)
         }
 
@@ -900,14 +904,16 @@ impl<'a> JoinState<'a> {
                     with_pool_set(|ps| {
                         prober.for_each(|val, x| {
                             updates.push_binding(*var, val[0]);
-                            let node =
+                            let node = if x.size() <= 16 {
+                                let sub = refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
+                                Arc::new(TrieNode::new(sub))
+                            } else {
                                 prober
                                     .node
                                     .get_cached_trie_node(a.column, val[0], info, || {
-                                        let sub =
-                                            refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
-                                        sub
-                                    });
+                                        refine_subset(x.to_owned(&ps.get_pool()), &[], &table)
+                                    })
+                            };
                             if node.subset.is_empty() {
                                 updates.rollback();
                                 return;
@@ -934,17 +940,16 @@ impl<'a> JoinState<'a> {
                         prober.for_each(|val, x| {
                             updates.push_binding(*var, val[0]);
 
-                            let node =
+                            let node = if x.size() <= 16 {
+                                let sub = refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
+                                Arc::new(TrieNode::new(sub))
+                            } else {
                                 prober
                                     .node
                                     .get_cached_trie_node(a.column, val[0], info, || {
-                                        let sub = refine_subset(
-                                            x.to_owned(&ps.get_pool()),
-                                            &a.cs,
-                                            &table,
-                                        );
-                                        sub
-                                    });
+                                        refine_subset(x.to_owned(&ps.get_pool()), &a.cs, &table)
+                                    })
+                            };
                             if node.subset.is_empty() {
                                 updates.rollback();
                                 return;
@@ -979,36 +984,46 @@ impl<'a> JoinState<'a> {
                     let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                     with_pool_set(|ps| {
                         smaller.for_each(|val, small_sub| {
-                            if let Some(mut large_sub) = larger.get_subset(val) {
+                            if let Some(large_sub) = larger.get_subset(val) {
                                 updates.push_binding(*var, val[0]);
-                                let smaller_node = smaller.node.get_cached_trie_node(
-                                    smaller_scan.column,
-                                    val[0],
-                                    small_info,
-                                    || {
-                                        let small_sub = refine_subset(
-                                            small_sub.to_owned(&ps.get_pool()),
-                                            &smaller_scan.cs,
-                                            &small_table,
-                                        );
-                                        small_sub
-                                    },
-                                );
+                                let smaller_node = if small_sub.size() <= 16 {
+                                    let small_sub = refine_subset(
+                                        small_sub.to_owned(&ps.get_pool()),
+                                        &smaller_scan.cs,
+                                        &small_table,
+                                    );
+                                    Arc::new(TrieNode::new(small_sub))
+                                } else {
+                                    smaller.node.get_cached_trie_node(
+                                        smaller_scan.column,
+                                        val[0],
+                                        small_info,
+                                        || {
+                                            refine_subset(
+                                                small_sub.to_owned(&ps.get_pool()),
+                                                &smaller_scan.cs,
+                                                &small_table,
+                                            )
+                                        },
+                                    )
+                                };
                                 if smaller_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
                                 }
                                 updates.refine_atom(smaller_atom, smaller_node);
-                                let larger_node = larger.node.get_cached_trie_node(
-                                    larger_scan.column,
-                                    val[0],
-                                    large_info,
-                                    || {
-                                        large_sub =
-                                            refine_subset(large_sub, &larger_scan.cs, &large_table);
-                                        large_sub
-                                    },
-                                );
+                                let larger_node = if large_sub.size() <= 16 {
+                                    let large_sub =
+                                        refine_subset(large_sub, &larger_scan.cs, &large_table);
+                                    Arc::new(TrieNode::new(large_sub))
+                                } else {
+                                    larger.node.get_cached_trie_node(
+                                        larger_scan.column,
+                                        val[0],
+                                        large_info,
+                                        || refine_subset(large_sub, &larger_scan.cs, &large_table),
+                                    )
+                                };
                                 if larger_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
@@ -1056,19 +1071,21 @@ impl<'a> JoinState<'a> {
                                     if i == smallest {
                                         continue;
                                     }
-                                    if let Some(mut sub) = probers[i].get_subset(key) {
+                                    if let Some(sub) = probers[i].get_subset(key) {
                                         let table = self.db.tables[atoms[rest[i].atom].table]
                                             .table
                                             .as_ref();
-                                        let node = probers[i].node.get_cached_trie_node(
-                                            scan.column,
-                                            key[0],
-                                            &self.db.tables[atoms[scan.atom].table],
-                                            || {
-                                                sub = refine_subset(sub, &rest[i].cs, &table);
-                                                sub
-                                            },
-                                        );
+                                        let node = if sub.size() <= 16 {
+                                            let sub = refine_subset(sub, &rest[i].cs, &table);
+                                            Arc::new(TrieNode::new(sub))
+                                        } else {
+                                            probers[i].node.get_cached_trie_node(
+                                                scan.column,
+                                                key[0],
+                                                &self.db.tables[atoms[scan.atom].table],
+                                                || refine_subset(sub, &rest[i].cs, &table),
+                                            )
+                                        };
                                         if node.subset.is_empty() {
                                             updates.rollback();
                                             return;
@@ -1080,17 +1097,25 @@ impl<'a> JoinState<'a> {
                                         return;
                                     }
                                 }
-                                let main_node = probers[smallest].node.get_cached_trie_node(
-                                    main_spec.column,
-                                    key[0],
-                                    main_spec_info,
-                                    || {
-                                        let sub = sub.to_owned(&ps.get_pool());
-                                        let sub =
-                                            refine_subset(sub, &main_spec.cs, &main_spec_table);
-                                        sub
-                                    },
-                                );
+                                let main_node = if sub.size() <= 16 {
+                                    let sub = refine_subset(
+                                        sub.to_owned(&ps.get_pool()),
+                                        &main_spec.cs,
+                                        &main_spec_table,
+                                    );
+                                    Arc::new(TrieNode::new(sub))
+                                } else {
+                                    probers[smallest].node.get_cached_trie_node(
+                                        main_spec.column,
+                                        key[0],
+                                        main_spec_info,
+                                        || {
+                                            let sub = sub.to_owned(&ps.get_pool());
+
+                                            refine_subset(sub, &main_spec.cs, &main_spec_table)
+                                        },
+                                    )
+                                };
                                 if main_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
@@ -1224,7 +1249,7 @@ impl<'a> JoinState<'a> {
                                 .iter()
                                 .map(|col| key[col.index()])
                                 .collect::<SmallVec<[Value; 4]>>();
-                            let Some(mut subset) = prober.get_subset(&index_key) else {
+                            let Some(subset) = prober.get_subset(&index_key) else {
                                 updates.rollback();
                                 // There are no possible values for this subset
                                 continue 'mid;
@@ -1232,7 +1257,7 @@ impl<'a> JoinState<'a> {
                             // apply any constraints needed in this scan.
                             let table_info = &self.db.tables[atoms[*atom].table];
                             let cs = &to_intersect[*i].0.constraints;
-                            subset = refine_subset(subset, cs, &table_info.table.as_ref());
+                            let subset = refine_subset(subset, cs, &table_info.table.as_ref());
                             if subset.is_empty() {
                                 updates.rollback();
                                 // There are no possible values for this subset
@@ -1303,6 +1328,13 @@ impl<'a> JoinState<'a> {
                             key.push(val);
                         }
                         if let Some(subset) = prober.get_subset(&key) {
+                            let subset = refine_subset(
+                                subset,
+                                &spec.constraints,
+                                &self.db.tables[atoms[spec.to_index.atom].table]
+                                    .table
+                                    .as_ref(),
+                            );
                             updates
                                 .refine_atom(spec.to_index.atom, Arc::new(TrieNode::new(subset)));
                         } else {
@@ -1879,9 +1911,8 @@ fn sort_plan_by_size_inner(
             JoinStage::Intersect { scans, .. } => scans
                 .iter()
                 .map(|scan| times_refined.get(scan.atom).copied().unwrap_or_default())
-                // .max()
-                // .unwrap(),
-                .sum(),
+                .max()
+                .unwrap(),
             JoinStage::FusedIntersect { cover, .. } => times_refined
                 .get(cover.to_index.atom)
                 .copied()

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -3,11 +3,11 @@
 use std::{
     cmp, iter, mem,
     ops::Range,
-    sync::{Arc, OnceLock, atomic::AtomicUsize},
+    sync::{Arc, Mutex, OnceLock, atomic::AtomicUsize},
 };
 
 use crate::{
-    common::HashMap,
+    common::{HashMap, ShardData, ShardId},
     free_join::plan::{JoinStages, MatId, MatScanMode, MatSpec},
     numeric_id::{DenseIdMap, IdVec, NumericId},
     query::Atom,
@@ -58,7 +58,7 @@ enum DynamicIndex {
 }
 
 struct Prober {
-    node: TrieNode,
+    node: Arc<TrieNode>,
     pool: Pool<SortedOffsetVector>,
     ix: DynamicIndex,
 }
@@ -202,13 +202,14 @@ impl Database {
                                         if subset.is_empty() {
                                             break 'eval;
                                         }
-                                        let mut cur = binding_info.unwrap_val(*atom);
+                                        let mut cur =
+                                            Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
                                         debug_assert!(cur.cached_subsets.get().is_none());
                                         cur.subset.intersect(
                                             subset.as_ref(),
                                             &with_pool_set(|ps| ps.get_pool()),
                                         );
-                                        binding_info.move_back_node(*atom, cur);
+                                        binding_info.move_back_node(*atom, Arc::new(cur));
                                     }
                                     join_state.run_join_stages(
                                         &plan.stages,
@@ -223,7 +224,8 @@ impl Database {
                                         if subset.is_empty() {
                                             break 'eval;
                                         }
-                                        let mut cur = binding_info.unwrap_val(*atom);
+                                        let mut cur =
+                                            Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
                                         debug_assert!(cur.cached_subsets.get().is_none());
                                         cur.subset.intersect(
                                             subset.as_ref(),
@@ -232,7 +234,7 @@ impl Database {
                                         if cur.subset.is_empty() {
                                             break 'eval;
                                         }
-                                        binding_info.move_back_node(*atom, cur);
+                                        binding_info.move_back_node(*atom, Arc::new(cur));
                                     }
 
                                     let mut materializations: DenseIdMap<
@@ -354,11 +356,11 @@ impl Database {
                                 if subset.is_empty() {
                                     break 'eval;
                                 }
-                                let mut cur = binding_info.unwrap_val(*atom);
+                                let mut cur = Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
                                 debug_assert!(cur.cached_subsets.get().is_none());
                                 cur.subset
                                     .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
-                                binding_info.move_back_node(*atom, cur);
+                                binding_info.move_back_node(*atom, Arc::new(cur));
                             }
                             join_state.run_join_stages(
                                 &plan.stages,
@@ -373,14 +375,14 @@ impl Database {
                                 if subset.is_empty() {
                                     break 'eval;
                                 }
-                                let mut cur = binding_info.unwrap_val(*atom);
+                                let mut cur = Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
                                 debug_assert!(cur.cached_subsets.get().is_none());
                                 cur.subset
                                     .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
                                 if cur.subset.is_empty() {
                                     break 'eval;
                                 }
-                                binding_info.move_back_node(*atom, cur);
+                                binding_info.move_back_node(*atom, Arc::new(cur));
                             }
 
                             let mut materializations =
@@ -491,7 +493,14 @@ struct JoinState<'a> {
     exec_state: ExecutionState<'a>,
 }
 
+// TODO: use SmallVec might be better
 type ColumnIndexes = IdVec<ColumnId, OnceLock<Arc<ColumnIndex>>>;
+// pub(crate) type ChildrenMaps =
+//     IdVec<ColumnId, OnceLock<Arc<HashMap<Value, OnceLock<Arc<TrieNode>>>>>>;
+
+// pub(crate) type ChildrenMaps = IdVec<ColumnId, OnceLock<Arc<DashMap<Value, Arc<TrieNode>>>>>;
+// pub(crate) type ChildrenMaps = IdVec<ColumnId, Arc<DashMap<Value, Arc<TrieNode>>>>;
+pub(crate) type ChildrenMaps = IdVec<ColumnId, Arc<Mutex<HashMap<Value, Arc<TrieNode>>>>>;
 
 /// Information about the current subset of an atom's relation that is being considered, along with
 /// lazily-initialized, cached indexes on that subset.
@@ -500,14 +509,31 @@ type ColumnIndexes = IdVec<ColumnId, OnceLock<Arc<ColumnIndex>>>;
 /// implementation and the FJ paper. It currently does not handle non-column indexes, but that
 /// should be a fairly straightforward extension if we start generating plans that need those.
 /// (Right now, most plans iterating over more than one column just do a scan anyway).
-struct TrieNode {
+pub(crate) struct TrieNode {
     /// The actual subset of the corresponding atom.
     subset: Subset,
     /// Any cached indexes on this subset.
     cached_subsets: OnceLock<Arc<Pooled<ColumnIndexes>>>,
+    cached_children: OnceLock<Arc<Pooled<ChildrenMaps>>>,
+}
+
+impl std::fmt::Debug for TrieNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrieNode")
+            .field("subset", &self.subset)
+            .finish()
+    }
 }
 
 impl TrieNode {
+    fn new(subset: Subset) -> Self {
+        Self {
+            subset,
+            cached_subsets: Default::default(),
+            cached_children: Default::default(),
+        }
+    }
+
     fn size(&self) -> usize {
         self.subset.size()
     }
@@ -524,6 +550,47 @@ impl TrieNode {
             })
             .clone()
     }
+
+    fn get_cached_trie_node(
+        &self,
+        col: ColumnId,
+        value: Value,
+        info: &TableInfo,
+        sub: impl FnOnce() -> Subset,
+    ) -> Arc<TrieNode> {
+        let mut map = self.cached_children.get_or_init(|| {
+            let mut vec: Pooled<ChildrenMaps> = with_pool_set(|ps| ps.get());
+            // vec.resize_with(info.spec.arity(), OnceLock::new);
+            vec.resize_with(info.spec.arity(), || {
+                Arc::new(Mutex::new(HashMap::default()))
+            });
+            Arc::new(vec)
+        })[col]
+            .lock()
+            .unwrap();
+        // .get_or_init(|| Arc::new(DashMap::with_hasher_and_shard_amount(Default::default(), 2)))
+
+        // if map.contains_key(&value) {
+        //     eprintln!(
+        //         "hit cache for column {:?} and value {:?} with {} tuples",
+        //         col,
+        //         value,
+        //         self.size()
+        //     );
+        // }
+        map.entry(value)
+            .or_insert_with(|| {
+                let sub = sub();
+                // eprintln!(
+                //     "Creating new trie node for column {:?} and {} tuples",
+                //     col,
+                //     sub.size()
+                // );
+                Arc::new(TrieNode::new(sub))
+            })
+            // .value()
+            .clone()
+    }
 }
 
 impl Clone for TrieNode {
@@ -535,6 +602,7 @@ impl Clone for TrieNode {
         Self {
             subset: self.subset.clone(),
             cached_subsets,
+            cached_children: self.cached_children.clone(),
         }
     }
 }
@@ -542,17 +610,22 @@ impl Clone for TrieNode {
 #[derive(Default, Clone)]
 struct BindingInfo {
     bindings: DenseIdMap<Variable, Value>,
-    subsets: DenseIdMap<AtomId, TrieNode>,
+    subsets: DenseIdMap<AtomId, Arc<TrieNode>>,
     materializations: DenseIdMap<MatId, Arc<HashMap<Vec<Value>, RowBuffer>>>,
 }
 
 impl BindingInfo {
     /// Initializes the atom-related metadata in the [`BindingInfo`].
     fn insert_subset(&mut self, atom: AtomId, subset: Subset) {
-        let node = TrieNode {
+        let node = Arc::new(TrieNode {
             subset,
             cached_subsets: Default::default(),
-        };
+            cached_children: Default::default(),
+        });
+        self.subsets.insert(atom, node);
+    }
+
+    fn insert_node(&mut self, atom: AtomId, node: Arc<TrieNode>) {
         self.subsets.insert(atom, node);
     }
 
@@ -562,7 +635,7 @@ impl BindingInfo {
         self.subsets.insert(atom, prober.node);
     }
 
-    fn move_back_node(&mut self, atom: AtomId, node: TrieNode) {
+    fn move_back_node(&mut self, atom: AtomId, node: Arc<TrieNode>) {
         self.subsets.insert(atom, node);
     }
 
@@ -570,7 +643,7 @@ impl BindingInfo {
         self.subsets[atom].subset.is_empty()
     }
 
-    fn unwrap_val(&mut self, atom: AtomId) -> TrieNode {
+    fn unwrap_val(&mut self, atom: AtomId) -> Arc<TrieNode> {
         self.subsets.unwrap_val(atom)
     }
 }
@@ -737,7 +810,7 @@ impl<'a> JoinState<'a> {
                             binding_info.bindings.insert(var, val);
                         }
                         UpdateInstr::RefineAtom(atom, subset) => {
-                            binding_info.insert_subset(atom, subset);
+                            binding_info.insert_node(atom, subset);
                         }
                         UpdateInstr::EndFrame => {
                             self.run_plan(
@@ -780,7 +853,7 @@ impl<'a> JoinState<'a> {
                                 binding_info.bindings.insert(var, val);
                             }
                             UpdateInstr::RefineAtom(atom, subset) => {
-                                binding_info.insert_subset(atom, subset);
+                                binding_info.insert_node(atom, subset);
                             }
                             UpdateInstr::EndFrame => {
                                 JoinState {
@@ -821,17 +894,25 @@ impl<'a> JoinState<'a> {
                         return;
                     }
                     let prober = self.get_column_index(atoms, binding_info, a.atom, a.column);
-                    let table = self.db.tables[atoms[a.atom].table].table.as_ref();
+                    let info = &self.db.tables[atoms[a.atom].table];
+                    let table = info.table.as_ref();
                     let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                     with_pool_set(|ps| {
                         prober.for_each(|val, x| {
                             updates.push_binding(*var, val[0]);
-                            let sub = refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
-                            if sub.is_empty() {
+                            let node =
+                                prober
+                                    .node
+                                    .get_cached_trie_node(a.column, val[0], info, || {
+                                        let sub =
+                                            refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
+                                        sub
+                                    });
+                            if node.subset.is_empty() {
                                 updates.rollback();
                                 return;
                             }
-                            updates.refine_atom(a.atom, sub);
+                            updates.refine_atom(a.atom, node);
                             updates.finish_frame();
                             if updates.frames() >= chunk_size {
                                 drain_updates!(updates);
@@ -846,17 +927,29 @@ impl<'a> JoinState<'a> {
                         return;
                     }
                     let prober = self.get_column_index(atoms, binding_info, a.atom, a.column);
+                    let info = &self.db.tables[atoms[a.atom].table];
                     let table = self.db.tables[atoms[a.atom].table].table.as_ref();
                     let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                     with_pool_set(|ps| {
                         prober.for_each(|val, x| {
                             updates.push_binding(*var, val[0]);
-                            let sub = refine_subset(x.to_owned(&ps.get_pool()), &a.cs, &table);
-                            if sub.is_empty() {
+
+                            let node =
+                                prober
+                                    .node
+                                    .get_cached_trie_node(a.column, val[0], info, || {
+                                        let sub = refine_subset(
+                                            x.to_owned(&ps.get_pool()),
+                                            &a.cs,
+                                            &table,
+                                        );
+                                        sub
+                                    });
+                            if node.subset.is_empty() {
                                 updates.rollback();
                                 return;
                             }
-                            updates.refine_atom(a.atom, sub);
+                            updates.refine_atom(a.atom, node);
                             updates.finish_frame();
                             if updates.frames() >= chunk_size {
                                 drain_updates!(updates);
@@ -879,29 +972,48 @@ impl<'a> JoinState<'a> {
 
                     let smaller_atom = smaller_scan.atom;
                     let larger_atom = larger_scan.atom;
-                    let large_table = self.db.tables[atoms[larger_atom].table].table.as_ref();
-                    let small_table = self.db.tables[atoms[smaller_atom].table].table.as_ref();
+                    let large_info = &self.db.tables[atoms[larger_atom].table];
+                    let large_table = large_info.table.as_ref();
+                    let small_info = &self.db.tables[atoms[smaller_atom].table];
+                    let small_table = small_info.table.as_ref();
                     let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                     with_pool_set(|ps| {
                         smaller.for_each(|val, small_sub| {
                             if let Some(mut large_sub) = larger.get_subset(val) {
-                                large_sub = refine_subset(large_sub, &larger_scan.cs, &large_table);
-                                if large_sub.is_empty() {
-                                    updates.rollback();
-                                    return;
-                                }
-                                let small_sub = refine_subset(
-                                    small_sub.to_owned(&ps.get_pool()),
-                                    &smaller_scan.cs,
-                                    &small_table,
-                                );
-                                if small_sub.is_empty() {
-                                    updates.rollback();
-                                    return;
-                                }
                                 updates.push_binding(*var, val[0]);
-                                updates.refine_atom(smaller_atom, small_sub);
-                                updates.refine_atom(larger_atom, large_sub);
+                                let smaller_node = smaller.node.get_cached_trie_node(
+                                    smaller_scan.column,
+                                    val[0],
+                                    small_info,
+                                    || {
+                                        let small_sub = refine_subset(
+                                            small_sub.to_owned(&ps.get_pool()),
+                                            &smaller_scan.cs,
+                                            &small_table,
+                                        );
+                                        small_sub
+                                    },
+                                );
+                                if smaller_node.subset.is_empty() {
+                                    updates.rollback();
+                                    return;
+                                }
+                                updates.refine_atom(smaller_atom, smaller_node);
+                                let larger_node = larger.node.get_cached_trie_node(
+                                    larger_scan.column,
+                                    val[0],
+                                    large_info,
+                                    || {
+                                        large_sub =
+                                            refine_subset(large_sub, &larger_scan.cs, &large_table);
+                                        large_sub
+                                    },
+                                );
+                                if larger_node.subset.is_empty() {
+                                    updates.rollback();
+                                    return;
+                                }
+                                updates.refine_atom(larger_atom, larger_node);
                                 updates.finish_frame();
                                 if updates.frames() >= chunk_size {
                                     drain_updates_parallel!(updates);
@@ -930,8 +1042,8 @@ impl<'a> JoinState<'a> {
                     }
 
                     let main_spec = &rest[smallest];
-                    let main_spec_table =
-                        self.db.tables[atoms[main_spec.atom].table].table.as_ref();
+                    let main_spec_info = &self.db.tables[atoms[main_spec.atom].table];
+                    let main_spec_table = main_spec_info.table.as_ref();
 
                     if smallest_size != 0 {
                         // Smallest leads the scan
@@ -948,25 +1060,42 @@ impl<'a> JoinState<'a> {
                                         let table = self.db.tables[atoms[rest[i].atom].table]
                                             .table
                                             .as_ref();
-                                        sub = refine_subset(sub, &rest[i].cs, &table);
-                                        if sub.is_empty() {
+                                        let node = probers[i].node.get_cached_trie_node(
+                                            scan.column,
+                                            key[0],
+                                            &self.db.tables[atoms[scan.atom].table],
+                                            || {
+                                                sub = refine_subset(sub, &rest[i].cs, &table);
+                                                sub
+                                            },
+                                        );
+                                        if node.subset.is_empty() {
                                             updates.rollback();
                                             return;
                                         }
-                                        updates.refine_atom(scan.atom, sub)
+                                        updates.refine_atom(scan.atom, node);
                                     } else {
                                         updates.rollback();
                                         // Empty intersection.
                                         return;
                                     }
                                 }
-                                let sub = sub.to_owned(&ps.get_pool());
-                                let sub = refine_subset(sub, &main_spec.cs, &main_spec_table);
-                                if sub.is_empty() {
+                                let main_node = probers[smallest].node.get_cached_trie_node(
+                                    main_spec.column,
+                                    key[0],
+                                    main_spec_info,
+                                    || {
+                                        let sub = sub.to_owned(&ps.get_pool());
+                                        let sub =
+                                            refine_subset(sub, &main_spec.cs, &main_spec_table);
+                                        sub
+                                    },
+                                );
+                                if main_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
                                 }
-                                updates.refine_atom(main_spec.atom, sub);
+                                updates.refine_atom(main_spec.atom, main_node);
                                 updates.finish_frame();
                                 if updates.frames() >= chunk_size {
                                     drain_updates_parallel!(updates);
@@ -1009,7 +1138,10 @@ impl<'a> JoinState<'a> {
                     for (row, key) in buffer.non_stale() {
                         updates.refine_atom(
                             cover_atom,
-                            Subset::Dense(OffsetRange::new(row, row.inc())),
+                            Arc::new(TrieNode::new(Subset::Dense(OffsetRange::new(
+                                row,
+                                row.inc(),
+                            )))),
                         );
                         // bind the values
                         for (i, (_, var)) in bind.iter().enumerate() {
@@ -1075,7 +1207,10 @@ impl<'a> JoinState<'a> {
                     'mid: for (row, key) in buffer.non_stale() {
                         updates.refine_atom(
                             cover_atom,
-                            Subset::Dense(OffsetRange::new(row, row.inc())),
+                            Arc::new(TrieNode::new(Subset::Dense(OffsetRange::new(
+                                row,
+                                row.inc(),
+                            )))),
                         );
                         // bind the values
                         for (i, (_, var)) in bind.iter().enumerate() {
@@ -1103,7 +1238,7 @@ impl<'a> JoinState<'a> {
                                 // There are no possible values for this subset
                                 continue 'mid;
                             }
-                            updates.refine_atom(*atom, subset);
+                            updates.refine_atom(*atom, Arc::new(TrieNode::new(subset)));
                         }
                         updates.finish_frame();
                         if updates.frames() >= chunk_size {
@@ -1168,7 +1303,8 @@ impl<'a> JoinState<'a> {
                             key.push(val);
                         }
                         if let Some(subset) = prober.get_subset(&key) {
-                            updates.refine_atom(spec.to_index.atom, subset);
+                            updates
+                                .refine_atom(spec.to_index.atom, Arc::new(TrieNode::new(subset)));
                         } else {
                             return false;
                         }
@@ -1743,8 +1879,9 @@ fn sort_plan_by_size_inner(
             JoinStage::Intersect { scans, .. } => scans
                 .iter()
                 .map(|scan| times_refined.get(scan.atom).copied().unwrap_or_default())
-                .max()
-                .unwrap(),
+                // .max()
+                // .unwrap(),
+                .sum(),
             JoinStage::FusedIntersect { cover, .. } => times_refined
                 .get(cover.to_index.atom)
                 .copied()

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -3,11 +3,11 @@
 use std::{
     cmp, iter, mem,
     ops::Range,
-    sync::{Arc, OnceLock, atomic::AtomicUsize},
+    sync::{Arc, Mutex, OnceLock, atomic::AtomicUsize},
 };
 
 use crate::{
-    common::HashMap,
+    common::{HashMap, ShardData, ShardId},
     free_join::plan::{JoinStages, MatId, MatScanMode, MatSpec},
     numeric_id::{DenseIdMap, IdVec, NumericId},
     query::Atom,
@@ -159,7 +159,7 @@ enum DynamicIndex {
 }
 
 struct Prober {
-    node: TrieNode,
+    node: Arc<TrieNode>,
     pool: Pool<SortedOffsetVector>,
     ix: DynamicIndex,
 }
@@ -311,13 +311,14 @@ impl Database {
                                         if subset.is_empty() {
                                             break 'eval;
                                         }
-                                        let mut cur = binding_info.unwrap_val(*atom);
+                                        let mut cur =
+                                            Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
                                         debug_assert!(cur.cached_subsets.get().is_none());
                                         cur.subset.intersect(
                                             subset.as_ref(),
                                             &with_pool_set(|ps| ps.get_pool()),
                                         );
-                                        binding_info.move_back_node(*atom, cur);
+                                        binding_info.move_back_node(*atom, Arc::new(cur));
                                     }
                                     join_state.run_join_stages(
                                         &plan.stages,
@@ -332,7 +333,8 @@ impl Database {
                                         if subset.is_empty() {
                                             break 'eval;
                                         }
-                                        let mut cur = binding_info.unwrap_val(*atom);
+                                        let mut cur =
+                                            Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
                                         debug_assert!(cur.cached_subsets.get().is_none());
                                         cur.subset.intersect(
                                             subset.as_ref(),
@@ -341,7 +343,7 @@ impl Database {
                                         if cur.subset.is_empty() {
                                             break 'eval;
                                         }
-                                        binding_info.move_back_node(*atom, cur);
+                                        binding_info.move_back_node(*atom, Arc::new(cur));
                                     }
 
                                     let mut materializations: DenseIdMap<
@@ -463,11 +465,11 @@ impl Database {
                                 if subset.is_empty() {
                                     break 'eval;
                                 }
-                                let mut cur = binding_info.unwrap_val(*atom);
+                                let mut cur = Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
                                 debug_assert!(cur.cached_subsets.get().is_none());
                                 cur.subset
                                     .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
-                                binding_info.move_back_node(*atom, cur);
+                                binding_info.move_back_node(*atom, Arc::new(cur));
                             }
                             join_state.run_join_stages(
                                 &plan.stages,
@@ -482,14 +484,14 @@ impl Database {
                                 if subset.is_empty() {
                                     break 'eval;
                                 }
-                                let mut cur = binding_info.unwrap_val(*atom);
+                                let mut cur = Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
                                 debug_assert!(cur.cached_subsets.get().is_none());
                                 cur.subset
                                     .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
                                 if cur.subset.is_empty() {
                                     break 'eval;
                                 }
-                                binding_info.move_back_node(*atom, cur);
+                                binding_info.move_back_node(*atom, Arc::new(cur));
                             }
 
                             let mut materializations =
@@ -600,7 +602,14 @@ struct JoinState<'a> {
     exec_state: ExecutionState<'a>,
 }
 
+// TODO: use SmallVec might be better
 type ColumnIndexes = IdVec<ColumnId, OnceLock<Arc<ColumnIndex>>>;
+// pub(crate) type ChildrenMaps =
+//     IdVec<ColumnId, OnceLock<Arc<HashMap<Value, OnceLock<Arc<TrieNode>>>>>>;
+
+// pub(crate) type ChildrenMaps = IdVec<ColumnId, OnceLock<Arc<DashMap<Value, Arc<TrieNode>>>>>;
+// pub(crate) type ChildrenMaps = IdVec<ColumnId, Arc<DashMap<Value, Arc<TrieNode>>>>;
+pub(crate) type ChildrenMaps = IdVec<ColumnId, Arc<Mutex<HashMap<Value, Arc<TrieNode>>>>>;
 
 /// Information about the current subset of an atom's relation that is being considered, along with
 /// lazily-initialized, cached indexes on that subset.
@@ -609,14 +618,31 @@ type ColumnIndexes = IdVec<ColumnId, OnceLock<Arc<ColumnIndex>>>;
 /// implementation and the FJ paper. It currently does not handle non-column indexes, but that
 /// should be a fairly straightforward extension if we start generating plans that need those.
 /// (Right now, most plans iterating over more than one column just do a scan anyway).
-struct TrieNode {
+pub(crate) struct TrieNode {
     /// The actual subset of the corresponding atom.
     subset: Subset,
     /// Any cached indexes on this subset.
     cached_subsets: OnceLock<Arc<Pooled<ColumnIndexes>>>,
+    cached_children: OnceLock<Arc<Pooled<ChildrenMaps>>>,
+}
+
+impl std::fmt::Debug for TrieNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrieNode")
+            .field("subset", &self.subset)
+            .finish()
+    }
 }
 
 impl TrieNode {
+    fn new(subset: Subset) -> Self {
+        Self {
+            subset,
+            cached_subsets: Default::default(),
+            cached_children: Default::default(),
+        }
+    }
+
     fn size(&self) -> usize {
         self.subset.size()
     }
@@ -633,6 +659,47 @@ impl TrieNode {
             })
             .clone()
     }
+
+    fn get_cached_trie_node(
+        &self,
+        col: ColumnId,
+        value: Value,
+        info: &TableInfo,
+        sub: impl FnOnce() -> Subset,
+    ) -> Arc<TrieNode> {
+        let mut map = self.cached_children.get_or_init(|| {
+            let mut vec: Pooled<ChildrenMaps> = with_pool_set(|ps| ps.get());
+            // vec.resize_with(info.spec.arity(), OnceLock::new);
+            vec.resize_with(info.spec.arity(), || {
+                Arc::new(Mutex::new(HashMap::default()))
+            });
+            Arc::new(vec)
+        })[col]
+            .lock()
+            .unwrap();
+        // .get_or_init(|| Arc::new(DashMap::with_hasher_and_shard_amount(Default::default(), 2)))
+
+        // if map.contains_key(&value) {
+        //     eprintln!(
+        //         "hit cache for column {:?} and value {:?} with {} tuples",
+        //         col,
+        //         value,
+        //         self.size()
+        //     );
+        // }
+        map.entry(value)
+            .or_insert_with(|| {
+                let sub = sub();
+                // eprintln!(
+                //     "Creating new trie node for column {:?} and {} tuples",
+                //     col,
+                //     sub.size()
+                // );
+                Arc::new(TrieNode::new(sub))
+            })
+            // .value()
+            .clone()
+    }
 }
 
 impl Clone for TrieNode {
@@ -644,6 +711,7 @@ impl Clone for TrieNode {
         Self {
             subset: self.subset.clone(),
             cached_subsets,
+            cached_children: self.cached_children.clone(),
         }
     }
 }
@@ -651,17 +719,22 @@ impl Clone for TrieNode {
 #[derive(Default, Clone)]
 struct BindingInfo {
     bindings: DenseIdMap<Variable, Value>,
-    subsets: DenseIdMap<AtomId, TrieNode>,
+    subsets: DenseIdMap<AtomId, Arc<TrieNode>>,
     materializations: DenseIdMap<MatId, Arc<HashMap<Vec<Value>, RowBuffer>>>,
 }
 
 impl BindingInfo {
     /// Initializes the atom-related metadata in the [`BindingInfo`].
     fn insert_subset(&mut self, atom: AtomId, subset: Subset) {
-        let node = TrieNode {
+        let node = Arc::new(TrieNode {
             subset,
             cached_subsets: Default::default(),
-        };
+            cached_children: Default::default(),
+        });
+        self.subsets.insert(atom, node);
+    }
+
+    fn insert_node(&mut self, atom: AtomId, node: Arc<TrieNode>) {
         self.subsets.insert(atom, node);
     }
 
@@ -671,7 +744,7 @@ impl BindingInfo {
         self.subsets.insert(atom, prober.node);
     }
 
-    fn move_back_node(&mut self, atom: AtomId, node: TrieNode) {
+    fn move_back_node(&mut self, atom: AtomId, node: Arc<TrieNode>) {
         self.subsets.insert(atom, node);
     }
 
@@ -679,7 +752,7 @@ impl BindingInfo {
         self.subsets[atom].subset.is_empty()
     }
 
-    fn unwrap_val(&mut self, atom: AtomId) -> TrieNode {
+    fn unwrap_val(&mut self, atom: AtomId) -> Arc<TrieNode> {
         self.subsets.unwrap_val(atom)
     }
 }
@@ -851,7 +924,7 @@ impl<'a> JoinState<'a> {
                             binding_info.bindings.insert(var, val);
                         }
                         UpdateInstr::RefineAtom(atom, subset) => {
-                            binding_info.insert_subset(atom, subset);
+                            binding_info.insert_node(atom, subset);
                         }
                         UpdateInstr::EndFrame => {
                             self.run_plan(
@@ -894,7 +967,7 @@ impl<'a> JoinState<'a> {
                                 binding_info.bindings.insert(var, val);
                             }
                             UpdateInstr::RefineAtom(atom, subset) => {
-                                binding_info.insert_subset(atom, subset);
+                                binding_info.insert_node(atom, subset);
                             }
                             UpdateInstr::EndFrame => {
                                 JoinState {
@@ -935,17 +1008,25 @@ impl<'a> JoinState<'a> {
                         return;
                     }
                     let prober = self.get_column_index(atoms, binding_info, a.atom, a.column);
-                    let table = self.db.tables[atoms[a.atom].table].table.as_ref();
+                    let info = &self.db.tables[atoms[a.atom].table];
+                    let table = info.table.as_ref();
                     let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                     with_pool_set(|ps| {
                         prober.for_each(|val, x| {
                             updates.push_binding(*var, val[0]);
-                            let sub = refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
-                            if sub.is_empty() {
+                            let node =
+                                prober
+                                    .node
+                                    .get_cached_trie_node(a.column, val[0], info, || {
+                                        let sub =
+                                            refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
+                                        sub
+                                    });
+                            if node.subset.is_empty() {
                                 updates.rollback();
                                 return;
                             }
-                            updates.refine_atom(a.atom, sub);
+                            updates.refine_atom(a.atom, node);
                             updates.finish_frame();
                             if updates.frames() >= chunk_size {
                                 drain_updates!(updates);
@@ -960,17 +1041,29 @@ impl<'a> JoinState<'a> {
                         return;
                     }
                     let prober = self.get_column_index(atoms, binding_info, a.atom, a.column);
+                    let info = &self.db.tables[atoms[a.atom].table];
                     let table = self.db.tables[atoms[a.atom].table].table.as_ref();
                     let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                     with_pool_set(|ps| {
                         prober.for_each(|val, x| {
                             updates.push_binding(*var, val[0]);
-                            let sub = refine_subset(x.to_owned(&ps.get_pool()), &a.cs, &table);
-                            if sub.is_empty() {
+
+                            let node =
+                                prober
+                                    .node
+                                    .get_cached_trie_node(a.column, val[0], info, || {
+                                        let sub = refine_subset(
+                                            x.to_owned(&ps.get_pool()),
+                                            &a.cs,
+                                            &table,
+                                        );
+                                        sub
+                                    });
+                            if node.subset.is_empty() {
                                 updates.rollback();
                                 return;
                             }
-                            updates.refine_atom(a.atom, sub);
+                            updates.refine_atom(a.atom, node);
                             updates.finish_frame();
                             if updates.frames() >= chunk_size {
                                 drain_updates!(updates);
@@ -993,29 +1086,48 @@ impl<'a> JoinState<'a> {
 
                     let smaller_atom = smaller_scan.atom;
                     let larger_atom = larger_scan.atom;
-                    let large_table = self.db.tables[atoms[larger_atom].table].table.as_ref();
-                    let small_table = self.db.tables[atoms[smaller_atom].table].table.as_ref();
+                    let large_info = &self.db.tables[atoms[larger_atom].table];
+                    let large_table = large_info.table.as_ref();
+                    let small_info = &self.db.tables[atoms[smaller_atom].table];
+                    let small_table = small_info.table.as_ref();
                     let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                     with_pool_set(|ps| {
                         smaller.for_each(|val, small_sub| {
                             if let Some(mut large_sub) = larger.get_subset(val) {
-                                large_sub = refine_subset(large_sub, &larger_scan.cs, &large_table);
-                                if large_sub.is_empty() {
-                                    updates.rollback();
-                                    return;
-                                }
-                                let small_sub = refine_subset(
-                                    small_sub.to_owned(&ps.get_pool()),
-                                    &smaller_scan.cs,
-                                    &small_table,
-                                );
-                                if small_sub.is_empty() {
-                                    updates.rollback();
-                                    return;
-                                }
                                 updates.push_binding(*var, val[0]);
-                                updates.refine_atom(smaller_atom, small_sub);
-                                updates.refine_atom(larger_atom, large_sub);
+                                let smaller_node = smaller.node.get_cached_trie_node(
+                                    smaller_scan.column,
+                                    val[0],
+                                    small_info,
+                                    || {
+                                        let small_sub = refine_subset(
+                                            small_sub.to_owned(&ps.get_pool()),
+                                            &smaller_scan.cs,
+                                            &small_table,
+                                        );
+                                        small_sub
+                                    },
+                                );
+                                if smaller_node.subset.is_empty() {
+                                    updates.rollback();
+                                    return;
+                                }
+                                updates.refine_atom(smaller_atom, smaller_node);
+                                let larger_node = larger.node.get_cached_trie_node(
+                                    larger_scan.column,
+                                    val[0],
+                                    large_info,
+                                    || {
+                                        large_sub =
+                                            refine_subset(large_sub, &larger_scan.cs, &large_table);
+                                        large_sub
+                                    },
+                                );
+                                if larger_node.subset.is_empty() {
+                                    updates.rollback();
+                                    return;
+                                }
+                                updates.refine_atom(larger_atom, larger_node);
                                 updates.finish_frame();
                                 if updates.frames() >= chunk_size {
                                     drain_updates_parallel!(updates);
@@ -1044,8 +1156,8 @@ impl<'a> JoinState<'a> {
                     }
 
                     let main_spec = &rest[smallest];
-                    let main_spec_table =
-                        self.db.tables[atoms[main_spec.atom].table].table.as_ref();
+                    let main_spec_info = &self.db.tables[atoms[main_spec.atom].table];
+                    let main_spec_table = main_spec_info.table.as_ref();
 
                     if smallest_size != 0 {
                         // Smallest leads the scan
@@ -1062,25 +1174,42 @@ impl<'a> JoinState<'a> {
                                         let table = self.db.tables[atoms[rest[i].atom].table]
                                             .table
                                             .as_ref();
-                                        sub = refine_subset(sub, &rest[i].cs, &table);
-                                        if sub.is_empty() {
+                                        let node = probers[i].node.get_cached_trie_node(
+                                            scan.column,
+                                            key[0],
+                                            &self.db.tables[atoms[scan.atom].table],
+                                            || {
+                                                sub = refine_subset(sub, &rest[i].cs, &table);
+                                                sub
+                                            },
+                                        );
+                                        if node.subset.is_empty() {
                                             updates.rollback();
                                             return;
                                         }
-                                        updates.refine_atom(scan.atom, sub)
+                                        updates.refine_atom(scan.atom, node);
                                     } else {
                                         updates.rollback();
                                         // Empty intersection.
                                         return;
                                     }
                                 }
-                                let sub = sub.to_owned(&ps.get_pool());
-                                let sub = refine_subset(sub, &main_spec.cs, &main_spec_table);
-                                if sub.is_empty() {
+                                let main_node = probers[smallest].node.get_cached_trie_node(
+                                    main_spec.column,
+                                    key[0],
+                                    main_spec_info,
+                                    || {
+                                        let sub = sub.to_owned(&ps.get_pool());
+                                        let sub =
+                                            refine_subset(sub, &main_spec.cs, &main_spec_table);
+                                        sub
+                                    },
+                                );
+                                if main_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
                                 }
-                                updates.refine_atom(main_spec.atom, sub);
+                                updates.refine_atom(main_spec.atom, main_node);
                                 updates.finish_frame();
                                 if updates.frames() >= chunk_size {
                                     drain_updates_parallel!(updates);
@@ -1123,7 +1252,10 @@ impl<'a> JoinState<'a> {
                     for (row, key) in buffer.non_stale() {
                         updates.refine_atom(
                             cover_atom,
-                            Subset::Dense(OffsetRange::new(row, row.inc())),
+                            Arc::new(TrieNode::new(Subset::Dense(OffsetRange::new(
+                                row,
+                                row.inc(),
+                            )))),
                         );
                         // bind the values
                         for (i, (_, var)) in bind.iter().enumerate() {
@@ -1189,7 +1321,10 @@ impl<'a> JoinState<'a> {
                     'mid: for (row, key) in buffer.non_stale() {
                         updates.refine_atom(
                             cover_atom,
-                            Subset::Dense(OffsetRange::new(row, row.inc())),
+                            Arc::new(TrieNode::new(Subset::Dense(OffsetRange::new(
+                                row,
+                                row.inc(),
+                            )))),
                         );
                         // bind the values
                         for (i, (_, var)) in bind.iter().enumerate() {
@@ -1217,7 +1352,7 @@ impl<'a> JoinState<'a> {
                                 // There are no possible values for this subset
                                 continue 'mid;
                             }
-                            updates.refine_atom(*atom, subset);
+                            updates.refine_atom(*atom, Arc::new(TrieNode::new(subset)));
                         }
                         updates.finish_frame();
                         if updates.frames() >= chunk_size {
@@ -1282,7 +1417,8 @@ impl<'a> JoinState<'a> {
                             key.push(val);
                         }
                         if let Some(subset) = prober.get_subset(&key) {
-                            updates.refine_atom(spec.to_index.atom, subset);
+                            updates
+                                .refine_atom(spec.to_index.atom, Arc::new(TrieNode::new(subset)));
                         } else {
                             return false;
                         }
@@ -1857,8 +1993,9 @@ fn sort_plan_by_size_inner(
             JoinStage::Intersect { scans, .. } => scans
                 .iter()
                 .map(|scan| times_refined.get(scan.atom).copied().unwrap_or_default())
-                .max()
-                .unwrap(),
+                // .max()
+                // .unwrap(),
+                .sum(),
             JoinStage::FusedIntersect { cover, .. } => times_refined
                 .get(cover.to_index.atom)
                 .copied()

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -3,11 +3,11 @@
 use std::{
     cmp, iter, mem,
     ops::Range,
-    sync::{Arc, Mutex, OnceLock, atomic::AtomicUsize},
+    sync::{Arc, OnceLock, atomic::AtomicUsize},
 };
 
 use crate::{
-    common::{HashMap, ShardData, ShardId},
+    common::HashMap,
     free_join::plan::{JoinStages, MatId, MatScanMode, MatSpec},
     numeric_id::{DenseIdMap, IdVec, NumericId},
     query::Atom,
@@ -16,6 +16,7 @@ use crate::{
 use crossbeam::utils::CachePadded;
 use dashmap::mapref::entry::Entry;
 use dashmap::mapref::one::RefMut;
+use egglog_concurrency::ReadOptimizedLock;
 use egglog_reports::{ReportLevel, RuleReport, RuleSetReport};
 use smallvec::SmallVec;
 use web_time::Instant;
@@ -158,6 +159,51 @@ enum DynamicIndex {
     SparseColumn(SparseColumnIndex),
 }
 
+/// This struct is used to mark subsets that can contain non-stale entries.
+/// Whether a subset can be stale depends on the type of index it came from.
+/// Indices that come from a table may contain stale entries, while
+/// those that are built on the fly will not.
+struct PotentiallyStale<T> {
+    inner: T,
+    can_be_stale: bool,
+}
+
+impl<T> PotentiallyStale<T> {
+    fn maybe_stale(inner: T) -> Self {
+        Self {
+            inner,
+            can_be_stale: true,
+        }
+    }
+
+    fn not_stale(inner: T) -> Self {
+        Self {
+            inner,
+            can_be_stale: false,
+        }
+    }
+}
+
+impl PotentiallyStale<SubsetRef<'_>> {
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+
+    fn to_owned(&self, pool: &Pool<SortedOffsetVector>) -> PotentiallyStale<Subset> {
+        PotentiallyStale {
+            inner: self.inner.to_owned(pool),
+            can_be_stale: self.can_be_stale,
+        }
+    }
+}
+
+impl PotentiallyStale<Subset> {
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+}
+
+
 struct Prober {
     node: Arc<TrieNode>,
     pool: Pool<SortedOffsetVector>,
@@ -165,7 +211,7 @@ struct Prober {
 }
 
 impl Prober {
-    fn get_subset(&self, key: &[Value]) -> Option<Subset> {
+    fn get_subset(&self, key: &[Value]) -> Option<PotentiallyStale<Subset>> {
         match &self.ix {
             DynamicIndex::Cached {
                 intersect_outer,
@@ -178,7 +224,7 @@ impl Prober {
                         return None;
                     }
                 }
-                Some(sub)
+                Some(PotentiallyStale::maybe_stale(sub))
             }
             DynamicIndex::CachedColumn {
                 intersect_outer,
@@ -196,19 +242,21 @@ impl Prober {
                         return None;
                     }
                 }
-                Some(sub)
+                Some(PotentiallyStale::maybe_stale(sub))
             }
-            DynamicIndex::Dynamic(tab) => tab.get_subset(key).map(|x| x.to_owned(&self.pool)),
-            DynamicIndex::DynamicColumn(tab) => {
-                tab.get_subset(&key[0]).map(|x| x.to_owned(&self.pool))
-            }
+            DynamicIndex::Dynamic(tab) => tab
+                .get_subset(key)
+                .map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool))),
+            DynamicIndex::DynamicColumn(tab) => tab
+                .get_subset(&key[0])
+                .map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool))),
             DynamicIndex::SparseColumn(tab) => {
                 debug_assert_eq!(key.len(), 1);
-                tab.get_subset(key[0]).map(|x| x.to_owned(&self.pool))
+                tab.get_subset(key[0]).map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool)))
             }
         }
     }
-    fn for_each(&self, mut f: impl FnMut(&[Value], SubsetRef)) {
+    fn for_each(&self, mut f: impl FnMut(&[Value], PotentiallyStale<SubsetRef>)) {
         match &self.ix {
             DynamicIndex::Cached {
                 intersect_outer: true,
@@ -217,13 +265,16 @@ impl Prober {
                 let mut res = v.to_owned(&self.pool);
                 res.intersect(self.node.subset.as_ref(), &self.pool);
                 if !res.is_empty() {
-                    f(k, res.as_ref())
+                    f(k, PotentiallyStale::maybe_stale(res.as_ref()))
                 }
             }),
             DynamicIndex::Cached {
                 intersect_outer: false,
                 table,
-            } => table.get().unwrap().for_each(|k, v| f(k, v)),
+            } => table
+                .get()
+                .unwrap()
+                .for_each(|k, v| f(k, PotentiallyStale::maybe_stale(v))),
             DynamicIndex::CachedColumn {
                 intersect_outer: true,
                 table,
@@ -232,7 +283,7 @@ impl Prober {
                     let mut res = v.to_owned(&self.pool);
                     res.intersect(self.node.subset.as_ref(), &self.pool);
                     if !res.is_empty() {
-                        f(&[*k], res.as_ref())
+                        f(&[*k], PotentiallyStale::maybe_stale(res.as_ref()))
                     }
                 });
             }
@@ -240,16 +291,19 @@ impl Prober {
                 intersect_outer: false,
                 table,
             } => {
-                table.get().unwrap().for_each(|k, v| f(&[*k], v));
+                table
+                    .get()
+                    .unwrap()
+                    .for_each(|k, v| f(&[*k], PotentiallyStale::maybe_stale(v)));
             }
             DynamicIndex::Dynamic(tab) => {
-                tab.for_each(f);
+                tab.for_each(|k, v| f(k, PotentiallyStale::not_stale(v)));
             }
             DynamicIndex::DynamicColumn(tab) => tab.for_each(|k, v| {
-                f(&[*k], v);
+                f(&[*k], PotentiallyStale::not_stale(v));
             }),
             DynamicIndex::SparseColumn(tab) => {
-                tab.for_each(f);
+                tab.for_each(|k, v| f(k, PotentiallyStale::not_stale(v)));
             }
         }
     }
@@ -304,22 +358,25 @@ impl Database {
                         let mut action_buf =
                             ScopedActionBuffer::new(rule_scope, rule_set, match_counter.clone());
                         let search_and_apply_timer = Instant::now();
+
                         'eval: {
+                            for JoinHeader { atom, subset, .. } in plan.header() {
+                                if subset.is_empty() {
+                                    break 'eval;
+                                }
+                                let mut cur =
+                                    Arc::try_unwrap(binding_info.unwrap_val(*atom)).unwrap();
+                                debug_assert!(cur.cached_subsets.get().is_none());
+                                cur.subset
+                                    .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
+                                if cur.subset.is_empty() {
+                                    break 'eval;
+                                }
+                                binding_info.move_back_node(*atom, Arc::new(cur));
+                            }
+
                             match plan {
                                 Plan::SinglePlan(plan) => {
-                                    for JoinHeader { atom, subset, .. } in &plan.header {
-                                        if subset.is_empty() {
-                                            break 'eval;
-                                        }
-                                        let mut cur =
-                                            Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
-                                        debug_assert!(cur.cached_subsets.get().is_none());
-                                        cur.subset.intersect(
-                                            subset.as_ref(),
-                                            &with_pool_set(|ps| ps.get_pool()),
-                                        );
-                                        binding_info.move_back_node(*atom, Arc::new(cur));
-                                    }
                                     join_state.run_join_stages(
                                         &plan.stages,
                                         &plan.atoms,
@@ -329,23 +386,6 @@ impl Database {
                                     );
                                 }
                                 Plan::DecomposedPlan(plan) => {
-                                    for JoinHeader { atom, subset, .. } in plan.header.iter() {
-                                        if subset.is_empty() {
-                                            break 'eval;
-                                        }
-                                        let mut cur =
-                                            Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
-                                        debug_assert!(cur.cached_subsets.get().is_none());
-                                        cur.subset.intersect(
-                                            subset.as_ref(),
-                                            &with_pool_set(|ps| ps.get_pool()),
-                                        );
-                                        if cur.subset.is_empty() {
-                                            break 'eval;
-                                        }
-                                        binding_info.move_back_node(*atom, Arc::new(cur));
-                                    }
-
                                     let mut materializations: DenseIdMap<
                                         MatId,
                                         Arc<DashMap<Vec<Value>, RowBuffer>>,
@@ -459,18 +499,21 @@ impl Database {
 
                 let search_and_apply_timer = Instant::now();
                 'eval: {
+                    for JoinHeader { atom, subset, .. } in plan.header() {
+                        if subset.is_empty() {
+                            break 'eval;
+                        }
+                        let mut cur = Arc::try_unwrap(binding_info.unwrap_val(*atom)).unwrap();
+                        debug_assert!(cur.cached_subsets.get().is_none());
+                        cur.subset
+                            .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
+                        if cur.subset.is_empty() {
+                            break 'eval;
+                        }
+                        binding_info.move_back_node(*atom, Arc::new(cur));
+                    }
                     match plan {
                         Plan::SinglePlan(plan) => {
-                            for JoinHeader { atom, subset, .. } in &plan.header {
-                                if subset.is_empty() {
-                                    break 'eval;
-                                }
-                                let mut cur = Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
-                                debug_assert!(cur.cached_subsets.get().is_none());
-                                cur.subset
-                                    .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
-                                binding_info.move_back_node(*atom, Arc::new(cur));
-                            }
                             join_state.run_join_stages(
                                 &plan.stages,
                                 &plan.atoms,
@@ -480,20 +523,6 @@ impl Database {
                             );
                         }
                         Plan::DecomposedPlan(plan) => {
-                            for JoinHeader { atom, subset, .. } in plan.header.iter() {
-                                if subset.is_empty() {
-                                    break 'eval;
-                                }
-                                let mut cur = Arc::unwrap_or_clone(binding_info.unwrap_val(*atom));
-                                debug_assert!(cur.cached_subsets.get().is_none());
-                                cur.subset
-                                    .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
-                                if cur.subset.is_empty() {
-                                    break 'eval;
-                                }
-                                binding_info.move_back_node(*atom, Arc::new(cur));
-                            }
-
                             let mut materializations =
                                 DenseIdMap::with_capacity(plan.stages.blocks.len());
                             for i in 0..plan.stages.blocks.len() {
@@ -609,7 +638,7 @@ type ColumnIndexes = IdVec<ColumnId, OnceLock<Arc<ColumnIndex>>>;
 
 // pub(crate) type ChildrenMaps = IdVec<ColumnId, OnceLock<Arc<DashMap<Value, Arc<TrieNode>>>>>;
 // pub(crate) type ChildrenMaps = IdVec<ColumnId, Arc<DashMap<Value, Arc<TrieNode>>>>;
-pub(crate) type ChildrenMaps = IdVec<ColumnId, Arc<Mutex<HashMap<Value, Arc<TrieNode>>>>>;
+pub(crate) type ChildrenMaps = IdVec<ColumnId, ReadOptimizedLock<HashMap<Value, Arc<TrieNode>>>>;
 
 /// Information about the current subset of an atom's relation that is being considered, along with
 /// lazily-initialized, cached indexes on that subset.
@@ -622,8 +651,8 @@ pub(crate) struct TrieNode {
     /// The actual subset of the corresponding atom.
     subset: Subset,
     /// Any cached indexes on this subset.
-    cached_subsets: OnceLock<Arc<Pooled<ColumnIndexes>>>,
-    cached_children: OnceLock<Arc<Pooled<ChildrenMaps>>>,
+    cached_subsets: OnceLock<Pooled<ColumnIndexes>>,
+    cached_children: OnceLock<Pooled<ChildrenMaps>>,
 }
 
 impl std::fmt::Debug for TrieNode {
@@ -651,7 +680,7 @@ impl TrieNode {
             // Pre-size the vector so we do not need to borrow it mutably to initialize the index.
             let mut vec: Pooled<ColumnIndexes> = with_pool_set(|ps| ps.get());
             vec.resize_with(info.spec.arity(), OnceLock::new);
-            Arc::new(vec)
+            vec
         })[col]
             .get_or_init(|| {
                 let col_index = info.table.group_by_col(self.subset.as_ref(), col);
@@ -667,51 +696,23 @@ impl TrieNode {
         info: &TableInfo,
         sub: impl FnOnce() -> Subset,
     ) -> Arc<TrieNode> {
-        let mut map = self.cached_children.get_or_init(|| {
+        let map = &self.cached_children.get_or_init(|| {
             let mut vec: Pooled<ChildrenMaps> = with_pool_set(|ps| ps.get());
-            // vec.resize_with(info.spec.arity(), OnceLock::new);
-            vec.resize_with(info.spec.arity(), || {
-                Arc::new(Mutex::new(HashMap::default()))
-            });
-            Arc::new(vec)
-        })[col]
-            .lock()
-            .unwrap();
-        // .get_or_init(|| Arc::new(DashMap::with_hasher_and_shard_amount(Default::default(), 2)))
-
-        // if map.contains_key(&value) {
-        //     eprintln!(
-        //         "hit cache for column {:?} and value {:?} with {} tuples",
-        //         col,
-        //         value,
-        //         self.size()
-        //     );
-        // }
-        map.entry(value)
-            .or_insert_with(|| {
-                let sub = sub();
-                // eprintln!(
-                //     "Creating new trie node for column {:?} and {} tuples",
-                //     col,
-                //     sub.size()
-                // );
-                Arc::new(TrieNode::new(sub))
-            })
-            // .value()
-            .clone()
-    }
-}
-
-impl Clone for TrieNode {
-    fn clone(&self) -> Self {
-        let cached_subsets = OnceLock::new();
-        if let Some(cached) = self.cached_subsets.get() {
-            cached_subsets.set(cached.clone()).ok().unwrap();
-        }
-        Self {
-            subset: self.subset.clone(),
-            cached_subsets,
-            cached_children: self.cached_children.clone(),
+            vec.resize_with(info.spec.arity(), ReadOptimizedLock::default);
+            vec
+        })[col];
+        let guard = map.read();
+        if let Some(node) = guard.get(&value) {
+            node.clone()
+        } else {
+            drop(guard);
+            let mut guard = map.lock();
+            if let Some(node) = guard.get(&value) {
+                return node.clone();
+            }
+            let new_node = Arc::new(TrieNode::new(sub()));
+            guard.insert(value, new_node.clone());
+            new_node
         }
     }
 }
@@ -992,11 +993,15 @@ impl<'a> JoinState<'a> {
         }
 
         fn refine_subset(
-            sub: Subset,
+            sub: PotentiallyStale<Subset>,
             constraints: &[Constraint],
             table: &WrappedTableRef,
         ) -> Subset {
-            let sub = table.refine_live(sub);
+            let sub = if sub.can_be_stale {
+                table.refine_live(sub.inner)
+            } else {
+                sub.inner
+            };
             table.refine(sub, constraints)
         }
 
@@ -1014,14 +1019,16 @@ impl<'a> JoinState<'a> {
                     with_pool_set(|ps| {
                         prober.for_each(|val, x| {
                             updates.push_binding(*var, val[0]);
-                            let node =
+                            let node = if x.size() <= 16 {
+                                let sub = refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
+                                Arc::new(TrieNode::new(sub))
+                            } else {
                                 prober
                                     .node
                                     .get_cached_trie_node(a.column, val[0], info, || {
-                                        let sub =
-                                            refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
-                                        sub
-                                    });
+                                        refine_subset(x.to_owned(&ps.get_pool()), &[], &table)
+                                    })
+                            };
                             if node.subset.is_empty() {
                                 updates.rollback();
                                 return;
@@ -1048,17 +1055,16 @@ impl<'a> JoinState<'a> {
                         prober.for_each(|val, x| {
                             updates.push_binding(*var, val[0]);
 
-                            let node =
+                            let node = if x.size() <= 16 {
+                                let sub = refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
+                                Arc::new(TrieNode::new(sub))
+                            } else {
                                 prober
                                     .node
                                     .get_cached_trie_node(a.column, val[0], info, || {
-                                        let sub = refine_subset(
-                                            x.to_owned(&ps.get_pool()),
-                                            &a.cs,
-                                            &table,
-                                        );
-                                        sub
-                                    });
+                                        refine_subset(x.to_owned(&ps.get_pool()), &a.cs, &table)
+                                    })
+                            };
                             if node.subset.is_empty() {
                                 updates.rollback();
                                 return;
@@ -1093,36 +1099,46 @@ impl<'a> JoinState<'a> {
                     let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                     with_pool_set(|ps| {
                         smaller.for_each(|val, small_sub| {
-                            if let Some(mut large_sub) = larger.get_subset(val) {
+                            if let Some(large_sub) = larger.get_subset(val) {
                                 updates.push_binding(*var, val[0]);
-                                let smaller_node = smaller.node.get_cached_trie_node(
-                                    smaller_scan.column,
-                                    val[0],
-                                    small_info,
-                                    || {
-                                        let small_sub = refine_subset(
-                                            small_sub.to_owned(&ps.get_pool()),
-                                            &smaller_scan.cs,
-                                            &small_table,
-                                        );
-                                        small_sub
-                                    },
-                                );
+                                let smaller_node = if small_sub.size() <= 16 {
+                                    let small_sub = refine_subset(
+                                        small_sub.to_owned(&ps.get_pool()),
+                                        &smaller_scan.cs,
+                                        &small_table,
+                                    );
+                                    Arc::new(TrieNode::new(small_sub))
+                                } else {
+                                    smaller.node.get_cached_trie_node(
+                                        smaller_scan.column,
+                                        val[0],
+                                        small_info,
+                                        || {
+                                            refine_subset(
+                                                small_sub.to_owned(&ps.get_pool()),
+                                                &smaller_scan.cs,
+                                                &small_table,
+                                            )
+                                        },
+                                    )
+                                };
                                 if smaller_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
                                 }
                                 updates.refine_atom(smaller_atom, smaller_node);
-                                let larger_node = larger.node.get_cached_trie_node(
-                                    larger_scan.column,
-                                    val[0],
-                                    large_info,
-                                    || {
-                                        large_sub =
-                                            refine_subset(large_sub, &larger_scan.cs, &large_table);
-                                        large_sub
-                                    },
-                                );
+                                let larger_node = if large_sub.size() <= 16 {
+                                    let large_sub =
+                                        refine_subset(large_sub, &larger_scan.cs, &large_table);
+                                    Arc::new(TrieNode::new(large_sub))
+                                } else {
+                                    larger.node.get_cached_trie_node(
+                                        larger_scan.column,
+                                        val[0],
+                                        large_info,
+                                        || refine_subset(large_sub, &larger_scan.cs, &large_table),
+                                    )
+                                };
                                 if larger_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
@@ -1170,19 +1186,21 @@ impl<'a> JoinState<'a> {
                                     if i == smallest {
                                         continue;
                                     }
-                                    if let Some(mut sub) = probers[i].get_subset(key) {
+                                    if let Some(sub) = probers[i].get_subset(key) {
                                         let table = self.db.tables[atoms[rest[i].atom].table]
                                             .table
                                             .as_ref();
-                                        let node = probers[i].node.get_cached_trie_node(
-                                            scan.column,
-                                            key[0],
-                                            &self.db.tables[atoms[scan.atom].table],
-                                            || {
-                                                sub = refine_subset(sub, &rest[i].cs, &table);
-                                                sub
-                                            },
-                                        );
+                                        let node = if sub.size() <= 16 {
+                                            let sub = refine_subset(sub, &rest[i].cs, &table);
+                                            Arc::new(TrieNode::new(sub))
+                                        } else {
+                                            probers[i].node.get_cached_trie_node(
+                                                scan.column,
+                                                key[0],
+                                                &self.db.tables[atoms[scan.atom].table],
+                                                || refine_subset(sub, &rest[i].cs, &table),
+                                            )
+                                        };
                                         if node.subset.is_empty() {
                                             updates.rollback();
                                             return;
@@ -1194,17 +1212,25 @@ impl<'a> JoinState<'a> {
                                         return;
                                     }
                                 }
-                                let main_node = probers[smallest].node.get_cached_trie_node(
-                                    main_spec.column,
-                                    key[0],
-                                    main_spec_info,
-                                    || {
-                                        let sub = sub.to_owned(&ps.get_pool());
-                                        let sub =
-                                            refine_subset(sub, &main_spec.cs, &main_spec_table);
-                                        sub
-                                    },
-                                );
+                                let main_node = if sub.size() <= 16 {
+                                    let sub = refine_subset(
+                                        sub.to_owned(&ps.get_pool()),
+                                        &main_spec.cs,
+                                        &main_spec_table,
+                                    );
+                                    Arc::new(TrieNode::new(sub))
+                                } else {
+                                    probers[smallest].node.get_cached_trie_node(
+                                        main_spec.column,
+                                        key[0],
+                                        main_spec_info,
+                                        || {
+                                            let sub = sub.to_owned(&ps.get_pool());
+
+                                            refine_subset(sub, &main_spec.cs, &main_spec_table)
+                                        },
+                                    )
+                                };
                                 if main_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
@@ -1338,7 +1364,7 @@ impl<'a> JoinState<'a> {
                                 .iter()
                                 .map(|col| key[col.index()])
                                 .collect::<SmallVec<[Value; 4]>>();
-                            let Some(mut subset) = prober.get_subset(&index_key) else {
+                            let Some(subset) = prober.get_subset(&index_key) else {
                                 updates.rollback();
                                 // There are no possible values for this subset
                                 continue 'mid;
@@ -1346,7 +1372,7 @@ impl<'a> JoinState<'a> {
                             // apply any constraints needed in this scan.
                             let table_info = &self.db.tables[atoms[*atom].table];
                             let cs = &to_intersect[*i].0.constraints;
-                            subset = refine_subset(subset, cs, &table_info.table.as_ref());
+                            let subset = refine_subset(subset, cs, &table_info.table.as_ref());
                             if subset.is_empty() {
                                 updates.rollback();
                                 // There are no possible values for this subset
@@ -1417,6 +1443,13 @@ impl<'a> JoinState<'a> {
                             key.push(val);
                         }
                         if let Some(subset) = prober.get_subset(&key) {
+                            let subset = refine_subset(
+                                subset,
+                                &spec.constraints,
+                                &self.db.tables[atoms[spec.to_index.atom].table]
+                                    .table
+                                    .as_ref(),
+                            );
                             updates
                                 .refine_atom(spec.to_index.atom, Arc::new(TrieNode::new(subset)));
                         } else {
@@ -1993,9 +2026,8 @@ fn sort_plan_by_size_inner(
             JoinStage::Intersect { scans, .. } => scans
                 .iter()
                 .map(|scan| times_refined.get(scan.atom).copied().unwrap_or_default())
-                // .max()
-                // .unwrap(),
-                .sum(),
+                .max()
+                .unwrap(),
             JoinStage::FusedIntersect { cover, .. } => times_refined
                 .get(cover.to_index.atom)
                 .copied()

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -203,7 +203,6 @@ impl PotentiallyStale<Subset> {
     }
 }
 
-
 struct Prober {
     node: Arc<TrieNode>,
     pool: Pool<SortedOffsetVector>,
@@ -252,7 +251,8 @@ impl Prober {
                 .map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool))),
             DynamicIndex::SparseColumn(tab) => {
                 debug_assert_eq!(key.len(), 1);
-                tab.get_subset(key[0]).map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool)))
+                tab.get_subset(key[0])
+                    .map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool)))
             }
         }
     }

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -1056,7 +1056,7 @@ impl<'a> JoinState<'a> {
                             updates.push_binding(*var, val[0]);
 
                             let node = if x.size() <= 16 {
-                                let sub = refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
+                                let sub = refine_subset(x.to_owned(&ps.get_pool()), &a.cs, &table);
                                 Arc::new(TrieNode::new(sub))
                             } else {
                                 prober

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -503,6 +503,8 @@ impl Database {
                         if subset.is_empty() {
                             break 'eval;
                         }
+                        // Before query execution, Arc<TrieNode> is owned exclusively by the binding info.
+                        // Trie nodes are only shared once we start running the query.
                         let mut cur = Arc::try_unwrap(binding_info.unwrap_val(*atom)).unwrap();
                         debug_assert!(cur.cached_subsets.get().is_none());
                         cur.subset
@@ -631,13 +633,11 @@ struct JoinState<'a> {
     exec_state: ExecutionState<'a>,
 }
 
-// TODO: use SmallVec might be better
+/// Per-column indexes on a trie node's subset, lazily initialized on first access per column.
 type ColumnIndexes = IdVec<ColumnId, OnceLock<Arc<ColumnIndex>>>;
-// pub(crate) type ChildrenMaps =
-//     IdVec<ColumnId, OnceLock<Arc<HashMap<Value, OnceLock<Arc<TrieNode>>>>>>;
 
-// pub(crate) type ChildrenMaps = IdVec<ColumnId, OnceLock<Arc<DashMap<Value, Arc<TrieNode>>>>>;
-// pub(crate) type ChildrenMaps = IdVec<ColumnId, Arc<DashMap<Value, Arc<TrieNode>>>>;
+/// Per-column maps from a value to the child trie node for that value, lazily populated on first
+/// lookup per (column, value) pair.
 pub(crate) type ChildrenMaps = IdVec<ColumnId, ReadOptimizedLock<HashMap<Value, Arc<TrieNode>>>>;
 
 /// Information about the current subset of an atom's relation that is being considered, along with

--- a/core-relations/src/free_join/frame_update.rs
+++ b/core-relations/src/free_join/frame_update.rs
@@ -15,20 +15,13 @@
 use std::sync::Arc;
 
 use crate::free_join::execute::TrieNode;
-use crate::numeric_id::{DenseIdMap, define_id};
+use crate::numeric_id::define_id;
 
-use crate::{Subset, Value};
+use crate::Value;
 
 use super::{AtomId, Variable};
 
 define_id!(pub SubsetId, u32, "An offset into a buffer of subsets");
-
-#[derive(Debug)]
-pub(super) enum UpdateCell {
-    PushBinding(Variable, Value),
-    RefineAtom(AtomId, Arc<TrieNode>),
-    EndFrame,
-}
 
 #[derive(Debug)]
 pub(super) enum UpdateInstr {
@@ -41,8 +34,7 @@ pub(super) enum UpdateInstr {
 /// A flat buffer of updates that is used to prepare a sequence of recursive calls to free join.
 #[derive(Default)]
 pub(super) struct FrameUpdates {
-    subsets: DenseIdMap<SubsetId, Subset>,
-    updates: Vec<UpdateCell>,
+    updates: Vec<UpdateInstr>,
     frames: usize,
     last_start: usize,
 }
@@ -50,7 +42,6 @@ pub(super) struct FrameUpdates {
 impl FrameUpdates {
     pub(super) fn with_capacity(capacity: usize) -> FrameUpdates {
         FrameUpdates {
-            subsets: DenseIdMap::with_capacity(capacity),
             updates: Vec::with_capacity(capacity * 2),
             frames: 0,
             last_start: 0,
@@ -59,12 +50,12 @@ impl FrameUpdates {
 
     /// Bind `var` to `val` in the current frame.
     pub(super) fn push_binding(&mut self, var: Variable, val: Value) {
-        self.updates.push(UpdateCell::PushBinding(var, val));
+        self.updates.push(UpdateInstr::PushBinding(var, val));
     }
 
     /// Refine `atom` to consider only the given `subset` in the current frame.
     pub(super) fn refine_atom(&mut self, atom: AtomId, node: Arc<TrieNode>) {
-        self.updates.push(UpdateCell::RefineAtom(atom, node));
+        self.updates.push(UpdateInstr::RefineAtom(atom, node));
     }
 
     /// Roll back the updates to the last frame start. Note that repeated calls
@@ -75,7 +66,7 @@ impl FrameUpdates {
 
     /// Finish the current frame and prepare for the next one.
     pub(super) fn finish_frame(&mut self) {
-        self.updates.push(UpdateCell::EndFrame);
+        self.updates.push(UpdateInstr::EndFrame);
         self.last_start = self.updates.len();
         self.frames += 1;
     }
@@ -86,28 +77,19 @@ impl FrameUpdates {
     }
 
     pub(super) fn clear(&mut self) {
-        self.subsets.clear();
         self.updates.clear();
     }
 
     pub(super) fn drain(&mut self, f: impl FnMut(UpdateInstr)) {
         let start = 0;
-        self.updates
-            .drain(start..)
-            .map(|cell| match cell {
-                UpdateCell::PushBinding(var, val) => UpdateInstr::PushBinding(var, val),
-                UpdateCell::RefineAtom(atom, subset) => UpdateInstr::RefineAtom(atom, subset),
-                UpdateCell::EndFrame => UpdateInstr::EndFrame,
-            })
-            .for_each(f);
-        self.subsets.clear();
+        self.updates.drain(start..).for_each(f);
         self.frames = 0;
         self.last_start = 0;
     }
 
     // for debugging
     #[allow(dead_code)]
-    pub(super) fn updates(&self) -> &[UpdateCell] {
+    pub(super) fn updates(&self) -> &[UpdateInstr] {
         &self.updates
     }
 }

--- a/core-relations/src/free_join/frame_update.rs
+++ b/core-relations/src/free_join/frame_update.rs
@@ -12,6 +12,9 @@
 //! those bindings in recursive calls. When parallelism is enabled, this data-structure allows us
 //! hand over an entire batch of recursive calls to a separate thread to process independently.
 
+use std::sync::Arc;
+
+use crate::free_join::execute::TrieNode;
 use crate::numeric_id::{DenseIdMap, define_id};
 
 use crate::{Subset, Value};
@@ -23,14 +26,14 @@ define_id!(pub SubsetId, u32, "An offset into a buffer of subsets");
 #[derive(Debug)]
 pub(super) enum UpdateCell {
     PushBinding(Variable, Value),
-    RefineAtom(AtomId, SubsetId),
+    RefineAtom(AtomId, Arc<TrieNode>),
     EndFrame,
 }
 
 #[derive(Debug)]
 pub(super) enum UpdateInstr {
     PushBinding(Variable, Value),
-    RefineAtom(AtomId, Subset),
+    RefineAtom(AtomId, Arc<TrieNode>),
     /// Marks the end of the current frame. Time to make a recursive call.
     EndFrame,
 }
@@ -60,9 +63,8 @@ impl FrameUpdates {
     }
 
     /// Refine `atom` to consider only the given `subset` in the current frame.
-    pub(super) fn refine_atom(&mut self, atom: AtomId, subset: Subset) {
-        let subset = self.subsets.push(subset);
-        self.updates.push(UpdateCell::RefineAtom(atom, subset));
+    pub(super) fn refine_atom(&mut self, atom: AtomId, node: Arc<TrieNode>) {
+        self.updates.push(UpdateCell::RefineAtom(atom, node));
     }
 
     /// Roll back the updates to the last frame start. Note that repeated calls
@@ -94,9 +96,7 @@ impl FrameUpdates {
             .drain(start..)
             .map(|cell| match cell {
                 UpdateCell::PushBinding(var, val) => UpdateInstr::PushBinding(var, val),
-                UpdateCell::RefineAtom(atom, subset) => {
-                    UpdateInstr::RefineAtom(atom, self.subsets.take(subset).unwrap())
-                }
+                UpdateCell::RefineAtom(atom, subset) => UpdateInstr::RefineAtom(atom, subset),
                 UpdateCell::EndFrame => UpdateInstr::EndFrame,
             })
             .for_each(f);

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -255,6 +255,13 @@ impl Plan {
             }
         }
     }
+
+    pub(crate) fn header(&self) -> &[JoinHeader] {
+        match self {
+            Plan::SinglePlan(p) => &p.header,
+            Plan::DecomposedPlan(p) => &p.header,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/core-relations/src/pool/mod.rs
+++ b/core-relations/src/pool/mod.rs
@@ -12,6 +12,7 @@ use std::{
 
 use crate::{
     AtomId,
+    free_join::execute::ChildrenMaps,
     numeric_id::{DenseIdMap, IdVec},
 };
 use fixedbitset::FixedBitSet;
@@ -439,6 +440,7 @@ pool_set! {
         instr_indexes: Vec<u32> [ 1 << 20 ],
         cached_subsets: IdVec<ColumnId, std::sync::OnceLock<std::sync::Arc<ColumnIndex>>> [ 4 << 20 ],
         intersected_on: DenseIdMap<AtomId, i64> [ 1 << 20 ],
+        children_map: ChildrenMaps [ 1 << 20 ],
     }
 }
 


### PR DESCRIPTION
The existing implementation of TrieNode only caches the column index, which is a mapping from key to a list of Row Ids. However, subtries are still created every time a key of the TrieNode is probed/iterated. So the existing implementation can repeatedly create TrieNodes which is very wasteful. This PR tries to also store subtries as part of the TrieNode.