### PR TITLE
add shared_arena module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,10 +115,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.9.4"
+name = "bit-set"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitmaps"
@@ -564,8 +579,10 @@ name = "egglog-concurrency"
 version = "2.0.0"
 dependencies = [
  "arc-swap",
+ "bumpalo",
  "codspeed-divan-compat",
  "egglog-numeric-id",
+ "proptest",
  "rayon",
  "smallvec",
 ]
@@ -729,6 +746,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1301,6 +1324,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1460,6 +1517,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1736,6 +1805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,6 +1838,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/concurrency/Cargo.toml
+++ b/concurrency/Cargo.toml
@@ -10,12 +10,14 @@ readme = { workspace = true }
 
 [dependencies]
 arc-swap = { workspace = true}
+bumpalo = { workspace = true}
 rayon = { workspace = true}
 egglog-numeric-id = { workspace = true }
 smallvec = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true}
+proptest = "1"
 rayon = { workspace = true}
 
 [[bench]]

--- a/concurrency/src/lib.rs
+++ b/concurrency/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) mod notification;
 pub(crate) mod notification_list;
 pub mod parallel_writer;
 pub(crate) mod resettable_oncelock;
+mod shared_arena;
 use arc_swap::{ArcSwap, Guard};
 
 pub use bitset::BitSet;
@@ -14,6 +15,7 @@ pub use notification::Notification;
 pub use notification_list::NotificationList;
 pub use parallel_writer::ParallelVecWriter;
 pub use resettable_oncelock::ResettableOnceLock;
+pub use shared_arena::{Handle, SharedArena, SharedRef};
 
 #[cfg(test)]
 mod tests;

--- a/concurrency/src/shared_arena.rs
+++ b/concurrency/src/shared_arena.rs
@@ -1,0 +1,298 @@
+//! Scoped thread-safe arena allocation.
+//!
+//! This module provides [`SharedArena`], a bump-allocation arena that can be
+//! shared by reference across scoped worker threads. Each worker creates a
+//! non-`Send`, non-`Sync` [`Handle`] and performs unsynchronized allocations
+//! into that handle's private local arena. Allocated values are exposed through
+//! [`SharedRef`], an immutable reference-like handle whose lifetime is tied to
+//! the borrowed [`SharedArena`].
+//!
+//! The arena owns all allocated values and runs destructors when the
+//! [`SharedArena`] is dropped. Since the arena itself is `Send`, values must be
+//! `Send` when they are allocated: the arena may be dropped on a different
+//! thread from the one that performed the allocation.
+
+use std::{
+    cell::RefCell, marker::PhantomData, mem, ops::Deref, pin::Pin, ptr::NonNull, rc::Rc,
+    sync::Mutex,
+};
+
+use bumpalo::Bump;
+
+/// A thread-safe scoped arena for bump-allocating shared immutable references.
+///
+/// `SharedArena` is designed for scoped parallelism: share `&SharedArena` with
+/// worker tasks, create one [`Handle`] inside each task, and allocate through
+/// that handle. Handles are deliberately not `Send` or `Sync`, so allocation
+/// from a single local arena stays thread-local.
+///
+/// Values allocated in the arena remain valid until the arena is dropped. For
+/// types with destructors, drops run when the arena is dropped. Drop order is
+/// last-in, first-out within a single handle's local arena; order across
+/// handles is unspecified.
+///
+/// # Examples
+///
+/// Sharing an arena by reference across a Rayon scope:
+///
+/// ```
+/// use egglog_concurrency::SharedArena;
+///
+/// let arena = SharedArena::new();
+/// let mut values = Vec::new();
+///
+/// rayon::scope(|scope| {
+///     let (left, right) = (&arena, &arena);
+///     scope.spawn(move |_| {
+///         let handle = left.new_handle();
+///         assert_eq!(*handle.alloc(1), 1);
+///     });
+///     scope.spawn(move |_| {
+///         let handle = right.new_handle();
+///         assert_eq!(*handle.alloc(2), 2);
+///     });
+/// });
+///
+/// let handle = arena.new_handle();
+/// values.push(handle.alloc(3));
+/// assert_eq!(*values[0], 3);
+/// ```
+///
+/// Allocated references may outlive the handle that created them:
+///
+/// ```
+/// use egglog_concurrency::SharedArena;
+///
+/// let arena = SharedArena::new();
+/// let value;
+/// {
+///     let handle = arena.new_handle();
+///     value = handle.alloc(String::from("scoped"));
+/// }
+///
+/// assert_eq!(value.as_str(), "scoped");
+/// ```
+pub struct SharedArena {
+    locals: Mutex<Vec<Pin<Box<LocalArena>>>>,
+}
+
+impl Default for SharedArena {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SharedArena {
+    /// Create an empty arena.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use egglog_concurrency::SharedArena;
+    ///
+    /// let arena = SharedArena::new();
+    /// let handle = arena.new_handle();
+    /// assert_eq!(*handle.alloc(10), 10);
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            locals: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Create a thread-local allocation handle for this arena.
+    ///
+    /// Handles are cheap to allocate and are intended to be created inside the
+    /// scoped thread that will use them. A handle cannot be sent to another
+    /// thread, but [`SharedRef`] values allocated by the handle can be shared
+    /// when their payload type is `Sync`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use egglog_concurrency::SharedArena;
+    ///
+    /// let arena = SharedArena::new();
+    /// std::thread::scope(|scope| {
+    ///     let arena = &arena;
+    ///     scope.spawn(move || {
+    ///         let handle = arena.new_handle();
+    ///         assert_eq!(*handle.alloc(99), 99);
+    ///     });
+    /// });
+    /// ```
+    ///
+    /// Handles intentionally do not implement `Send`:
+    ///
+    /// ```compile_fail
+    /// use egglog_concurrency::SharedArena;
+    ///
+    /// fn assert_send<T: Send>(_: T) {}
+    ///
+    /// let arena = SharedArena::new();
+    /// let handle = arena.new_handle();
+    /// assert_send(handle);
+    /// ```
+    pub fn new_handle(&self) -> Handle<'_> {
+        let mut locals = self.locals.lock().unwrap();
+        locals.push(Box::pin(LocalArena::new()));
+        let local = NonNull::from(locals.last().unwrap().as_ref().get_ref());
+        Handle {
+            local,
+            _arena: PhantomData,
+            _not_send_sync: PhantomData,
+        }
+    }
+}
+
+/// A thread-local handle for allocating values in a [`SharedArena`].
+///
+/// `Handle` values borrow their parent arena and cannot be sent or shared
+/// across threads. Create a separate handle in each scoped worker that needs to
+/// allocate.
+pub struct Handle<'arena> {
+    local: NonNull<LocalArena>,
+    _arena: PhantomData<&'arena SharedArena>,
+    _not_send_sync: PhantomData<Rc<()>>,
+}
+
+impl<'arena> Handle<'arena> {
+    /// Allocate `value` in the parent [`SharedArena`].
+    ///
+    /// The returned [`SharedRef`] remains valid until the arena is dropped.
+    /// `T` must be `Send` because the arena may be moved to and dropped on a
+    /// different thread from the allocating handle.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use egglog_concurrency::SharedArena;
+    ///
+    /// let arena = SharedArena::new();
+    /// let handle = arena.new_handle();
+    /// let value = handle.alloc(vec![1, 2, 3]);
+    ///
+    /// assert_eq!(value.as_slice(), &[1, 2, 3]);
+    /// ```
+    pub fn alloc<T>(&self, value: T) -> SharedRef<'arena, T>
+    where
+        T: Send + 'arena,
+    {
+        // SAFETY: `self.local` points to a boxed `LocalArena` stored in the
+        // parent `SharedArena`. Boxes are never removed from that vector before
+        // the `SharedArena` is dropped, and this handle's lifetime prevents the
+        // arena from being dropped while the handle is alive.
+        let local = unsafe { self.local.as_ref() };
+        SharedRef {
+            ptr: local.alloc(value),
+            _lifetime: PhantomData,
+        }
+    }
+}
+
+/// An immutable reference to a value allocated in a [`SharedArena`].
+///
+/// `SharedRef` is copyable and dereferences to `T`. It implements `Send` and
+/// `Sync` when `T: Sync`, matching the sharing behavior of `&T`.
+///
+/// # Examples
+///
+/// ```
+/// use egglog_concurrency::{SharedArena, SharedRef};
+///
+/// let arena = SharedArena::new();
+/// let handle = arena.new_handle();
+/// let value: SharedRef<'_, usize> = handle.alloc(5);
+///
+/// assert_eq!(*value, 5);
+/// assert_eq!(*value, *value.clone());
+/// ```
+pub struct SharedRef<'arena, T> {
+    ptr: NonNull<T>,
+    _lifetime: PhantomData<&'arena T>,
+}
+
+impl<T> Copy for SharedRef<'_, T> {}
+
+impl<T> Clone for SharedRef<'_, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Deref for SharedRef<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: `ptr` is created from a valid bump allocation and the
+        // `SharedRef` lifetime is tied to the parent arena. The API never
+        // exposes mutable references to allocated values after allocation.
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+unsafe impl<T: Sync> Send for SharedRef<'_, T> {}
+unsafe impl<T: Sync> Sync for SharedRef<'_, T> {}
+
+struct LocalArena {
+    bump: Bump,
+    drops: RefCell<Vec<DropEntry>>,
+}
+
+// SAFETY: `LocalArena` is stored behind a `SharedArena` mutex and only exposed
+// to a single non-`Send`, non-`Sync` `Handle` for allocation. It may be dropped
+// on another thread when its parent `SharedArena` is moved, but `Handle::alloc`
+// requires allocated values to be `Send`, so running destructors on that thread
+// is sound.
+unsafe impl Send for LocalArena {}
+
+impl LocalArena {
+    fn new() -> Self {
+        Self {
+            bump: Bump::new(),
+            drops: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn alloc<T>(&self, value: T) -> NonNull<T>
+    where
+        T: Send,
+    {
+        let value = self.bump.alloc(value);
+        let ptr = NonNull::from(value);
+
+        if mem::needs_drop::<T>() {
+            self.drops.borrow_mut().push(DropEntry {
+                ptr: ptr.cast(),
+                drop: drop_value::<T>,
+            });
+        }
+
+        ptr
+    }
+}
+
+impl Drop for LocalArena {
+    fn drop(&mut self) {
+        for entry in self.drops.get_mut().iter().rev() {
+            // SAFETY: Every drop entry is registered immediately after a
+            // successful allocation of a value of the corresponding type. This
+            // is the only place where registered destructors are run.
+            unsafe {
+                (entry.drop)(entry.ptr.as_ptr());
+            }
+        }
+    }
+}
+
+struct DropEntry {
+    ptr: NonNull<()>,
+    drop: unsafe fn(*mut ()),
+}
+
+unsafe fn drop_value<T>(ptr: *mut ()) {
+    // SAFETY: `ptr` was recorded from a live `T` allocation in `LocalArena::alloc`.
+    unsafe {
+        ptr.cast::<T>().drop_in_place();
+    }
+}

--- a/concurrency/src/tests.rs
+++ b/concurrency/src/tests.rs
@@ -1,18 +1,20 @@
 use std::{
+    cell::Cell,
     mem,
     sync::{
-        Arc, Barrier,
+        Arc, Barrier, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
     thread::{self, sleep},
     time::Duration,
 };
 
+use proptest::prelude::*;
 use smallvec::SmallVec;
 
 use crate::{
-    ConcurrentVec, Notification, NotificationList, ParallelVecWriter, ReadOptimizedLock,
-    ResettableOnceLock,
+    BitSet, ConcurrentVec, Notification, NotificationList, ParallelVecWriter, ReadOptimizedLock,
+    ResettableOnceLock, SharedArena, SharedRef, parallel_writer::write_cell_slice,
 };
 
 #[test]
@@ -57,6 +59,23 @@ fn notification_times_out() {
     for t in threads {
         t.join().unwrap();
     }
+}
+
+#[test]
+fn notification_timeout_observes_notification() {
+    let n = Notification::default();
+    n.notify();
+    assert!(n.wait_with_timeout(Duration::from_millis(1)));
+
+    let n = Arc::new(Notification::default());
+    let n_inner = n.clone();
+    let notifier = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(1));
+        n_inner.notify();
+    });
+
+    assert!(n.wait_with_timeout(Duration::from_secs(1)));
+    notifier.join().unwrap();
 }
 
 #[test]
@@ -155,6 +174,56 @@ fn simple_mutex() {
 }
 
 #[test]
+fn read_optimized_lock_convenience_methods() {
+    let mut lock = ReadOptimizedLock::<Vec<usize>>::default();
+    lock.as_mut_ref().extend([1, 2, 3]);
+    assert_eq!(lock.into_inner(), vec![1, 2, 3]);
+}
+
+#[test]
+fn read_optimized_lock_waits_for_ongoing_writer() {
+    let lock = Arc::new(ReadOptimizedLock::new(0usize));
+    let writer = lock.lock();
+    let attempted = Arc::new(Notification::new());
+    let acquired = Arc::new(Notification::new());
+
+    let lock_inner = lock.clone();
+    let attempted_inner = attempted.clone();
+    let acquired_inner = acquired.clone();
+    let waiter = thread::spawn(move || {
+        attempted_inner.notify();
+        let mut guard = lock_inner.lock();
+        *guard = 1;
+        acquired_inner.notify();
+    });
+
+    attempted.wait();
+    sleep(Duration::from_millis(1));
+    assert!(!acquired.has_been_notified());
+    mem::drop(writer);
+    acquired.wait();
+    waiter.join().unwrap();
+    assert_eq!(*lock.read(), 1);
+}
+
+#[test]
+fn bitset_get_set_resize_and_clear() {
+    let bits = BitSet::with_capacity(0);
+    assert!(!bits.get(5));
+    assert!(!bits.get(130));
+
+    bits.set(5, true);
+    bits.set(130, true);
+    assert!(bits.get(5));
+    assert!(bits.get(130));
+    assert!(!bits.get(6));
+
+    bits.set(5, false);
+    assert!(!bits.get(5));
+    assert!(bits.get(130));
+}
+
+#[test]
 fn basic_parallel_vec_push() {
     const N_THREADS: usize = 10;
     const PER_THREAD: usize = 10;
@@ -189,6 +258,26 @@ fn basic_parallel_vec_push() {
         results,
         (0..(N_THREADS * PER_THREAD)).collect::<Vec<usize>>()
     );
+}
+
+#[test]
+fn concurrent_vec_drops_initialized_values() {
+    struct DropCounter(Arc<AtomicUsize>);
+
+    impl Drop for DropCounter {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let drops = Arc::new(AtomicUsize::new(0));
+    {
+        let v = ConcurrentVec::with_capacity(0);
+        v.push(DropCounter(drops.clone()));
+        v.push(DropCounter(drops.clone()));
+    }
+
+    assert_eq!(drops.load(Ordering::SeqCst), 2);
 }
 
 #[test]
@@ -327,6 +416,76 @@ fn basic_parallel_vec_write_slice() {
     let mut v = Arc::try_unwrap(v).ok().unwrap().finish();
     v.sort();
     assert_eq!(v, (0..200).collect::<Vec<usize>>());
+}
+
+#[test]
+fn parallel_vec_writer_unsafe_read_access_reads_written_ranges() {
+    let v = ParallelVecWriter::new(vec![1, 2]);
+    let start = v.write_contents([3, 4].into_iter());
+    let access = v.unsafe_read_access();
+
+    // SAFETY: indices 0..2 were initialized in the input vector, and
+    // `start..start + 2` was initialized by the completed write above.
+    unsafe {
+        assert_eq!(*access.get_unchecked(0), 1);
+        assert_eq!(access.get_unchecked_slice(start..start + 2), &[3, 4]);
+    }
+
+    assert_eq!(v.finish(), vec![1, 2, 3, 4]);
+}
+
+#[test]
+fn parallel_vec_writer_take_resets_writer() {
+    let mut v = ParallelVecWriter::new(vec![1]);
+    v.write_contents([2, 3].into_iter());
+    assert_eq!(v.take(), vec![1, 2, 3]);
+
+    v.write_contents([4].into_iter());
+    assert_eq!(v.finish(), vec![4]);
+}
+
+#[test]
+fn parallel_vec_writer_writes_cell_slices() {
+    let v = ParallelVecWriter::new(vec![Cell::new(1)]);
+    let start = write_cell_slice(&v, &[Cell::new(2), Cell::new(3)]);
+    assert_eq!(start, 1);
+
+    let values = v
+        .finish()
+        .into_iter()
+        .map(|cell| cell.get())
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![1, 2, 3]);
+}
+
+#[test]
+#[should_panic(expected = "passed ExactSizeIterator with incorrect number of items")]
+fn parallel_vec_writer_panics_on_incorrect_exact_size_iterator() {
+    struct BadExactSizeIterator {
+        yielded: bool,
+    }
+
+    impl Iterator for BadExactSizeIterator {
+        type Item = usize;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.yielded {
+                None
+            } else {
+                self.yielded = true;
+                Some(1)
+            }
+        }
+    }
+
+    impl ExactSizeIterator for BadExactSizeIterator {
+        fn len(&self) -> usize {
+            2
+        }
+    }
+
+    let v = ParallelVecWriter::new(Vec::new());
+    v.write_contents(BadExactSizeIterator { yielded: false });
 }
 
 #[test]
@@ -476,4 +635,154 @@ fn resettable_once_lock_send_sync() {
 
     let result = handle.join().unwrap();
     assert_eq!(result, 43);
+}
+
+#[test]
+fn shared_arena_refs_outlive_handles() {
+    let arena = SharedArena::new();
+    let value;
+    let text;
+
+    {
+        let handle = arena.new_handle();
+        value = handle.alloc(42usize);
+        text = handle.alloc(String::from("arena allocated"));
+        assert_eq!(*value, 42);
+        assert_eq!(text.as_str(), "arena allocated");
+    }
+
+    assert_eq!(*value, 42);
+    assert_eq!(text.as_str(), "arena allocated");
+}
+
+#[test]
+fn shared_arena_allocates_from_scoped_threads() {
+    const N_THREADS: usize = 8;
+    const PER_THREAD: usize = 64;
+
+    let arena = SharedArena::new();
+    let refs = Mutex::new(Vec::new());
+
+    thread::scope(|scope| {
+        for thread_id in 0..N_THREADS {
+            let arena = &arena;
+            let refs = &refs;
+            scope.spawn(move || {
+                let handle = arena.new_handle();
+                for offset in 0..PER_THREAD {
+                    refs.lock()
+                        .unwrap()
+                        .push(handle.alloc(thread_id * PER_THREAD + offset));
+                }
+            });
+        }
+    });
+
+    let mut values = refs
+        .into_inner()
+        .unwrap()
+        .into_iter()
+        .map(|value| *value)
+        .collect::<Vec<_>>();
+    values.sort_unstable();
+    assert_eq!(values, (0..N_THREADS * PER_THREAD).collect::<Vec<_>>());
+}
+
+#[test]
+fn shared_arena_drops_values_lifo_within_a_handle() {
+    #[derive(Debug)]
+    struct DropRecorder {
+        value: usize,
+        drops: Arc<Mutex<Vec<usize>>>,
+    }
+
+    impl Drop for DropRecorder {
+        fn drop(&mut self) {
+            self.drops.lock().unwrap().push(self.value);
+        }
+    }
+
+    let drops = Arc::new(Mutex::new(Vec::new()));
+    {
+        let arena = SharedArena::new();
+        let handle = arena.new_handle();
+        for value in 0..4 {
+            handle.alloc(DropRecorder {
+                value,
+                drops: drops.clone(),
+            });
+        }
+        assert!(drops.lock().unwrap().is_empty());
+    }
+
+    assert_eq!(*drops.lock().unwrap(), vec![3, 2, 1, 0]);
+}
+
+#[test]
+fn shared_arena_send_sync_bounds() {
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    assert_send_sync::<SharedArena>();
+    assert_send_sync::<SharedRef<'static, usize>>();
+}
+
+#[test]
+fn shared_arena_default_and_clone_ref() {
+    fn clone_through_trait<T: Clone>(value: &T) -> T {
+        value.clone()
+    }
+
+    let arena = SharedArena::default();
+    let handle = arena.new_handle();
+    let value = handle.alloc(11usize);
+    let cloned = clone_through_trait(&value);
+
+    assert_eq!(*cloned, 11);
+}
+
+proptest! {
+    #[test]
+    fn shared_arena_alloc_preserves_values(values in proptest::collection::vec(any::<i64>(), 0..256)) {
+        let arena = SharedArena::new();
+        let handle = arena.new_handle();
+        let refs = values
+            .iter()
+            .copied()
+            .map(|value| handle.alloc(value))
+            .collect::<Vec<_>>();
+        let got = refs.iter().map(|value| **value).collect::<Vec<_>>();
+
+        prop_assert_eq!(got, values);
+    }
+
+    #[test]
+    fn shared_arena_drops_every_registered_value(values in proptest::collection::vec(0usize..1024, 0..128)) {
+        #[derive(Debug)]
+        struct DropRecorder {
+            value: usize,
+            drops: Arc<Mutex<Vec<usize>>>,
+        }
+
+        impl Drop for DropRecorder {
+            fn drop(&mut self) {
+                self.drops.lock().unwrap().push(self.value);
+            }
+        }
+
+        let drops = Arc::new(Mutex::new(Vec::new()));
+        {
+            let arena = SharedArena::new();
+            let handle = arena.new_handle();
+            for &value in &values {
+                handle.alloc(DropRecorder {
+                    value,
+                    drops: drops.clone(),
+                });
+            }
+        }
+
+        let expected = values.into_iter().rev().collect::<Vec<_>>();
+        let got = drops.lock().unwrap();
+        prop_assert_eq!(got.as_slice(), expected.as_slice());
+    }
 }


### PR DESCRIPTION
We may want to use an abstraction like this in query execution to cut down on `Arc` allocations.