### PR TITLE
Claude experiment

### DIFF
--- a/core-relations/src/common.rs
+++ b/core-relations/src/common.rs
@@ -152,6 +152,9 @@ impl ShardData {
         1 << self.log2_shard_count
     }
     pub(crate) fn shard_id(&self, hash: u64) -> ShardId {
+        if self.log2_shard_count == 0 {
+            return ShardId::new(0);
+        }
         let high_bits = (hash.wrapping_shr(64 - (self.log2_shard_count + 7)))
             & ((1 << self.log2_shard_count) - 1);
         ShardId::from_usize(high_bits as usize)
@@ -160,6 +163,9 @@ impl ShardData {
     where
         for<'b> &'b K: Hash,
     {
+        if self.log2_shard_count == 0 {
+            return &table[ShardId::new(0)];
+        }
         let hc = {
             let mut hasher = FxHasher::default();
             val.hash(&mut hasher);
@@ -173,6 +179,9 @@ impl ShardData {
         val: impl Hash,
         table: &'a mut IdVec<ShardId, V>,
     ) -> &'a mut V {
+        if self.log2_shard_count == 0 {
+            return &mut table[ShardId::new(0)];
+        }
         let hc = {
             let mut hasher = FxHasher::default();
             val.hash(&mut hasher);

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -269,8 +269,7 @@ impl Prober {
             }
             DynamicIndex::SparseColumn(tab) => {
                 debug_assert_eq!(key.len(), 1);
-                tab.get_subset(key[0])
-                    .map(PotentiallyStale::not_stale)
+                tab.get_subset(key[0]).map(PotentiallyStale::not_stale)
             }
         }
     }

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -3,7 +3,7 @@
 use std::{
     cmp, iter, mem,
     ops::Range,
-    sync::{Arc, OnceLock, atomic::AtomicUsize},
+    sync::{Arc, OnceLock, RwLock, atomic::AtomicUsize},
 };
 
 use crate::{
@@ -16,7 +16,6 @@ use crate::{
 use crossbeam::utils::CachePadded;
 use dashmap::mapref::entry::Entry;
 use dashmap::mapref::one::RefMut;
-use egglog_concurrency::ReadOptimizedLock;
 use egglog_reports::{ReportLevel, RuleReport, RuleSetReport};
 use smallvec::SmallVec;
 use web_time::Instant;
@@ -147,11 +146,15 @@ impl SparseColumnIndex {
 
 enum DynamicIndex {
     Cached {
-        intersect_outer: bool,
+        /// When Some(range), intersect each subset from the index with this dense range.
+        /// The range is the Dense outer subset known at Prober construction time.
+        intersect_outer: Option<OffsetRange>,
         table: HashIndex,
     },
     CachedColumn {
-        intersect_outer: bool,
+        /// When Some(range), intersect each subset from the index with this dense range.
+        /// The range is the Dense outer subset known at Prober construction time.
+        intersect_outer: Option<OffsetRange>,
         table: HashColumnIndex,
     },
     Dynamic(TupleIndex),
@@ -197,98 +200,113 @@ impl PotentiallyStale<SubsetRef<'_>> {
     }
 }
 
-impl PotentiallyStale<Subset> {
-    fn size(&self) -> usize {
-        self.inner.size()
+/// Intersect a `SubsetRef` with a dense `OffsetRange` and return the result as a
+/// borrowed `SubsetRef`, or `None` if the intersection is empty.
+///
+/// This function never allocates — it borrows into
+/// the source data via `subslice`. Use this in `for_each` paths where the result
+/// may be discarded (e.g., empty after refinement), to avoid pool allocations.
+#[inline]
+fn intersect_with_dense_ref<'a>(v: SubsetRef<'a>, range: OffsetRange) -> Option<SubsetRef<'a>> {
+    match v {
+        SubsetRef::Dense(r) => {
+            let resl = cmp::max(r.start, range.start);
+            let resr = cmp::min(r.end, range.end);
+            if resl >= resr {
+                None
+            } else {
+                Some(SubsetRef::Dense(OffsetRange::new(resl, resr)))
+            }
+        }
+        SubsetRef::Sparse(s) => {
+            let l = s.binary_search_by_id(range.start);
+            let r = s.binary_search_by_id(range.end);
+            if l >= r {
+                None
+            } else {
+                Some(SubsetRef::Sparse(s.subslice(l, r)))
+            }
+        }
     }
 }
 
 struct Prober {
     node: Arc<TrieNode>,
-    pool: Pool<SortedOffsetVector>,
     ix: DynamicIndex,
 }
 
 impl Prober {
-    fn get_subset(&self, key: &[Value]) -> Option<PotentiallyStale<Subset>> {
+    fn get_subset<'a>(&'a self, key: &'a [Value]) -> Option<PotentiallyStale<SubsetRef<'a>>> {
         match &self.ix {
             DynamicIndex::Cached {
                 intersect_outer,
                 table,
             } => {
-                let mut sub = table.get().unwrap().get_subset(key)?.to_owned(&self.pool);
-                if *intersect_outer {
-                    sub.intersect(self.node.subset.as_ref(), &self.pool);
-                    if sub.is_empty() {
-                        return None;
-                    }
-                }
-                Some(PotentiallyStale::maybe_stale(sub))
+                let subset_ref = table.get().unwrap().get_subset(key)?;
+                let subset = if let Some(range) = intersect_outer {
+                    intersect_with_dense_ref(subset_ref, *range)?
+                } else {
+                    subset_ref
+                };
+                Some(PotentiallyStale::maybe_stale(subset))
             }
             DynamicIndex::CachedColumn {
                 intersect_outer,
                 table,
             } => {
                 debug_assert_eq!(key.len(), 1);
-                let mut sub = table
-                    .get()
-                    .unwrap()
-                    .get_subset(&key[0])?
-                    .to_owned(&self.pool);
-                if *intersect_outer {
-                    sub.intersect(self.node.subset.as_ref(), &self.pool);
-                    if sub.is_empty() {
-                        return None;
-                    }
-                }
-                Some(PotentiallyStale::maybe_stale(sub))
+                let subset_ref = table.get().unwrap().get_subset(&key[0])?;
+                let subset = if let Some(range) = intersect_outer {
+                    intersect_with_dense_ref(subset_ref, *range)?
+                } else {
+                    subset_ref
+                };
+                Some(PotentiallyStale::maybe_stale(subset))
             }
-            DynamicIndex::Dynamic(tab) => tab
-                .get_subset(key)
-                .map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool))),
-            DynamicIndex::DynamicColumn(tab) => tab
-                .get_subset(&key[0])
-                .map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool))),
+            DynamicIndex::Dynamic(tab) => tab.get_subset(key).map(PotentiallyStale::not_stale),
+            DynamicIndex::DynamicColumn(tab) => {
+                tab.get_subset(&key[0]).map(PotentiallyStale::not_stale)
+            }
             DynamicIndex::SparseColumn(tab) => {
                 debug_assert_eq!(key.len(), 1);
                 tab.get_subset(key[0])
-                    .map(|x| PotentiallyStale::not_stale(x.to_owned(&self.pool)))
+                    .map(PotentiallyStale::not_stale)
             }
         }
     }
     fn for_each(&self, mut f: impl FnMut(&[Value], PotentiallyStale<SubsetRef>)) {
         match &self.ix {
             DynamicIndex::Cached {
-                intersect_outer: true,
+                intersect_outer: Some(range),
                 table,
-            } => table.get().unwrap().for_each(|k, v| {
-                let mut res = v.to_owned(&self.pool);
-                res.intersect(self.node.subset.as_ref(), &self.pool);
-                if !res.is_empty() {
-                    f(k, PotentiallyStale::maybe_stale(res.as_ref()))
-                }
-            }),
+            } => {
+                let range = *range;
+                table.get().unwrap().for_each(|k, v| {
+                    if let Some(res) = intersect_with_dense_ref(v, range) {
+                        f(k, PotentiallyStale::maybe_stale(res))
+                    }
+                });
+            }
             DynamicIndex::Cached {
-                intersect_outer: false,
+                intersect_outer: None,
                 table,
             } => table
                 .get()
                 .unwrap()
                 .for_each(|k, v| f(k, PotentiallyStale::maybe_stale(v))),
             DynamicIndex::CachedColumn {
-                intersect_outer: true,
+                intersect_outer: Some(range),
                 table,
             } => {
+                let range = *range;
                 table.get().unwrap().for_each(|k, v| {
-                    let mut res = v.to_owned(&self.pool);
-                    res.intersect(self.node.subset.as_ref(), &self.pool);
-                    if !res.is_empty() {
-                        f(&[*k], PotentiallyStale::maybe_stale(res.as_ref()))
+                    if let Some(res) = intersect_with_dense_ref(v, range) {
+                        f(&[*k], PotentiallyStale::maybe_stale(res))
                     }
                 });
             }
             DynamicIndex::CachedColumn {
-                intersect_outer: false,
+                intersect_outer: None,
                 table,
             } => {
                 table
@@ -367,8 +385,7 @@ impl Database {
                                 let mut cur =
                                     Arc::try_unwrap(binding_info.unwrap_val(*atom)).unwrap();
                                 debug_assert!(cur.cached_subsets.get().is_none());
-                                cur.subset
-                                    .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
+                                cur.subset.intersect(subset.as_ref(), &join_state.pool);
                                 if cur.subset.is_empty() {
                                     break 'eval;
                                 }
@@ -507,8 +524,7 @@ impl Database {
                         // Trie nodes are only shared once we start running the query.
                         let mut cur = Arc::try_unwrap(binding_info.unwrap_val(*atom)).unwrap();
                         debug_assert!(cur.cached_subsets.get().is_none());
-                        cur.subset
-                            .intersect(subset.as_ref(), &with_pool_set(|ps| ps.get_pool()));
+                        cur.subset.intersect(subset.as_ref(), &join_state.pool);
                         if cur.subset.is_empty() {
                             break 'eval;
                         }
@@ -631,6 +647,9 @@ impl Default for ActionState {
 struct JoinState<'a> {
     db: &'a Database,
     exec_state: ExecutionState<'a>,
+    /// Cached thread-local pool for SortedOffsetVector allocations.
+    /// Stored here to avoid a per-call `with_pool_set` TLS access in `get_index`.
+    pool: Pool<SortedOffsetVector>,
 }
 
 /// Per-column indexes on a trie node's subset, lazily initialized on first access per column.
@@ -638,7 +657,7 @@ type ColumnIndexes = IdVec<ColumnId, OnceLock<Arc<ColumnIndex>>>;
 
 /// Per-column maps from a value to the child trie node for that value, lazily populated on first
 /// lookup per (column, value) pair.
-pub(crate) type ChildrenMaps = IdVec<ColumnId, ReadOptimizedLock<HashMap<Value, Arc<TrieNode>>>>;
+pub(crate) type ChildrenMaps = IdVec<ColumnId, RwLock<HashMap<Value, Arc<TrieNode>>>>;
 
 /// Information about the current subset of an atom's relation that is being considered, along with
 /// lazily-initialized, cached indexes on that subset.
@@ -652,6 +671,9 @@ pub(crate) struct TrieNode {
     subset: Subset,
     /// Any cached indexes on this subset.
     cached_subsets: OnceLock<Pooled<ColumnIndexes>>,
+    /// Cached child trie nodes, keyed by value. In practice each TrieNode is
+    /// only ever probed with a single column, so we store one (col, map) pair
+    /// instead of an IdVec across all columns.
     cached_children: OnceLock<Pooled<ChildrenMaps>>,
 }
 
@@ -698,21 +720,35 @@ impl TrieNode {
     ) -> Arc<TrieNode> {
         let map = &self.cached_children.get_or_init(|| {
             let mut vec: Pooled<ChildrenMaps> = with_pool_set(|ps| ps.get());
-            vec.resize_with(info.spec.arity(), ReadOptimizedLock::default);
+            vec.resize_with(info.spec.arity(), || RwLock::new(HashMap::default()));
             vec
         })[col];
-        let guard = map.read();
-        if let Some(node) = guard.get(&value) {
-            node.clone()
-        } else {
-            drop(guard);
-            let mut guard = map.lock();
+        // Optimistic read path: most calls are cache hits, so try shared lock first.
+        {
+            let guard = map.read().unwrap();
             if let Some(node) = guard.get(&value) {
                 return node.clone();
             }
-            let new_node = Arc::new(TrieNode::new(sub()));
-            guard.insert(value, new_node.clone());
-            new_node
+        }
+        // Cache miss: acquire write lock and insert.
+        let mut guard = map.write().unwrap();
+        // Double-check in case another thread inserted while we were waiting.
+        if let Some(node) = guard.get(&value) {
+            return node.clone();
+        }
+        let new_node = Arc::new(TrieNode::new(sub()));
+        guard.insert(value, new_node.clone());
+        new_node
+    }
+}
+
+impl FrameUpdates {
+    /// Refine `atom` to `subset`, using the dense fast path to avoid an
+    /// `Arc<TrieNode>` allocation when the subset is already a contiguous range.
+    fn refine_atom_subset(&mut self, atom: AtomId, subset: Subset) {
+        match subset {
+            Subset::Dense(range) => self.refine_atom_dense(atom, range),
+            sub => self.refine_atom(atom, Arc::new(TrieNode::new(sub))),
         }
     }
 }
@@ -725,13 +761,9 @@ struct BindingInfo {
 }
 
 impl BindingInfo {
-    /// Initializes the atom-related metadata in the [`BindingInfo`].
+    /// Initializes the atom-related metadata in the [`BindingInfo`].    
     fn insert_subset(&mut self, atom: AtomId, subset: Subset) {
-        let node = Arc::new(TrieNode {
-            subset,
-            cached_subsets: Default::default(),
-            cached_children: Default::default(),
-        });
+        let node = Arc::new(TrieNode::new(subset));
         self.subsets.insert(atom, node);
     }
 
@@ -760,7 +792,11 @@ impl BindingInfo {
 
 impl<'a> JoinState<'a> {
     fn new(db: &'a Database, exec_state: ExecutionState<'a>) -> Self {
-        Self { db, exec_state }
+        Self {
+            db,
+            exec_state,
+            pool: with_pool_set(|ps| ps.get_pool()),
+        }
     }
 
     fn get_index(
@@ -791,11 +827,17 @@ impl<'a> JoinState<'a> {
                 subset.as_ref(),
                 cols[0],
             ))
-        } else if all_cacheable && subset.is_dense() && whole_table.size() / 2 < subset.size() {
+        } else if let Subset::Dense(range) = subset
+            && all_cacheable
+            && whole_table.size() / 2 < subset.size()
+        {
             // Skip intersecting with the subset if we are just looking at the
             // whole table.
-            let intersect_outer =
+            let needs_intersect =
                 !(whole_table.is_dense() && subset.bounds() == whole_table.bounds());
+            // When intersecting, store the Dense range directly so we can do a
+            // combined copy+filter without a runtime match on subset type later.
+            let intersect_outer = if needs_intersect { Some(*range) } else { None };
             // heuristic: if the subset we are scanning is somewhat
             // large _or_ it is most of the table, or we already have a cached
             // index for it, then return it.
@@ -818,7 +860,6 @@ impl<'a> JoinState<'a> {
         };
         Prober {
             node: trie_node,
-            pool: with_pool_set(|ps| ps.get_pool().clone()),
             ix: dyn_index,
         }
     }
@@ -917,7 +958,7 @@ impl<'a> JoinState<'a> {
                 if self.exec_state.should_stop() {
                     return;
                 }
-                if cur == 0 || cur == 1 {
+                if (cur == 0 || cur == 1) && action_buf.supports_parallel_drain() {
                     drain_updates_parallel!($updates)
                 } else {
                     $updates.drain(|update| match update {
@@ -927,16 +968,29 @@ impl<'a> JoinState<'a> {
                         UpdateInstr::RefineAtom(atom, subset) => {
                             binding_info.insert_node(atom, subset);
                         }
+                        UpdateInstr::RefineAtomDense(atom, range) => {
+                            binding_info.insert_subset(atom, Subset::Dense(range));
+                        }
                         UpdateInstr::EndFrame => {
-                            self.run_plan(
-                                stages,
-                                atoms,
-                                action,
-                                instr_order,
-                                cur + 1,
-                                binding_info,
-                                action_buf,
-                            );
+                            // Inline leaf-level: if cur+1 is the leaf (no more
+                            // join stages), call push_bindings directly without
+                            // a recursive run_plan call, avoiding function call
+                            // overhead + an extra should_stop() check.
+                            if cur + 1 >= instr_order.len() {
+                                action_buf.push_bindings(action, &binding_info.bindings, || {
+                                    self.exec_state.clone()
+                                });
+                            } else {
+                                self.run_plan(
+                                    stages,
+                                    atoms,
+                                    action,
+                                    instr_order,
+                                    cur + 1,
+                                    binding_info,
+                                    action_buf,
+                                );
+                            }
                         }
                     })
                 }
@@ -970,10 +1024,17 @@ impl<'a> JoinState<'a> {
                             UpdateInstr::RefineAtom(atom, subset) => {
                                 binding_info.insert_node(atom, subset);
                             }
+                            UpdateInstr::RefineAtomDense(atom, range) => {
+                                binding_info.insert_subset(atom, Subset::Dense(range));
+                            }
                             UpdateInstr::EndFrame => {
                                 JoinState {
                                     db,
                                     exec_state: exec_state_for_work.clone(),
+                                    // Each rayon task uses its own thread-local pool.
+                                    // This makes drain_updates_parallel slightly more expensive
+                                    // than drain_updates eevn when both are run in single thread
+                                    pool: with_pool_set(|ps| ps.get_pool()),
                                 }
                                 .run_plan(
                                     stages,
@@ -996,85 +1057,59 @@ impl<'a> JoinState<'a> {
             sub: PotentiallyStale<Subset>,
             constraints: &[Constraint],
             table: &WrappedTableRef,
+            has_stale: bool,
         ) -> Subset {
-            let sub = if sub.can_be_stale {
+            let sub = if sub.can_be_stale && has_stale {
                 table.refine_live(sub.inner)
             } else {
                 sub.inner
             };
-            table.refine(sub, constraints)
+            if constraints.is_empty() {
+                sub
+            } else {
+                table.refine(sub, constraints)
+            }
         }
 
+        let pool = &self.pool;
         match &stages.instrs[instr_order.get(cur)] {
             JoinStage::Intersect { var, scans } => match scans.as_slice() {
                 [] => {}
-                [a] if a.cs.is_empty() => {
-                    if binding_info.has_empty_subset(a.atom) {
-                        return;
-                    }
-                    let prober = self.get_column_index(atoms, binding_info, a.atom, a.column);
-                    let info = &self.db.tables[atoms[a.atom].table];
-                    let table = info.table.as_ref();
-                    let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
-                    with_pool_set(|ps| {
-                        prober.for_each(|val, x| {
-                            updates.push_binding(*var, val[0]);
-                            let node = if x.size() <= 16 {
-                                let sub = refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
-                                Arc::new(TrieNode::new(sub))
-                            } else {
-                                prober
-                                    .node
-                                    .get_cached_trie_node(a.column, val[0], info, || {
-                                        refine_subset(x.to_owned(&ps.get_pool()), &[], &table)
-                                    })
-                            };
-                            if node.subset.is_empty() {
-                                updates.rollback();
-                                return;
-                            }
-                            updates.refine_atom(a.atom, node);
-                            updates.finish_frame();
-                            if updates.frames() >= chunk_size {
-                                drain_updates!(updates);
-                            }
-                        })
-                    });
-                    drain_updates!(updates);
-                    binding_info.move_back(a.atom, prober);
-                }
                 [a] => {
                     if binding_info.has_empty_subset(a.atom) {
                         return;
                     }
                     let prober = self.get_column_index(atoms, binding_info, a.atom, a.column);
                     let info = &self.db.tables[atoms[a.atom].table];
-                    let table = self.db.tables[atoms[a.atom].table].table.as_ref();
+                    let table = info.table.as_ref();
+                    let has_stale = table.has_stale_rows();
                     let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
-                    with_pool_set(|ps| {
-                        prober.for_each(|val, x| {
-                            updates.push_binding(*var, val[0]);
-
-                            let node = if x.size() <= 16 {
-                                let sub = refine_subset(x.to_owned(&ps.get_pool()), &a.cs, &table);
-                                Arc::new(TrieNode::new(sub))
-                            } else {
+                    prober.for_each(|val, x| {
+                        updates.push_binding(*var, val[0]);
+                        if x.size() <= 16 {
+                            let sub = refine_subset(x.to_owned(pool), &a.cs, &table, has_stale);
+                            if sub.is_empty() {
+                                updates.rollback();
+                                return;
+                            }
+                            updates.refine_atom_subset(a.atom, sub);
+                        } else {
+                            let node =
                                 prober
                                     .node
                                     .get_cached_trie_node(a.column, val[0], info, || {
-                                        refine_subset(x.to_owned(&ps.get_pool()), &a.cs, &table)
-                                    })
-                            };
+                                        refine_subset(x.to_owned(pool), &a.cs, &table, has_stale)
+                                    });
                             if node.subset.is_empty() {
                                 updates.rollback();
                                 return;
                             }
                             updates.refine_atom(a.atom, node);
-                            updates.finish_frame();
-                            if updates.frames() >= chunk_size {
-                                drain_updates!(updates);
-                            }
-                        })
+                        }
+                        updates.finish_frame();
+                        if updates.frames() >= chunk_size {
+                            drain_updates!(updates);
+                        }
                     });
                     drain_updates!(updates);
                     binding_info.move_back(a.atom, prober);
@@ -1094,62 +1129,83 @@ impl<'a> JoinState<'a> {
                     let larger_atom = larger_scan.atom;
                     let large_info = &self.db.tables[atoms[larger_atom].table];
                     let large_table = large_info.table.as_ref();
+                    let large_has_stale = large_table.has_stale_rows();
                     let small_info = &self.db.tables[atoms[smaller_atom].table];
                     let small_table = small_info.table.as_ref();
+                    let small_has_stale = small_table.has_stale_rows();
                     let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
-                    with_pool_set(|ps| {
-                        smaller.for_each(|val, small_sub| {
-                            if let Some(large_sub) = larger.get_subset(val) {
-                                updates.push_binding(*var, val[0]);
-                                let smaller_node = if small_sub.size() <= 16 {
-                                    let small_sub = refine_subset(
-                                        small_sub.to_owned(&ps.get_pool()),
-                                        &smaller_scan.cs,
-                                        &small_table,
-                                    );
-                                    Arc::new(TrieNode::new(small_sub))
-                                } else {
-                                    smaller.node.get_cached_trie_node(
-                                        smaller_scan.column,
-                                        val[0],
-                                        small_info,
-                                        || {
-                                            refine_subset(
-                                                small_sub.to_owned(&ps.get_pool()),
-                                                &smaller_scan.cs,
-                                                &small_table,
-                                            )
-                                        },
-                                    )
-                                };
+                    smaller.for_each(|val, small_sub| {
+                        if let Some(large_sub) = larger.get_subset(val) {
+                            updates.push_binding(*var, val[0]);
+                            if small_sub.size() <= 16 {
+                                let small_sub = refine_subset(
+                                    small_sub.to_owned(pool),
+                                    &smaller_scan.cs,
+                                    &small_table,
+                                    small_has_stale,
+                                );
+                                if small_sub.is_empty() {
+                                    updates.rollback();
+                                    return;
+                                }
+                                updates.refine_atom_subset(smaller_atom, small_sub);
+                            } else {
+                                let smaller_node = smaller.node.get_cached_trie_node(
+                                    smaller_scan.column,
+                                    val[0],
+                                    small_info,
+                                    || {
+                                        refine_subset(
+                                            small_sub.to_owned(pool),
+                                            &smaller_scan.cs,
+                                            &small_table,
+                                            small_has_stale,
+                                        )
+                                    },
+                                );
                                 if smaller_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
                                 }
                                 updates.refine_atom(smaller_atom, smaller_node);
-                                let larger_node = if large_sub.size() <= 16 {
-                                    let large_sub =
-                                        refine_subset(large_sub, &larger_scan.cs, &large_table);
-                                    Arc::new(TrieNode::new(large_sub))
-                                } else {
-                                    larger.node.get_cached_trie_node(
-                                        larger_scan.column,
-                                        val[0],
-                                        large_info,
-                                        || refine_subset(large_sub, &larger_scan.cs, &large_table),
-                                    )
-                                };
+                            }
+                            if large_sub.size() <= 16 {
+                                let large_sub = refine_subset(
+                                    large_sub.to_owned(pool),
+                                    &larger_scan.cs,
+                                    &large_table,
+                                    large_has_stale,
+                                );
+                                if large_sub.is_empty() {
+                                    updates.rollback();
+                                    return;
+                                }
+                                updates.refine_atom_subset(larger_atom, large_sub);
+                            } else {
+                                let larger_node = larger.node.get_cached_trie_node(
+                                    larger_scan.column,
+                                    val[0],
+                                    large_info,
+                                    || {
+                                        refine_subset(
+                                            large_sub.to_owned(pool),
+                                            &larger_scan.cs,
+                                            &large_table,
+                                            large_has_stale,
+                                        )
+                                    },
+                                );
                                 if larger_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
                                 }
                                 updates.refine_atom(larger_atom, larger_node);
-                                updates.finish_frame();
-                                if updates.frames() >= chunk_size {
-                                    drain_updates_parallel!(updates);
-                                }
                             }
-                        });
+                            updates.finish_frame();
+                            if updates.frames() >= chunk_size {
+                                drain_updates!(updates);
+                            }
+                        }
                     });
                     drain_updates!(updates);
 
@@ -1174,73 +1230,106 @@ impl<'a> JoinState<'a> {
                     let main_spec = &rest[smallest];
                     let main_spec_info = &self.db.tables[atoms[main_spec.atom].table];
                     let main_spec_table = main_spec_info.table.as_ref();
+                    let main_spec_has_stale = main_spec_table.has_stale_rows();
+                    // Pre-compute has_stale for each scan to avoid vtable calls in the hot loop.
+                    let rest_has_stale: SmallVec<[bool; 3]> = rest
+                        .iter()
+                        .map(|scan| {
+                            self.db.tables[atoms[scan.atom].table]
+                                .table
+                                .as_ref()
+                                .has_stale_rows()
+                        })
+                        .collect();
 
                     if smallest_size != 0 {
                         // Smallest leads the scan
                         let mut updates =
                             FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                         probers[smallest].for_each(|key, sub| {
-                            with_pool_set(|ps| {
-                                updates.push_binding(*var, key[0]);
-                                for (i, scan) in rest.iter().enumerate() {
-                                    if i == smallest {
-                                        continue;
-                                    }
-                                    if let Some(sub) = probers[i].get_subset(key) {
-                                        let table = self.db.tables[atoms[rest[i].atom].table]
-                                            .table
-                                            .as_ref();
-                                        let node = if sub.size() <= 16 {
-                                            let sub = refine_subset(sub, &rest[i].cs, &table);
-                                            Arc::new(TrieNode::new(sub))
-                                        } else {
-                                            probers[i].node.get_cached_trie_node(
-                                                scan.column,
-                                                key[0],
-                                                &self.db.tables[atoms[scan.atom].table],
-                                                || refine_subset(sub, &rest[i].cs, &table),
-                                            )
-                                        };
+                            updates.push_binding(*var, key[0]);
+                            for (i, scan) in rest.iter().enumerate() {
+                                if i == smallest {
+                                    continue;
+                                }
+                                if let Some(sub) = probers[i].get_subset(key) {
+                                    let table =
+                                        self.db.tables[atoms[rest[i].atom].table].table.as_ref();
+                                    if sub.size() <= 16 {
+                                        let sub = refine_subset(
+                                            sub.to_owned(pool),
+                                            &rest[i].cs,
+                                            &table,
+                                            rest_has_stale[i],
+                                        );
+                                        if sub.is_empty() {
+                                            updates.rollback();
+                                            return;
+                                        }
+                                        updates.refine_atom_subset(scan.atom, sub);
+                                    } else {
+                                        let node = probers[i].node.get_cached_trie_node(
+                                            scan.column,
+                                            key[0],
+                                            &self.db.tables[atoms[scan.atom].table],
+                                            || {
+                                                refine_subset(
+                                                    sub.to_owned(pool),
+                                                    &rest[i].cs,
+                                                    &table,
+                                                    rest_has_stale[i],
+                                                )
+                                            },
+                                        );
                                         if node.subset.is_empty() {
                                             updates.rollback();
                                             return;
                                         }
                                         updates.refine_atom(scan.atom, node);
-                                    } else {
-                                        updates.rollback();
-                                        // Empty intersection.
-                                        return;
                                     }
-                                }
-                                let main_node = if sub.size() <= 16 {
-                                    let sub = refine_subset(
-                                        sub.to_owned(&ps.get_pool()),
-                                        &main_spec.cs,
-                                        &main_spec_table,
-                                    );
-                                    Arc::new(TrieNode::new(sub))
                                 } else {
-                                    probers[smallest].node.get_cached_trie_node(
-                                        main_spec.column,
-                                        key[0],
-                                        main_spec_info,
-                                        || {
-                                            let sub = sub.to_owned(&ps.get_pool());
-
-                                            refine_subset(sub, &main_spec.cs, &main_spec_table)
-                                        },
-                                    )
-                                };
+                                    updates.rollback();
+                                    // Empty intersection.
+                                    return;
+                                }
+                            }
+                            if sub.size() <= 16 {
+                                let main_sub = refine_subset(
+                                    sub.to_owned(pool),
+                                    &main_spec.cs,
+                                    &main_spec_table,
+                                    main_spec_has_stale,
+                                );
+                                if main_sub.is_empty() {
+                                    updates.rollback();
+                                    return;
+                                }
+                                updates.refine_atom_subset(main_spec.atom, main_sub);
+                            } else {
+                                let main_node = probers[smallest].node.get_cached_trie_node(
+                                    main_spec.column,
+                                    key[0],
+                                    main_spec_info,
+                                    || {
+                                        let sub = sub.to_owned(pool);
+                                        refine_subset(
+                                            sub,
+                                            &main_spec.cs,
+                                            &main_spec_table,
+                                            main_spec_has_stale,
+                                        )
+                                    },
+                                );
                                 if main_node.subset.is_empty() {
                                     updates.rollback();
                                     return;
                                 }
                                 updates.refine_atom(main_spec.atom, main_node);
-                                updates.finish_frame();
-                                if updates.frames() >= chunk_size {
-                                    drain_updates_parallel!(updates);
-                                }
-                            })
+                            }
+                            updates.finish_frame();
+                            if updates.frames() >= chunk_size {
+                                drain_updates!(updates);
+                            }
                         });
                         drain_updates!(updates);
                     }
@@ -1275,21 +1364,15 @@ impl<'a> JoinState<'a> {
                         &cover.constraints,
                         &mut buffer,
                     );
-                    for (row, key) in buffer.non_stale() {
-                        updates.refine_atom(
-                            cover_atom,
-                            Arc::new(TrieNode::new(Subset::Dense(OffsetRange::new(
-                                row,
-                                row.inc(),
-                            )))),
-                        );
+                    for (row, key) in buffer.iter() {
+                        updates.refine_atom_dense(cover_atom, OffsetRange::new(row, row.inc()));
                         // bind the values
                         for (i, (_, var)) in bind.iter().enumerate() {
                             updates.push_binding(*var, key[i]);
                         }
                         updates.finish_frame();
                         if updates.frames() >= chunk_size {
-                            drain_updates_parallel!(updates);
+                            drain_updates!(updates);
                         }
                     }
                     if let Some(next) = next {
@@ -1327,6 +1410,16 @@ impl<'a> JoinState<'a> {
                         )
                     })
                     .collect::<SmallVec<[(usize, AtomId, Prober); 4]>>();
+                // Pre-compute has_stale per prober to avoid vtable calls in the hot loop.
+                let index_has_stale: SmallVec<[bool; 4]> = index_probers
+                    .iter()
+                    .map(|(_, atom, _)| {
+                        self.db.tables[atoms[*atom].table]
+                            .table
+                            .as_ref()
+                            .has_stale_rows()
+                    })
+                    .collect();
                 let proj = SmallVec::<[ColumnId; 4]>::from_iter(bind.iter().map(|(col, _)| *col));
                 let cover_node = binding_info.unwrap_val(cover_atom);
                 let cover_subset = cover_node.subset.as_ref();
@@ -1344,27 +1437,26 @@ impl<'a> JoinState<'a> {
                         &cover.constraints,
                         &mut buffer,
                     );
-                    'mid: for (row, key) in buffer.non_stale() {
-                        updates.refine_atom(
-                            cover_atom,
-                            Arc::new(TrieNode::new(Subset::Dense(OffsetRange::new(
-                                row,
-                                row.inc(),
-                            )))),
-                        );
+                    'mid: for (row, key) in buffer.iter() {
+                        updates.refine_atom_dense(cover_atom, OffsetRange::new(row, row.inc()));
                         // bind the values
                         for (i, (_, var)) in bind.iter().enumerate() {
                             updates.push_binding(*var, key[i]);
                         }
                         // now probe each remaining indexes
-                        for (i, atom, prober) in &index_probers {
+                        for (prober_idx, (i, atom, prober)) in index_probers.iter().enumerate() {
                             // create a key: to_intersect indexes into the key from the cover
                             let index_cols = &to_intersect[*i].1;
-                            let index_key = index_cols
-                                .iter()
-                                .map(|col| key[col.index()])
-                                .collect::<SmallVec<[Value; 4]>>();
-                            let Some(subset) = prober.get_subset(&index_key) else {
+                            // Fast path for the common single-column case: avoid SmallVec collect.
+                            let index_key_buf: SmallVec<[Value; 4]>;
+                            let index_key: &[Value] = if let [col] = index_cols.as_slice() {
+                                std::slice::from_ref(&key[col.index()])
+                            } else {
+                                index_key_buf =
+                                    index_cols.iter().map(|col| key[col.index()]).collect();
+                                &index_key_buf
+                            };
+                            let Some(subset) = prober.get_subset(index_key) else {
                                 updates.rollback();
                                 // There are no possible values for this subset
                                 continue 'mid;
@@ -1372,17 +1464,22 @@ impl<'a> JoinState<'a> {
                             // apply any constraints needed in this scan.
                             let table_info = &self.db.tables[atoms[*atom].table];
                             let cs = &to_intersect[*i].0.constraints;
-                            let subset = refine_subset(subset, cs, &table_info.table.as_ref());
+                            let subset = refine_subset(
+                                subset.to_owned(pool),
+                                cs,
+                                &table_info.table.as_ref(),
+                                index_has_stale[prober_idx],
+                            );
                             if subset.is_empty() {
                                 updates.rollback();
                                 // There are no possible values for this subset
                                 continue 'mid;
                             }
-                            updates.refine_atom(*atom, Arc::new(TrieNode::new(subset)));
+                            updates.refine_atom_subset(*atom, subset);
                         }
                         updates.finish_frame();
                         if updates.frames() >= chunk_size {
-                            drain_updates_parallel!(updates);
+                            drain_updates!(updates);
                         }
                     }
                     if let Some(next) = next {
@@ -1421,13 +1518,25 @@ impl<'a> JoinState<'a> {
                         )
                     })
                     .collect::<SmallVec<[Prober; 4]>>();
+                // Pre-compute has_stale per prober to avoid vtable calls in the hot loop.
+                let probers_has_stale: SmallVec<[bool; 4]> = to_intersect
+                    .iter()
+                    .map(|(spec, _)| {
+                        self.db.tables[atoms[spec.to_index.atom].table]
+                            .table
+                            .as_ref()
+                            .has_stale_rows()
+                    })
+                    .collect();
 
                 let mut key = Vec::with_capacity(4);
                 let mut prune_probers = |updates: &mut FrameUpdates,
                                          mat_key: Option<&[Value]>,
                                          mat_non_key: Option<&[Value]>|
                  -> bool {
-                    for ((spec, cols), prober) in to_intersect.iter().zip(probers.iter()) {
+                    for (j, ((spec, cols), prober)) in
+                        to_intersect.iter().zip(probers.iter()).enumerate()
+                    {
                         key.clear();
                         for col in cols.iter() {
                             let val = match mat_key {
@@ -1444,14 +1553,17 @@ impl<'a> JoinState<'a> {
                         }
                         if let Some(subset) = prober.get_subset(&key) {
                             let subset = refine_subset(
-                                subset,
+                                subset.to_owned(pool),
                                 &spec.constraints,
                                 &self.db.tables[atoms[spec.to_index.atom].table]
                                     .table
                                     .as_ref(),
+                                probers_has_stale[j],
                             );
-                            updates
-                                .refine_atom(spec.to_index.atom, Arc::new(TrieNode::new(subset)));
+                            if subset.is_empty() {
+                                return false;
+                            }
+                            updates.refine_atom_subset(spec.to_index.atom, subset);
                         } else {
                             return false;
                         }
@@ -1512,8 +1624,8 @@ impl<'a> JoinState<'a> {
                         // lookup keys
                         if let Some(group) = cover_mat.get(&keys) {
                             if matches!(mode, MatScanMode::Lookup(_)) {
-                                assert_eq!(to_intersect.len(), 0);
-                                assert_eq!(bind.len(), 0);
+                                debug_assert_eq!(to_intersect.len(), 0);
+                                debug_assert_eq!(bind.len(), 0);
                                 if group.len() > 0 {
                                     updates.finish_frame();
                                 }
@@ -1532,7 +1644,7 @@ impl<'a> JoinState<'a> {
                                         updates.rollback();
                                     }
                                     if updates.frames() >= chunk_size {
-                                        drain_updates_parallel!(updates);
+                                        drain_updates!(updates);
                                     }
                                 }
                             }
@@ -1601,6 +1713,14 @@ trait ActionBuffer<'state, A: NumericId>: Send {
     fn morsel_size(&mut self, _level: usize, _total: usize) -> usize {
         256
     }
+
+    /// Whether this buffer supports parallel drain operations.
+    ///
+    /// When `false`, `drain_updates` will use the serial path even at `cur <= 1`,
+    /// avoiding the per-frame `ExecutionState::clone()` overhead.
+    fn supports_parallel_drain(&self) -> bool {
+        true
+    }
 }
 
 /// The action buffer we use if we are executing in a single-threaded
@@ -1657,6 +1777,10 @@ impl<'a, 'outer: 'a> ActionBuffer<'a, ActionId> for InPlaceActionBuffer<'outer> 
         work: impl for<'b> FnOnce(BorrowedLocalState<'b>, &mut Self) + Send + 'a,
     ) {
         work(local, self)
+    }
+
+    fn supports_parallel_drain(&self) -> bool {
+        false
     }
 }
 
@@ -1840,6 +1964,10 @@ impl<'a> ActionBuffer<'a, MatId> for InPlaceMaterializer<'a> {
     ) {
         work(local, self)
     }
+
+    fn supports_parallel_drain(&self) -> bool {
+        false
+    }
 }
 
 struct ScopedMaterializer<'inner, 'scope> {
@@ -1984,6 +2112,10 @@ fn sort_plan_by_size_inner(
     instrs: &[JoinStage],
     binding_info: &mut BindingInfo,
 ) {
+    // Nothing to sort if there's 0 or 1 element.
+    if range.len() <= 1 {
+        return;
+    }
     // How many times an atom has been intersected/joined
     let mut times_refined = with_pool_set(|ps| ps.get::<DenseIdMap<AtomId, i64>>());
 

--- a/core-relations/src/free_join/frame_update.rs
+++ b/core-relations/src/free_join/frame_update.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use crate::free_join::execute::TrieNode;
 use crate::numeric_id::define_id;
+use crate::offsets::OffsetRange;
 
 use crate::Value;
 
@@ -27,6 +28,8 @@ define_id!(pub SubsetId, u32, "An offset into a buffer of subsets");
 pub(super) enum UpdateInstr {
     PushBinding(Variable, Value),
     RefineAtom(AtomId, Arc<TrieNode>),
+    /// Refine an atom to a dense offset range, avoiding an Arc<TrieNode> allocation.
+    RefineAtomDense(AtomId, OffsetRange),
     /// Marks the end of the current frame. Time to make a recursive call.
     EndFrame,
 }
@@ -56,6 +59,12 @@ impl FrameUpdates {
     /// Refine `atom` to consider only the given `subset` in the current frame.
     pub(super) fn refine_atom(&mut self, atom: AtomId, node: Arc<TrieNode>) {
         self.updates.push(UpdateInstr::RefineAtom(atom, node));
+    }
+
+    /// Refine `atom` to consider only the given dense offset range, without
+    /// allocating an Arc<TrieNode> eagerly.
+    pub(super) fn refine_atom_dense(&mut self, atom: AtomId, range: OffsetRange) {
+        self.updates.push(UpdateInstr::RefineAtomDense(atom, range));
     }
 
     /// Roll back the updates to the last frame start. Note that repeated calls

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -221,7 +221,7 @@ pub(crate) fn invoke_batch(
     args: &[QueryEntry],
     out_var: Variable,
 ) {
-    let pool: Pool<Vec<Value>> = with_pool_set(|ps| ps.get_pool().clone());
+    let pool: Pool<Vec<Value>> = with_pool_set(|ps| ps.get_pool());
     let mut out = pool.get();
     out.reserve(mask.len());
     for_each_binding_with_mask!(mask, args, bindings, |iter| {

--- a/core-relations/src/hash_index/mod.rs
+++ b/core-relations/src/hash_index/mod.rs
@@ -221,6 +221,7 @@ impl IndexBase for ColumnIndex {
             self.add_row(key, src_id);
         }
     }
+
     fn for_each(&self, mut f: impl FnMut(&Self::Key, SubsetRef)) {
         for (subsets, (k, v)) in self
             .shards
@@ -230,6 +231,7 @@ impl IndexBase for ColumnIndex {
             f(k, v.as_ref(subsets));
         }
     }
+
     fn len(&self) -> usize {
         self.shards.iter().map(|(_, shard)| shard.table.len()).sum()
     }
@@ -246,7 +248,7 @@ impl IndexBase for ColumnIndex {
         let split_buf = |buf: TaggedRowBuffer| {
             let mut split = IdVec::<ShardId, TaggedRowBuffer>::default();
             split.resize_with(shard_data.n_shards(), || TaggedRowBuffer::new(1));
-            for (row_id, keys) in buf.non_stale() {
+            for (row_id, keys) in buf.iter() {
                 for key in keys {
                     shard_data
                         .get_shard_mut(*key, &mut split)
@@ -285,7 +287,7 @@ impl IndexBase for ColumnIndex {
                 let mut vec = queues[shard_id].lock().unwrap();
                 vec.sort_by_key(|(start, _)| *start);
                 for (_, buf) in vec.drain(..) {
-                    for (row_id, key) in buf.non_stale() {
+                    for (row_id, key) in buf.iter() {
                         debug_assert_eq!(key.len(), 1);
                         match shard.table.entry(key[0]) {
                             Entry::Occupied(mut occ) => {
@@ -405,7 +407,8 @@ impl IndexBase for TupleIndex {
         let hash = hash_key(key);
         let shard = &self.shards[self.shard_data.shard_id(hash)];
         let entry = shard.table.hash.find(hash, |entry| {
-            entry.hash == hash && shard.table.keys.get_row(entry.key) == key
+            // SAFETY: entry.key was stored by add_row, which returns a valid RowId.
+            entry.hash == hash && unsafe { shard.table.keys.get_row_unchecked(entry.key) } == key
         })?;
         Some(entry.vals.as_ref(&shard.subsets))
     }
@@ -416,7 +419,11 @@ impl IndexBase for TupleIndex {
         let shard = &mut self.shards[self.shard_data.shard_id(hash)];
         let table_entry = shard.table.hash.entry(
             hash,
-            |entry| entry.hash == hash && shard.table.keys.get_row(entry.key) == key,
+            // SAFETY: entry.key was stored by add_row, which returns a valid RowId.
+            |entry| {
+                entry.hash == hash
+                    && unsafe { shard.table.keys.get_row_unchecked(entry.key) } == key
+            },
             |ent| ent.hash,
         );
         match table_entry {
@@ -446,7 +453,8 @@ impl IndexBase for TupleIndex {
     fn for_each(&self, mut f: impl FnMut(&Self::Key, SubsetRef)) {
         for (_, shard) in self.shards.iter() {
             for entry in shard.table.hash.iter() {
-                let key = shard.table.keys.get_row(entry.key);
+                // SAFETY: entry.key was stored by add_row, so it is always in-bounds.
+                let key = unsafe { shard.table.keys.get_row_unchecked(entry.key) };
                 f(key, entry.vals.as_ref(&shard.subsets));
             }
         }
@@ -474,7 +482,7 @@ impl IndexBase for TupleIndex {
         let split_buf = |buf: TaggedRowBuffer| {
             let mut split = IdVec::<ShardId, TaggedRowBuffer>::default();
             split.resize_with(shard_data.n_shards(), || TaggedRowBuffer::new(cols.len()));
-            for (row_id, key) in buf.non_stale() {
+            for (row_id, key) in buf.iter() {
                 shard_data
                     .get_shard_mut(key, &mut split)
                     .add_row(row_id, key);
@@ -509,12 +517,15 @@ impl IndexBase for TupleIndex {
                 let mut vec = queues[shard_id].lock().unwrap();
                 vec.sort_by_key(|(start, _)| *start);
                 for (_, buf) in vec.drain(..) {
-                    for (row_id, key) in buf.non_stale() {
+                    for (row_id, key) in buf.iter() {
                         let hash = hash_key(key);
                         let table_entry = shard.table.hash.entry(
                             hash,
+                            // SAFETY: entry.key was stored by add_row, which returns a valid RowId.
                             |entry| {
-                                entry.hash == hash && shard.table.keys.get_row(entry.key) == key
+                                entry.hash == hash
+                                    && unsafe { shard.table.keys.get_row_unchecked(entry.key) }
+                                        == key
                             },
                             |ent| ent.hash,
                         );
@@ -669,7 +680,7 @@ impl SubsetBuffer {
     }
 
     fn push_vec(&mut self, vec: BufferedVec, row: RowId) -> BufferedVec {
-        assert!(
+        debug_assert!(
             vec.is_empty() || self.buf[vec.1.index() - 1] <= row,
             "vec={vec:?}, row={row:?}, last_elt={:?}",
             self.buf[vec.1.index() - 1]

--- a/core-relations/src/offsets/mod.rs
+++ b/core-relations/src/offsets/mod.rs
@@ -43,7 +43,7 @@ impl Offsets for OffsetRange {
 
 impl OffsetRange {
     pub fn new(start: RowId, end: RowId) -> OffsetRange {
-        assert!(
+        debug_assert!(
             start <= end,
             "attempting to create malformed range {start:?}..{end:?}"
         );
@@ -64,7 +64,7 @@ impl SortedOffsetVector {
     }
 
     pub(crate) fn push(&mut self, offset: RowId) {
-        assert!(self.0.last().is_none_or(|last| last <= &offset));
+        debug_assert!(self.0.last().is_none_or(|last| last <= &offset));
         // SAFETY: we just checked the invariant
         unsafe { self.push_unchecked(offset) }
     }
@@ -358,6 +358,7 @@ impl Subset {
         }
     }
     /// Remove any elements of the current subset not present in `other`.
+    #[inline]
     pub(crate) fn intersect(&mut self, other: SubsetRef, pool: &Pool<SortedOffsetVector>) {
         match (self, other) {
             (Subset::Dense(cur), SubsetRef::Dense(other)) => {
@@ -372,34 +373,62 @@ impl Subset {
             (x @ Subset::Dense(_), SubsetRef::Sparse(sparse)) => {
                 let (low, hi) = x.bounds().unwrap();
                 if sparse.bounds().is_some() {
-                    let mut res = pool.get();
                     let l = sparse.binary_search_by_id(low);
                     let r = sparse.binary_search_by_id(hi);
-                    let subslice = sparse.subslice(l, r);
-                    res.extend_nonoverlapping(subslice);
-                    *x = Subset::Sparse(res);
+                    // Check emptiness before allocating from the pool.
+                    if l >= r {
+                        *x = Subset::Dense(OffsetRange::new(RowId::new(0), RowId::new(0)));
+                    } else {
+                        let subslice = sparse.subslice(l, r);
+                        let mut res = pool.get();
+                        res.extend_nonoverlapping(subslice);
+                        *x = Subset::Sparse(res);
+                    }
                 } else {
                     // empty range
                     *x = Subset::Dense(OffsetRange::new(RowId::new(0), RowId::new(0)));
                 }
             }
             (Subset::Sparse(sparse), SubsetRef::Dense(dense)) => {
+                // Binary search for both bounds; avoid copy_within if no prefix to remove.
+                let l = sparse.slice().binary_search_by_id(dense.start);
                 let r = sparse.slice().binary_search_by_id(dense.end);
-                sparse.0.truncate(r);
-                sparse.retain(|row| row >= dense.start);
+                if l == 0 {
+                    sparse.0.truncate(r);
+                } else {
+                    sparse.0.copy_within(l..r, 0);
+                    sparse.0.truncate(r - l);
+                }
             }
             (Subset::Sparse(cur), SubsetRef::Sparse(other)) => {
+                // Hybrid intersect: O(1) fast paths for dense matches and already-past
+                // cases, falling back to binary search when other needs to advance.
                 let mut other_off = 0;
-                cur.retain(|rowid| match other.scan_for_offset(other_off, rowid) {
-                    Ok(found) => {
-                        other_off = found + 1;
-                        true
+                cur.retain(|rowid| {
+                    if other_off >= other.inner().len() {
+                        return false;
                     }
-                    Err(next_off) => {
-                        other_off = next_off;
-                        false
+                    let cur_other = other.inner()[other_off];
+                    if cur_other == rowid {
+                        // Dense match: advance and return true.
+                        other_off += 1;
+                        return true;
                     }
-                })
+                    if cur_other > rowid {
+                        // cur is already past cur's rowid — other hasn't reached it.
+                        return false;
+                    }
+                    match other.scan_for_offset(other_off, rowid) {
+                        Ok(found) => {
+                            other_off = found + 1;
+                            true
+                        }
+                        Err(next_off) => {
+                            other_off = next_off;
+                            false
+                        }
+                    }
+                });
             }
         }
     }

--- a/core-relations/src/offsets/mod.rs
+++ b/core-relations/src/offsets/mod.rs
@@ -141,9 +141,6 @@ impl SortedOffsetSlice {
         // SAFETY: SortedOffsetSlice is repr(transparent), so the two layouts are compatible.
         unsafe { mem::transmute::<&[RowId], &SortedOffsetSlice>(slice) }
     }
-    fn len(&self) -> usize {
-        self.0.len()
-    }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = RowId> + '_ {
         self.0.iter().copied()
@@ -176,12 +173,56 @@ impl SortedOffsetSlice {
         }
     }
 
+    #[inline]
     fn scan_for_offset(&self, start: usize, target: RowId) -> Result<usize, usize> {
-        let i = self.binary_search_from(start, target);
-        if i < self.len() && self.inner()[i] == target {
-            Ok(i)
-        } else {
-            Err(i)
+        let slice = self.inner();
+        let len = slice.len();
+
+        if start >= len {
+            return Err(len);
+        }
+        if slice[start] == target {
+            return Ok(start);
+        }
+        if slice[start] > target {
+            return Err(start);
+        }
+
+        // Galloping search: slice[start] < target, so probe at start+1, start+2, start+4, ...
+        // until we overshoot or reach the end, then binary search the narrowed range.
+        let mut lo = start;
+        let mut step = 1usize;
+        let hi = loop {
+            let probe = lo + step;
+            if probe >= len {
+                break len;
+            }
+            match slice[probe].cmp(&target) {
+                cmp::Ordering::Less => {
+                    lo = probe;
+                    step = step.saturating_mul(2);
+                }
+                cmp::Ordering::Equal => {
+                    let mut found = probe;
+                    while found > start && slice[found - 1] == target {
+                        found -= 1;
+                    }
+                    return Ok(found);
+                }
+                cmp::Ordering::Greater => break probe,
+            }
+        };
+
+        // Invariant: slice[lo] < target, and either hi == len or slice[hi] > target.
+        match slice[lo + 1..hi].binary_search(&target) {
+            Ok(mut found) => {
+                found += lo + 1;
+                while found > start && slice[found - 1] == target {
+                    found -= 1;
+                }
+                Ok(found)
+            }
+            Err(x) => Err(lo + 1 + x),
         }
     }
 }
@@ -392,7 +433,7 @@ impl Subset {
             (Subset::Sparse(sparse), SubsetRef::Dense(dense)) => {
                 // Binary search for both bounds; avoid copy_within if no prefix to remove.
                 let l = sparse.slice().binary_search_by_id(dense.start);
-                let r = sparse.slice().binary_search_by_id(dense.end);
+                let r = sparse.slice().binary_search_from(l, dense.end);
                 if l == 0 {
                     sparse.0.truncate(r);
                 } else {
@@ -401,24 +442,59 @@ impl Subset {
                 }
             }
             (Subset::Sparse(cur), SubsetRef::Sparse(other)) => {
-                // Hybrid intersect: O(1) fast paths for dense matches and already-past
-                // cases, falling back to binary search when other needs to advance.
-                let mut other_off = 0;
-                cur.retain(|rowid| {
-                    if other_off >= other.inner().len() {
-                        return false;
+                let cur_len = cur.0.len();
+                let other_inner = other.inner();
+                let other_len = other_inner.len();
+                if (cur_len <= 16 && other_len <= 16)
+                    || (cur_len / 4 <= other_len && other_len <= cur_len * 4)
+                {
+                    // Similar sizes: two-pointer intersection in O(cur_len + other_len).
+                    let mut write = 0usize;
+                    let mut oi = 0usize;
+                    for ci in 0..cur_len {
+                        let target = cur.0[ci];
+                        while oi < other_len && other_inner[oi] < target {
+                            oi += 1;
+                        }
+                        if oi == other_len {
+                            break;
+                        }
+                        if other_inner[oi] == target {
+                            cur.0[write] = target;
+                            write += 1;
+                            oi += 1;
+                        }
                     }
-                    let cur_other = other.inner()[other_off];
-                    if cur_other == rowid {
-                        // Dense match: advance and return true.
-                        other_off += 1;
-                        return true;
+                    cur.0.truncate(write);
+                } else if cur_len > other_len {
+                    // other is much smaller: iterate other and gallop in cur.
+                    // O(other_len * log(cur_len / other_len)) vs O(cur_len) for retain.
+                    let mut write = 0usize;
+                    let mut ci = 0usize;
+                    #[allow(clippy::needless_range_loop)]
+                    for oi in 0..other_len {
+                        if ci >= cur_len {
+                            break;
+                        }
+                        let target = other_inner[oi];
+                        let result = cur.slice().scan_for_offset(ci, target);
+                        match result {
+                            Ok(found) => {
+                                cur.0[write] = target;
+                                write += 1;
+                                ci = found + 1;
+                            }
+                            Err(next_ci) => {
+                                ci = next_ci;
+                            }
+                        }
                     }
-                    if cur_other > rowid {
-                        // cur is already past cur's rowid — other hasn't reached it.
-                        return false;
-                    }
-                    match other.scan_for_offset(other_off, rowid) {
+                    cur.0.truncate(write);
+                } else {
+                    // cur is much smaller than other: iterate cur and gallop in other.
+                    // O(cur_len * log(other_len / cur_len)).
+                    let mut other_off = 0;
+                    cur.retain(|rowid| match other.scan_for_offset(other_off, rowid) {
                         Ok(found) => {
                             other_off = found + 1;
                             true
@@ -427,8 +503,8 @@ impl Subset {
                             other_off = next_off;
                             false
                         }
-                    }
-                });
+                    });
+                }
             }
         }
     }

--- a/core-relations/src/offsets/mod.rs
+++ b/core-relations/src/offsets/mod.rs
@@ -64,8 +64,7 @@ impl SortedOffsetVector {
     }
 
     pub(crate) fn push(&mut self, offset: RowId) {
-        debug_assert!(self.0.last().is_none_or(|last| last <= &offset));
-        // SAFETY: we just checked the invariant
+        assert!(self.0.last().is_none_or(|last| last <= &offset));
         unsafe { self.push_unchecked(offset) }
     }
 

--- a/core-relations/src/offsets/tests.rs
+++ b/core-relations/src/offsets/tests.rs
@@ -2,7 +2,7 @@ use crate::numeric_id::NumericId;
 
 use crate::{OffsetRange, Subset, common::HashSet, pool::with_pool_set};
 
-use super::{Offsets, RowId, SortedOffsetVector};
+use super::{Offsets, RowId};
 
 fn o(u: usize) -> RowId {
     RowId::from_usize(u)
@@ -29,21 +29,25 @@ fn subset_push() {
     assert_eq!(collect(&s, &elts), vec![1, 2, 3, 7]);
 }
 
+#[cfg(debug_assertions)]
 #[test]
 #[should_panic]
 fn bad_offset_range() {
     OffsetRange::new(o(3), o(2));
 }
 
+#[cfg(debug_assertions)]
 #[test]
 #[should_panic]
 fn bad_offset_stride() {
     OffsetRange::new(o(3), o(2));
 }
 
+#[cfg(debug_assertions)]
 #[test]
 #[should_panic]
 fn not_sorted_vec_push() {
+    use crate::offsets::SortedOffsetVector;
     let mut v = SortedOffsetVector::default();
     v.push(o(3));
     v.push(o(1));
@@ -78,7 +82,7 @@ fn intersect() {
             let mut expected = Vec::from_iter(l_set.intersection(&r_set).copied());
             l_sub.intersect(
                 r_sub.as_ref(),
-                &with_pool_set(|pool_set| pool_set.get_pool().clone()),
+                &with_pool_set(|pool_set| pool_set.get_pool()),
             );
             expected.sort();
             let mut got = Vec::new();

--- a/core-relations/src/offsets/tests.rs
+++ b/core-relations/src/offsets/tests.rs
@@ -56,7 +56,7 @@ fn not_sorted_vec_push() {
 
 #[test]
 fn intersect() {
-    let elts = vec![
+    let elts = [
         vec![1, 3, 4, 8, 9, 12, 20],
         vec![3, 4, 8, 9, 11, 12, 15, 18, 20],
         vec![3, 4, 8, 9, 11, 12, 15, 18, 20, 22, 24],
@@ -67,16 +67,25 @@ fn intersect() {
         Vec::from_iter(4..50),
     ];
 
-    for l in &elts {
-        for r in &elts {
+    // Also include size-skewed pairs that exercise the two-pointer/galloping boundary.
+    // Two-pointer fires when max/min < 4; galloping fires otherwise.
+    let skewed: Vec<Vec<usize>> = vec![
+        Vec::from_iter(0..5),
+        Vec::from_iter(0..100), // 20x skew → galloping path
+        Vec::from_iter((0..100).filter(|x| x % 7 == 0)),
+    ];
+    let all_elts: Vec<&Vec<usize>> = elts.iter().chain(skewed.iter()).collect();
+
+    for l in &all_elts {
+        for r in &all_elts {
             let mut l_sub = Subset::empty();
             let mut r_sub = Subset::empty();
             let l_set = HashSet::from_iter(l.iter().copied().map(o));
             let r_set = HashSet::from_iter(r.iter().copied().map(o));
-            for row in l {
+            for row in l.iter() {
                 l_sub.add_row_sorted(o(*row));
             }
-            for row in r {
+            for row in r.iter() {
                 r_sub.add_row_sorted(o(*row));
             }
             let mut expected = Vec::from_iter(l_set.intersection(&r_set).copied());

--- a/core-relations/src/pool/mod.rs
+++ b/core-relations/src/pool/mod.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::{
     AtomId,
-    free_join::execute::ChildrenMaps,
+    free_join::execute::TrieNode,
     numeric_id::{DenseIdMap, IdVec},
 };
 use fixedbitset::FixedBitSet;
@@ -440,7 +440,8 @@ pool_set! {
         instr_indexes: Vec<u32> [ 1 << 20 ],
         cached_subsets: IdVec<ColumnId, std::sync::OnceLock<std::sync::Arc<ColumnIndex>>> [ 4 << 20 ],
         intersected_on: DenseIdMap<AtomId, i64> [ 1 << 20 ],
-        children_map: ChildrenMaps [ 1 << 20 ],
+
+        cached_child: IdVec<ColumnId, std::sync::RwLock<HashMap<Value, std::sync::Arc<TrieNode>>>> [ 1 << 20 ],
     }
 }
 

--- a/core-relations/src/row_buffer/mod.rs
+++ b/core-relations/src/row_buffer/mod.rs
@@ -337,7 +337,7 @@ impl RowBuffer {
     /// This method panics if the length of `row` does not match the arity of
     /// the RowBuffer.
     pub(crate) fn add_row(&mut self, row: &[Value]) -> RowId {
-        assert_eq!(
+        debug_assert_eq!(
             row.len(),
             self.n_columns,
             "attempting to add a row with mismatched arity to table"
@@ -449,7 +449,7 @@ impl<V: ValueVec> TaggedRowBuffer<V> {
         //
         // Changes to the implementation of one method should probably also
         // change the other.
-        assert_eq!(
+        debug_assert_eq!(
             row.len(),
             self.base_arity(),
             "attempting to add a row with mismatched arity to table"

--- a/core-relations/src/table/mod.rs
+++ b/core-relations/src/table/mod.rs
@@ -345,6 +345,10 @@ impl Table for SortedWritesTable {
         Subset::Dense(OffsetRange::new(RowId::new(0), self.data.next_row()))
     }
 
+    fn has_stale_rows(&self) -> bool {
+        self.data.stale_rows > 0
+    }
+
     fn len(&self) -> usize {
         self.data.data.len() - self.data.stale_rows
     }
@@ -357,19 +361,25 @@ impl Table for SortedWritesTable {
             // Empty subset
             return;
         };
-        assert!(
+        debug_assert!(
             hi.index() <= self.data.data.len(),
             "{} vs. {}",
             hi.index(),
             self.data.data.len()
         );
-        // SAFETY: subsets are sorted, low must be at most hi, and hi is less
-        // than the length of the table.
-        subset.offsets(|row| unsafe {
-            if let Some(vals) = self.data.get_row_unchecked(row) {
-                f(row, vals)
-            }
-        })
+        if self.data.stale_rows == 0 {
+            // Fast path: no stale rows, skip is_stale check per row.
+            // SAFETY: subsets are sorted, low must be at most hi, and hi is less
+            // than the length of the table.
+            subset.offsets(|row| unsafe { f(row, self.data.data.get_row_unchecked(row)) })
+        } else {
+            // SAFETY: same as above.
+            subset.offsets(|row| unsafe {
+                if let Some(vals) = self.data.get_row_unchecked(row) {
+                    f(row, vals)
+                }
+            })
+        }
     }
 
     fn scan_generic_bounded(
@@ -384,14 +394,25 @@ impl Table for SortedWritesTable {
         Self: Sized,
     {
         if cs.is_empty() {
-            subset
-                .iter_bounded(start.index(), start.index() + n, |row| {
-                    let Some(entry) = self.data.get_row(row) else {
-                        return;
-                    };
-                    f(row, entry);
-                })
-                .map(Offset::from_usize)
+            if self.data.stale_rows == 0 {
+                // Fast path: no stale rows, skip bounds check and is_stale check.
+                // SAFETY: subsets are valid (bounds within table), so all row IDs are in-bounds.
+                subset
+                    .iter_bounded(start.index(), start.index() + n, |row| {
+                        let entry = unsafe { self.data.data.get_row_unchecked(row) };
+                        f(row, entry);
+                    })
+                    .map(Offset::from_usize)
+            } else {
+                subset
+                    .iter_bounded(start.index(), start.index() + n, |row| {
+                        let Some(entry) = self.data.get_row(row) else {
+                            return;
+                        };
+                        f(row, entry);
+                    })
+                    .map(Offset::from_usize)
+            }
         } else {
             subset
                 .iter_bounded(start.index(), start.index() + n, |row| {
@@ -970,7 +991,13 @@ impl SortedWritesTable {
     }
 
     fn get_if(&self, cs: &[Constraint], row: RowId) -> Option<&[Value]> {
-        let row = self.data.get_row(row)?;
+        // Fast path: when no stale rows, skip the stale check.
+        let row = if self.data.stale_rows == 0 {
+            // SAFETY: callers guarantee row is within bounds via subset construction.
+            unsafe { self.data.data.get_row_unchecked(row) }
+        } else {
+            self.data.get_row(row)?
+        };
         let mut res = true;
         for constraint in cs {
             match constraint {

--- a/core-relations/src/table/mod.rs
+++ b/core-relations/src/table/mod.rs
@@ -361,7 +361,7 @@ impl Table for SortedWritesTable {
             // Empty subset
             return;
         };
-        debug_assert!(
+        assert!(
             hi.index() <= self.data.data.len(),
             "{} vs. {}",
             hi.index(),
@@ -393,10 +393,20 @@ impl Table for SortedWritesTable {
     where
         Self: Sized,
     {
+        let Some((_low, hi)) = subset.bounds() else {
+            // Empty subset
+            return None;
+        };
+        assert!(
+            hi.index() <= self.data.data.len(),
+            "{} vs. {}",
+            hi.index(),
+            self.data.data.len()
+        );
         if cs.is_empty() {
             if self.data.stale_rows == 0 {
                 // Fast path: no stale rows, skip bounds check and is_stale check.
-                // SAFETY: subsets are valid (bounds within table), so all row IDs are in-bounds.
+                // SAFETY: all row IDs are in-bounds.
                 subset
                     .iter_bounded(start.index(), start.index() + n, |row| {
                         let entry = unsafe { self.data.data.get_row_unchecked(row) };
@@ -406,7 +416,8 @@ impl Table for SortedWritesTable {
             } else {
                 subset
                     .iter_bounded(start.index(), start.index() + n, |row| {
-                        let Some(entry) = self.data.get_row(row) else {
+                        // SAFETY: all row IDs are in-bounds.
+                        let Some(entry) = (unsafe { self.data.get_row_unchecked(row) }) else {
                             return;
                         };
                         f(row, entry);
@@ -416,7 +427,8 @@ impl Table for SortedWritesTable {
         } else {
             subset
                 .iter_bounded(start.index(), start.index() + n, |row| {
-                    let Some(entry) = self.get_if(cs, row) else {
+                    // SAFETY: all row IDs are in-bounds.
+                    let Some(entry) = (unsafe { self.get_if_unchecked(cs, row) }) else {
                         return;
                     };
                     f(row, entry);
@@ -990,26 +1002,33 @@ impl SortedWritesTable {
         self.get_if(cs, row).is_some()
     }
 
-    fn get_if(&self, cs: &[Constraint], row: RowId) -> Option<&[Value]> {
-        // Fast path: when no stale rows, skip the stale check.
-        let row = if self.data.stale_rows == 0 {
-            // SAFETY: callers guarantee row is within bounds via subset construction.
-            unsafe { self.data.data.get_row_unchecked(row) }
+    fn eval_constraints(cs: &[Constraint], row: &[Value]) -> bool {
+        cs.iter().all(|constraint| match constraint {
+            Constraint::Eq { l_col, r_col } => row[l_col.index()] == row[r_col.index()],
+            Constraint::EqConst { col, val } => row[col.index()] == *val,
+            Constraint::LtConst { col, val } => row[col.index()] < *val,
+            Constraint::GtConst { col, val } => row[col.index()] > *val,
+            Constraint::LeConst { col, val } => row[col.index()] <= *val,
+            Constraint::GeConst { col, val } => row[col.index()] >= *val,
+        })
+    }
+
+    unsafe fn get_if_unchecked(&self, cs: &[Constraint], row: RowId) -> Option<&[Value]> {
+        let row = unsafe { self.data.data.get_row_unchecked(row) };
+        if Self::eval_constraints(cs, row) {
+            Some(row)
         } else {
-            self.data.get_row(row)?
-        };
-        let mut res = true;
-        for constraint in cs {
-            match constraint {
-                Constraint::Eq { l_col, r_col } => res &= row[l_col.index()] == row[r_col.index()],
-                Constraint::EqConst { col, val } => res &= row[col.index()] == *val,
-                Constraint::LtConst { col, val } => res &= row[col.index()] < *val,
-                Constraint::GtConst { col, val } => res &= row[col.index()] > *val,
-                Constraint::LeConst { col, val } => res &= row[col.index()] <= *val,
-                Constraint::GeConst { col, val } => res &= row[col.index()] >= *val,
-            }
+            None
         }
-        if res { Some(row) } else { None }
+    }
+
+    fn get_if(&self, cs: &[Constraint], row: RowId) -> Option<&[Value]> {
+        let row = self.data.get_row(row)?;
+        if Self::eval_constraints(cs, row) {
+            Some(row)
+        } else {
+            None
+        }
     }
 
     fn maybe_rehash(&mut self) {

--- a/core-relations/src/table_spec.rs
+++ b/core-relations/src/table_spec.rs
@@ -263,6 +263,13 @@ pub trait Table: Any + Send + Sync {
         }
     }
 
+    /// Returns true if the table contains any stale rows (rows whose first column
+    /// has been set to [`Value::stale()`]). The default implementation returns `true`
+    /// (conservative). Tables that track stale-row counts should override this.
+    fn has_stale_rows(&self) -> bool {
+        true
+    }
+
     /// Filter a given subset of the table for the rows that are live
     fn refine_live(&self, subset: Subset) -> Subset {
         // NB: This relies on Value::stale() being strictly larger than any other value in the table.


### PR DESCRIPTION
I have categorized the optimizations Claude did into the following categories.

- Low-level optimizations
    - fast paths
        - shard computation when shard_count == 0
        - don’t access thread-local pool if the subset is empty
        - skip staleness check if we know the table does not have stale rows (good for datalog only workload)
    - RefineAtomDense
        - avoids Arc<TrieNode> creation if we later find a candidate to join does not satisfy the given constraints
    - Replace get_row with unsafe versions get_row_unchecked
    - Replace debug_assert! with assert!
    - Inline the last level of GJ recursion
    - avoid drain_updates_parallel is we know we are in single thread
        - parallel draining may copy some intermediate state even if we are not creating new threads
- Good improvements
    - Avoid thread-local storage access, store the thread-local pointer in a struct
- Great improvements
    - Fixed a performance bug when intersecting two subsets
        - Old algorithm can take O(n log m) time in worse case when the ranges of the two subsets do not overlap
    - When interesting a slice of row ids with a range [l, r], the result does not need to be instantiated/allocated: the result is always a subslice of the original slice.