### PR TITLE
Factorize binding representations

### DIFF
--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -960,7 +960,6 @@ impl<'a> JoinState<'a> {
         if cur >= instr_order.len() {
             action_buf.push_bindings_factorized(
                 action,
-                self.db,
                 &mut binding_info.bindings,
                 &binding_info.binding_sets,
                 || self.exec_state.clone(),
@@ -1005,7 +1004,6 @@ impl<'a> JoinState<'a> {
                             if cur + 1 >= instr_order.len() {
                                 action_buf.push_bindings_factorized(
                                     action,
-                                    self.db,
                                     &mut binding_info.bindings,
                                     &binding_info.binding_sets,
                                     || self.exec_state.clone(),
@@ -1742,24 +1740,18 @@ trait ActionBuffer<'state, A: NumericId>: Send {
     type AsLocal<'a>: ActionBuffer<'state, A>
     where
         'state: 'a;
-    /// Push the given bindings to be executed for the specified action. If this
-    /// buffer has built up a sufficient batch size, it may execute
-    /// `to_exec_state` and then execute the action.
-    ///
-    /// NB: `push_bindings` makes module-specific assumptions on what values are passed to
-    /// `bindings` for a common `action`. This is not a general-purpose trait for that reason and
-    /// it should not, in general, be used outside of this module.
+    
+    /// Expand the binding sets to individual bindings and 
+    /// call push_bindings
     fn push_bindings_factorized(
         &mut self,
         action: A,
-        db: &Database,
         bindings: &mut DenseIdMap<Variable, Value>,
         binding_sets: &BindingSet,
         mut to_exec_state: impl FnMut() -> ExecutionState<'state>,
     ) {
         expand_binding_sets(
             self,
-            db,
             action,
             bindings,
             &binding_sets,
@@ -1768,6 +1760,13 @@ trait ActionBuffer<'state, A: NumericId>: Send {
         );
     }
 
+    /// Push the given bindings to be executed for the specified action. If this
+    /// buffer has built up a sufficient batch size, it may execute
+    /// `to_exec_state` and then execute the action.
+    ///
+    /// NB: `push_bindings` makes module-specific assumptions on what values are passed to
+    /// `bindings` for a common `action`. This is not a general-purpose trait for that reason and
+    /// it should not, in general, be used outside of this module.
     fn push_bindings(
         &mut self,
         action: A,
@@ -1982,7 +1981,6 @@ impl<'scope> ActionBuffer<'scope, ActionId> for ScopedActionBuffer<'_, 'scope> {
 
 fn expand_binding_sets<'state, A: NumericId, BUF: ActionBuffer<'state, A> + ?Sized>(
     action_buf: &mut BUF,
-    db: &Database,
     action: A,
     bindings: &mut DenseIdMap<Variable, Value>,
     binding_sets: &BindingSet,
@@ -2010,7 +2008,6 @@ fn expand_binding_sets<'state, A: NumericId, BUF: ActionBuffer<'state, A> + ?Siz
         }
         expand_binding_sets(
             action_buf,
-            db,
             action,
             bindings,
             binding_sets,

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -11,7 +11,7 @@ use crate::{
     free_join::plan::{JoinStages, MatId, MatScanMode, MatSpec},
     numeric_id::{DenseIdMap, IdVec, NumericId},
     query::Atom,
-    row_buffer::RowBuffer,
+    row_buffer::{RowBuffer, SmallValueVec},
 };
 use crossbeam::utils::CachePadded;
 use dashmap::mapref::entry::Entry;

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -760,9 +760,12 @@ impl FrameUpdates {
     }
 }
 
+type BindingSet = Vec<(SmallVec<[Variable; 4]>, Arc<TaggedRowBuffer<SmallValueVec>>)>;
+
 #[derive(Default, Clone)]
 struct BindingInfo {
     bindings: DenseIdMap<Variable, Value>,
+    binding_sets: BindingSet,
     subsets: DenseIdMap<AtomId, Arc<TrieNode>>,
     materializations: DenseIdMap<MatId, Arc<HashMap<Vec<Value>, RowBuffer>>>,
 }
@@ -955,12 +958,17 @@ impl<'a> JoinState<'a> {
         }
 
         if cur >= instr_order.len() {
-            action_buf.push_bindings(action, &binding_info.bindings, || self.exec_state.clone());
+            action_buf.push_bindings_factorized(
+                action,
+                self.db,
+                &mut binding_info.bindings,
+                &binding_info.binding_sets,
+                || self.exec_state.clone(),
+            );
             return;
         }
         let chunk_size = action_buf.morsel_size(cur, instr_order.len());
         let mut cur_size = estimate_size(&stages.instrs[instr_order.get(cur)], binding_info);
-        // TODO: add dynamic sort plan back
         if cur_size > 32 && cur % 3 == 1 && cur < instr_order.len() - 1 {
             // If we have a reasonable number of tuples to process, adjust the variable order every
             // 3 rounds, but always make sure to readjust on the second roung.
@@ -995,9 +1003,13 @@ impl<'a> JoinState<'a> {
                             // a recursive run_plan call, avoiding function call
                             // overhead + an extra should_stop() check.
                             if cur + 1 >= instr_order.len() {
-                                action_buf.push_bindings(action, &binding_info.bindings, || {
-                                    self.exec_state.clone()
-                                });
+                                action_buf.push_bindings_factorized(
+                                    action,
+                                    self.db,
+                                    &mut binding_info.bindings,
+                                    &binding_info.binding_sets,
+                                    || self.exec_state.clone(),
+                                );
                             } else {
                                 self.run_plan(
                                     stages,
@@ -1360,6 +1372,44 @@ impl<'a> JoinState<'a> {
                 cover,
                 bind,
                 to_intersect,
+                is_leaf_scan: true,
+            } if to_intersect.is_empty() => {
+                let cover_atom = cover.to_index.atom;
+                if binding_info.has_empty_subset(cover_atom) {
+                    return;
+                }
+                let table = self.db.tables[atoms[cover_atom].table].table.as_ref();
+                let cover_node = binding_info.unwrap_val(cover_atom);
+                let cover_subset = cover_node.subset.as_ref();
+
+                let proj = SmallVec::<[ColumnId; 4]>::from_iter(bind.iter().map(|(col, _)| *col));
+                let vars = bind.iter().map(|(_, var)| *var).collect();
+                let mut buf = TaggedRowBuffer::new_inline(bind.len());
+                table.scan_project(
+                    cover_subset,
+                    &proj,
+                    Offset::new(0),
+                    usize::MAX,
+                    &cover.constraints,
+                    &mut buf,
+                );
+
+                if buf.is_empty() {
+                    return;
+                }
+
+                binding_info.binding_sets.push((vars, Arc::new(buf)));
+                let mut updates = FrameUpdates::with_capacity(1);
+                updates.finish_frame();
+                drain_updates!(updates);
+                binding_info.binding_sets.pop();
+                binding_info.move_back_node(cover_atom, cover_node);
+            }
+            JoinStage::FusedIntersect {
+                cover,
+                bind,
+                to_intersect,
+                is_leaf_scan: false,
             } if to_intersect.is_empty() => {
                 let cover_atom = cover.to_index.atom;
                 if binding_info.has_empty_subset(cover_atom) {
@@ -1407,6 +1457,7 @@ impl<'a> JoinState<'a> {
                 cover,
                 bind,
                 to_intersect,
+                is_leaf_scan: _,
             } => {
                 let cover_atom = cover.to_index.atom;
                 if binding_info.has_empty_subset(cover_atom) {
@@ -1698,6 +1749,25 @@ trait ActionBuffer<'state, A: NumericId>: Send {
     /// NB: `push_bindings` makes module-specific assumptions on what values are passed to
     /// `bindings` for a common `action`. This is not a general-purpose trait for that reason and
     /// it should not, in general, be used outside of this module.
+    fn push_bindings_factorized(
+        &mut self,
+        action: A,
+        db: &Database,
+        bindings: &mut DenseIdMap<Variable, Value>,
+        binding_sets: &BindingSet,
+        mut to_exec_state: impl FnMut() -> ExecutionState<'state>,
+    ) {
+        expand_binding_sets(
+            self,
+            db,
+            action,
+            bindings,
+            &binding_sets,
+            0,
+            &mut to_exec_state,
+        );
+    }
+
     fn push_bindings(
         &mut self,
         action: A,
@@ -1907,6 +1977,46 @@ impl<'scope> ActionBuffer<'scope, ActionId> for ScopedActionBuffer<'_, 'scope> {
             0 if _total > 2 => 32,
             _ => 256,
         }
+    }
+}
+
+fn expand_binding_sets<'state, A: NumericId, BUF: ActionBuffer<'state, A> + ?Sized>(
+    action_buf: &mut BUF,
+    db: &Database,
+    action: A,
+    bindings: &mut DenseIdMap<Variable, Value>,
+    binding_sets: &BindingSet,
+    idx: usize,
+    mut to_exec_state: &mut impl FnMut() -> ExecutionState<'state>,
+) {
+    if idx >= binding_sets.len() {
+        action_buf.push_bindings(action, bindings, to_exec_state);
+        return;
+    }
+    if idx + 1 == binding_sets.len() {
+        let (vars, buf) = &binding_sets[idx];
+        for (_, row) in buf.iter() {
+            for (var, val) in vars.iter().zip(row.iter()) {
+                bindings.insert(*var, *val);
+            }
+            action_buf.push_bindings(action, bindings, &mut to_exec_state);
+        }
+        return;
+    }
+    let (vars, buf) = &binding_sets[idx];
+    for (_, row) in buf.iter() {
+        for (var, val) in vars.iter().zip(row.iter()) {
+            bindings.insert(*var, *val);
+        }
+        expand_binding_sets(
+            action_buf,
+            db,
+            action,
+            bindings,
+            binding_sets,
+            idx + 1,
+            to_exec_state,
+        );
     }
 }
 

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -1740,8 +1740,8 @@ trait ActionBuffer<'state, A: NumericId>: Send {
     type AsLocal<'a>: ActionBuffer<'state, A>
     where
         'state: 'a;
-    
-    /// Expand the binding sets to individual bindings and 
+
+    /// Expand the binding sets to individual bindings and
     /// call push_bindings
     fn push_bindings_factorized(
         &mut self,
@@ -1750,14 +1750,7 @@ trait ActionBuffer<'state, A: NumericId>: Send {
         binding_sets: &BindingSet,
         mut to_exec_state: impl FnMut() -> ExecutionState<'state>,
     ) {
-        expand_binding_sets(
-            self,
-            action,
-            bindings,
-            &binding_sets,
-            0,
-            &mut to_exec_state,
-        );
+        expand_binding_sets(self, action, bindings, binding_sets, 0, &mut to_exec_state);
     }
 
     /// Push the given bindings to be executed for the specified action. If this

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -962,7 +962,7 @@ impl<'a> JoinState<'a> {
                 action,
                 &mut binding_info.bindings,
                 &binding_info.binding_sets,
-                || self.exec_state.clone(),
+                &self.exec_state,
             );
             return;
         }
@@ -1006,7 +1006,7 @@ impl<'a> JoinState<'a> {
                                     action,
                                     &mut binding_info.bindings,
                                     &binding_info.binding_sets,
-                                    || self.exec_state.clone(),
+                                    &self.exec_state,
                                 );
                             } else {
                                 self.run_plan(
@@ -1748,9 +1748,9 @@ trait ActionBuffer<'state, A: NumericId>: Send {
         action: A,
         bindings: &mut DenseIdMap<Variable, Value>,
         binding_sets: &BindingSet,
-        mut to_exec_state: impl FnMut() -> ExecutionState<'state>,
+        exec_state: &ExecutionState<'state>,
     ) {
-        expand_binding_sets(self, action, bindings, binding_sets, 0, &mut to_exec_state);
+        expand_binding_sets(self, action, bindings, binding_sets, 0, exec_state);
     }
 
     /// Push the given bindings to be executed for the specified action. If this
@@ -1978,19 +1978,25 @@ fn expand_binding_sets<'state, A: NumericId, BUF: ActionBuffer<'state, A> + ?Siz
     bindings: &mut DenseIdMap<Variable, Value>,
     binding_sets: &BindingSet,
     idx: usize,
-    mut to_exec_state: &mut impl FnMut() -> ExecutionState<'state>,
+    exec_state: &ExecutionState<'state>,
 ) {
+    if exec_state.should_stop() {
+        return;
+    }
     if idx >= binding_sets.len() {
-        action_buf.push_bindings(action, bindings, to_exec_state);
+        action_buf.push_bindings(action, bindings, || exec_state.clone());
         return;
     }
     if idx + 1 == binding_sets.len() {
         let (vars, buf) = &binding_sets[idx];
         for (_, row) in buf.iter() {
+            if exec_state.should_stop() {
+                return;
+            }
             for (var, val) in vars.iter().zip(row.iter()) {
                 bindings.insert(*var, *val);
             }
-            action_buf.push_bindings(action, bindings, &mut to_exec_state);
+            action_buf.push_bindings(action, bindings, || exec_state.clone());
         }
         return;
     }
@@ -2005,7 +2011,7 @@ fn expand_binding_sets<'state, A: NumericId, BUF: ActionBuffer<'state, A> + ?Siz
             bindings,
             binding_sets,
             idx + 1,
-            to_exec_state,
+            exec_state,
         );
     }
 }

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -211,65 +211,6 @@ impl JoinStage {
                 };
                 true
             }
-            // (
-            //     FusedIntersect {
-            //         cover,
-            //         bind,
-            //         to_intersect,
-            //         is_leaf_scan: _,
-            //     },
-            //     Intersect { var, scans },
-            // ) if to_intersect.is_empty()
-            //     && scans.len() == 1
-            //     && cover.to_index.atom == scans[0].atom
-            //     && scans[0].cs.is_empty() =>
-            // {
-            //     let col = scans[0].column;
-            //     bind.push((col, *var));
-            //     cover.to_index.vars.push(col);
-            //     true
-            // }
-            // (
-            //     x,
-            //     Intersect {
-            //         var: var2,
-            //         scans: scans2,
-            //     },
-            // ) => {
-            //     // This is all somewhat mangled because of the borrowing rules
-            //     // when we pass &mut self into a tuple.
-            //     let (var1, mut scans1) = if let Intersect {
-            //         var: var1,
-            //         scans: scans1,
-            //     } = x
-            //     {
-            //         if !(scans1.len() == 1
-            //             && scans2.len() == 1
-            //             && scans1[0].atom == scans2[0].atom
-            //             && scans2[0].cs.is_empty())
-            //         {
-            //             return false;
-            //         }
-            //         (*var1, mem::take(scans1))
-            //     } else {
-            //         return false;
-            //     };
-            //     let atom = scans1[0].atom;
-            //     let col1 = scans1[0].column;
-            //     let col2 = scans2[0].column;
-            //     *x = FusedIntersect {
-            //         cover: ScanSpec {
-            //             to_index: SubAtom {
-            //                 atom,
-            //                 vars: smallvec![col1, col2],
-            //             },
-            //             constraints: mem::take(&mut scans1[0].cs),
-            //         },
-            //         bind: smallvec![(col1, var1), (col2, *var2)],
-            //         to_intersect: Default::default(),
-            //     };
-            //     true
-            // }
             _ => false,
         }
     }

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -1106,9 +1106,7 @@ fn revert_bad_leaf_scans(stages: &mut [JoinStage]) {
             _ => false,
         });
 
-        if needs_scalar
-            && let JoinStage::FusedIntersect { is_leaf_scan, .. } = &mut stages[i]
-        {
+        if needs_scalar && let JoinStage::FusedIntersect { is_leaf_scan, .. } = &mut stages[i] {
             *is_leaf_scan = false;
         }
     }
@@ -1651,9 +1649,9 @@ fn plan_gj(
         {
             let cover_atom = cover.to_index.atom;
             let mut used_later = false;
-            for j in (i + 1)..stages.len() {
+            for later_stage in &stages[i + 1..] {
                 used_later = used_later
-                    || match &stages[j] {
+                    || match later_stage {
                         JoinStage::Intersect { scans, .. } => {
                             scans.iter().any(|scan| scan.atom == cover_atom)
                         }

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -147,6 +147,7 @@ pub(crate) enum JoinStage {
         bind: SmallVec<[(ColumnId, Variable); 2]>,
         // to_intersect.1 is the index into the cover atom.
         to_intersect: Vec<(ScanSpec, SmallVec<[ColumnId; 2]>)>,
+        is_leaf_scan: bool,
     },
     FusedIntersectMat {
         cover: MatId,
@@ -163,65 +164,112 @@ impl JoinStage {
     /// scans that do no filtering whatsoever.
     fn fuse(&mut self, other: &JoinStage) -> bool {
         use JoinStage::*;
-        match (self, other) {
+        match (&*self, other) {
             (
                 FusedIntersect {
-                    cover,
-                    bind,
-                    to_intersect,
+                    cover: cover1,
+                    bind: bind1,
+                    to_intersect: to_intersect1,
+                    is_leaf_scan: is_leaf_scan1,
                 },
-                Intersect { var, scans },
-            ) if to_intersect.is_empty()
-                && scans.len() == 1
-                && cover.to_index.atom == scans[0].atom
-                && scans[0].cs.is_empty() =>
+                FusedIntersect {
+                    cover: cover2,
+                    bind: bind2,
+                    to_intersect: to_intersect2,
+                    is_leaf_scan: is_leaf_scan2,
+                },
+            ) if cover1.to_index.atom == cover2.to_index.atom
+                && to_intersect1.is_empty()
+                && to_intersect2.is_empty()
+                && (cover1.constraints.is_empty() || cover2.constraints.is_empty()) =>
             {
-                let col = scans[0].column;
-                bind.push((col, *var));
-                cover.to_index.vars.push(col);
-                true
-            }
-            (
-                x,
-                Intersect {
-                    var: var2,
-                    scans: scans2,
-                },
-            ) => {
-                // This is all somewhat mangled because of the borrowing rules
-                // when we pass &mut self into a tuple.
-                let (var1, mut scans1) = if let Intersect {
-                    var: var1,
-                    scans: scans1,
-                } = x
-                {
-                    if !(scans1.len() == 1
-                        && scans2.len() == 1
-                        && scans1[0].atom == scans2[0].atom
-                        && scans2[0].cs.is_empty())
-                    {
-                        return false;
-                    }
-                    (*var1, mem::take(scans1))
-                } else {
-                    return false;
+                assert!(!*is_leaf_scan1 && !is_leaf_scan2);
+                let to_index = SubAtom {
+                    atom: cover1.to_index.atom,
+                    vars: cover1
+                        .to_index
+                        .vars
+                        .iter()
+                        .chain(cover2.to_index.vars.iter())
+                        .copied()
+                        .collect(),
                 };
-                let atom = scans1[0].atom;
-                let col1 = scans1[0].column;
-                let col2 = scans2[0].column;
-                *x = FusedIntersect {
+                let bind = bind1.iter().chain(bind2.iter()).copied().collect();
+                *self = FusedIntersect {
                     cover: ScanSpec {
-                        to_index: SubAtom {
-                            atom,
-                            vars: smallvec![col1, col2],
-                        },
-                        constraints: mem::take(&mut scans1[0].cs),
+                        to_index,
+                        constraints: cover1
+                            .constraints
+                            .iter()
+                            .chain(cover2.constraints.iter())
+                            .cloned()
+                            .collect(),
                     },
-                    bind: smallvec![(col1, var1), (col2, *var2)],
+                    bind,
                     to_intersect: Default::default(),
+                    is_leaf_scan: false,
                 };
                 true
             }
+            // (
+            //     FusedIntersect {
+            //         cover,
+            //         bind,
+            //         to_intersect,
+            //         is_leaf_scan: _,
+            //     },
+            //     Intersect { var, scans },
+            // ) if to_intersect.is_empty()
+            //     && scans.len() == 1
+            //     && cover.to_index.atom == scans[0].atom
+            //     && scans[0].cs.is_empty() =>
+            // {
+            //     let col = scans[0].column;
+            //     bind.push((col, *var));
+            //     cover.to_index.vars.push(col);
+            //     true
+            // }
+            // (
+            //     x,
+            //     Intersect {
+            //         var: var2,
+            //         scans: scans2,
+            //     },
+            // ) => {
+            //     // This is all somewhat mangled because of the borrowing rules
+            //     // when we pass &mut self into a tuple.
+            //     let (var1, mut scans1) = if let Intersect {
+            //         var: var1,
+            //         scans: scans1,
+            //     } = x
+            //     {
+            //         if !(scans1.len() == 1
+            //             && scans2.len() == 1
+            //             && scans1[0].atom == scans2[0].atom
+            //             && scans2[0].cs.is_empty())
+            //         {
+            //             return false;
+            //         }
+            //         (*var1, mem::take(scans1))
+            //     } else {
+            //         return false;
+            //     };
+            //     let atom = scans1[0].atom;
+            //     let col1 = scans1[0].column;
+            //     let col2 = scans2[0].column;
+            //     *x = FusedIntersect {
+            //         cover: ScanSpec {
+            //             to_index: SubAtom {
+            //                 atom,
+            //                 vars: smallvec![col1, col2],
+            //             },
+            //             constraints: mem::take(&mut scans1[0].cs),
+            //         },
+            //         bind: smallvec![(col1, var1), (col2, *var2)],
+            //         to_intersect: Default::default(),
+            //     };
+            //     true
+            // }
             _ => false,
         }
     }
@@ -352,6 +400,7 @@ impl SinglePlan {
                     cover,
                     bind: _,
                     to_intersect,
+                    is_leaf_scan: _,
                 } => {
                     let cover_atom_name = get_atom(cover.to_index.atom);
                     let cover_cols: Vec<(String, i64)> = cover
@@ -1523,6 +1572,39 @@ fn plan_gj(
         }
         stages.push(next_stage);
     }
+    for i in 0..stages.len() {
+        if let JoinStage::FusedIntersect {
+            cover,
+            to_intersect,
+            ..
+        } = &stages[i]
+            && to_intersect.is_empty()
+        {
+            let cover_atom = cover.to_index.atom;
+            let mut used_later = false;
+            for j in (i + 1)..stages.len() {
+                used_later = used_later
+                    || match &stages[j] {
+                        JoinStage::Intersect { scans, .. } => {
+                            scans.iter().any(|scan| scan.atom == cover_atom)
+                        }
+                        JoinStage::FusedIntersect { cover, .. } => {
+                            cover.to_index.atom == cover_atom
+                        }
+                        JoinStage::FusedIntersectMat { .. } => unreachable!(),
+                    };
+                if used_later {
+                    break;
+                }
+            }
+            if !used_later {
+                let JoinStage::FusedIntersect { is_leaf_scan, .. } = &mut stages[i] else {
+                    unreachable!();
+                };
+                *is_leaf_scan = true;
+            }
+        }
+    }
 }
 
 /// Compile a stage info into a concrete join stage, updating constraint state.
@@ -1548,7 +1630,8 @@ fn compile_stage(
         }
     }
 
-    if vars.len() == 1 {
+    // Only do this if it's a join of more than one relations
+    if vars.len() == 1 && !filters.is_empty() {
         let scans = SmallVec::<[SingleScanSpec; 3]>::from_iter(
             iter::once(&cover)
                 .chain(filters.iter().map(|(x, _)| x))
@@ -1595,5 +1678,6 @@ fn compile_stage(
         cover: cover_spec,
         bind,
         to_intersect,
+        is_leaf_scan: false,
     }
 }

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -951,6 +951,13 @@ fn plan_single_bag(
     let (header, mut instrs) = plan_stages(&stripped_bag, strat);
     instrs.splice(0..0, prologue);
     instrs.extend(epilogue);
+    // `plan_gj` decides `is_leaf_scan` based only on the stages it produces, so it cannot
+    // see the prologue/epilogue stages we just spliced in. A leaf scan factorizes its
+    // bound variables into `binding_info.binding_sets` rather than `binding_info.bindings`,
+    // which breaks any later `FusedIntersectMat::Value`/`Lookup` that reads those variables
+    // directly from `bindings`. Downgrade bad leaf scans now that the full instruction
+    // sequence is known.
+    revert_bad_leaf_scans(&mut instrs);
 
     let stages = JoinStages {
         instrs: Arc::new(instrs),
@@ -1043,6 +1050,68 @@ fn fuse_last_stage(
     last_block.instrs = Arc::new(instrs);
 
     (blocks, last_block)
+}
+
+/// Downgrade any `FusedIntersect { is_leaf_scan: true, .. }` whose factorized bindings
+/// would be observed as missing by a later stage.
+///
+/// `is_leaf_scan` instructs the executor to factorize the stage's bindings into
+/// `BindingInfo::binding_sets` instead of materializing them into `BindingInfo::bindings`.
+/// That is OK only if no subsequent stage in the same `JoinStages` reads any of those
+/// variables as a scalar value from `bindings`. The only stages that do so are
+/// `FusedIntersectMat::Value` / `Lookup`, whose `index_vars` are looked up directly.
+///
+/// `plan_gj` performs its own (cover-atom-based) check, but that runs before prologue /
+/// epilogue stages are spliced into the instruction list, so it cannot detect
+/// `FusedIntersectMat` lookups that come from the epilogue. This pass closes that gap.
+///
+/// # Example
+///
+/// Suppose `plan_gj` produces the following two stages for a bag, where stage 0 is
+/// the last `FusedIntersect` and binds variable `y` from atom `A` via a leaf scan
+/// (no atom later in `plan_gj`'s output reuses `A`):
+///
+/// ```text
+///   stage 0: FusedIntersect { cover: A, bind: [(col, y)], is_leaf_scan: true, ... }
+/// ```
+///
+/// `plan_single_bag` then splices an epilogue that looks up an earlier block's
+/// materialization keyed on `y`:
+///
+/// ```text
+///   stage 0: FusedIntersect { cover: A, bind: [(col, y)], is_leaf_scan: true, ... }
+///   stage 1: FusedIntersectMat { mode: Lookup([y]), ... }
+/// ```
+///
+/// With `is_leaf_scan: true`, stage 0 puts `y` into `binding_sets` instead of
+/// `bindings`. Stage 1 then tries `binding_info.bindings[y]` and panics on a missing
+/// entry. This pass detects the overlap (`y ∈ bound_vars ∩ Lookup`'s index_vars) and
+/// flips stage 0's `is_leaf_scan` back to `false`.
+fn revert_bad_leaf_scans(stages: &mut [JoinStage]) {
+    for i in 0..stages.len() {
+        let bound_vars: SmallVec<[Variable; 4]> = match &stages[i] {
+            JoinStage::FusedIntersect {
+                bind,
+                is_leaf_scan: true,
+                ..
+            } => bind.iter().map(|(_, v)| *v).collect(),
+            _ => continue,
+        };
+
+        let needs_scalar = ((i + 1)..stages.len()).any(|j| match &stages[j] {
+            JoinStage::FusedIntersectMat {
+                mode: MatScanMode::Value(vars) | MatScanMode::Lookup(vars),
+                ..
+            } => vars.iter().any(|v| bound_vars.contains(v)),
+            _ => false,
+        });
+
+        if needs_scalar
+            && let JoinStage::FusedIntersect { is_leaf_scan, .. } = &mut stages[i]
+        {
+            *is_leaf_scan = false;
+        }
+    }
 }
 
 /// Eagerly lift materialization lookups up

--- a/tests/snapshots/files__shared_snapshot_eggcc_2mm.snap
+++ b/tests/snapshots/files__shared_snapshot_eggcc_2mm.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/files.rs
-assertion_line: 97
 expression: snapshot_content_across_treatments
 ---
 ((Abs 1)
@@ -186,7 +185,7 @@ expression: snapshot_content_across_treatments
  (Shl 1)
  (Shr 1)
  (Single 957)
- (Smaller 1826)
+ (Smaller 1804)
  (Smax 1)
  (Smin 1)
  (StateT 1)
@@ -196,7 +195,7 @@ expression: snapshot_content_across_treatments
  (SuffixAt-List<PtrPointees> 0)
  (SuffixAt-List<i64+IntInterval> 0)
  (Switch 0)
- (TCPair 2744)
+ (TCPair 2743)
  (TCons 318)
  (TLConcat 1649)
  (TNil 1)
@@ -204,7 +203,7 @@ expression: snapshot_content_across_treatments
  (TermArg 1)
  (TermBop 134)
  (TermCall 0)
- (TermConcat 1907)
+ (TermConcat 1906)
  (TermCons 0)
  (TermConst 22)
  (TermEmpty 0)


### PR DESCRIPTION
For benchmarks like cykjson, the join has the following patterns

```
R(a, b) x S(b, c)
```

where for the same b, there are many `a`s and `c`s. The existing join implementation is not efficient because it will call run_plan on the cartesian product of `a ' and `c`, which can waste time in index building and create quadratically many Arc<Trie>.

I think with this optimization we may be able to revert several other optimizations, or they may not be as important, such as #840 and some ugly ones in #852 or #855 .