### PR TITLE
Return simplified proofs

### DIFF
--- a/src/proofs/proof_extraction.rs
+++ b/src/proofs/proof_extraction.rs
@@ -140,6 +140,6 @@ impl ProofInstrumentor<'_> {
             .check_proof(simplified_proof, &self.egraph.proof_check_program)
             .expect("simplified existence proof should still be valid");
 
-        Ok((proof_store, extra_rule_removed))
+        Ok((proof_store, simplified_proof))
     }
 }

--- a/tests/snapshots/files__shared_snapshot_commute_collapse.snap
+++ b/tests/snapshots/files__shared_snapshot_commute_collapse.snap
@@ -2,28 +2,23 @@
 source: tests/files.rs
 expression: snapshot_content_across_treatments
 ---
-(let prop0 (= (Add 2 3) (Num 5)))
-(let prf0 (Fiat (= (Add 2 3) (Add 2 3))))
-(let prf1
+(let prf0
   (Sym
-        (= (Add 2 3) (Add 3 2))
-        (Rule
-          (= (Add 3 2) (Add 2 3))
-          (name "rw1")
-          (premises prf0)
-          (substitution (a 2) (b 3)))))
-(Trans
-  prop0
-  prf0
-  (Trans
-    prop0
-    prf1
-    (Sym
-      (= (Add 3 2) (Num 5))
+      (= (Add 2 3) (Add 3 2))
       (Rule
-        (= (Num 5) (Add 3 2))
-        (name "rw2")
-        (premises prf1 (Fiat (= () ())))
-        (substitution (a 3) (b 2))))))
+        (= (Add 3 2) (Add 2 3))
+        (name "rw1")
+        (premises (Fiat (= (Add 2 3) (Add 2 3))))
+        (substitution (a 2) (b 3)))))
+(Trans
+  (= (Add 2 3) (Num 5))
+  prf0
+  (Sym
+    (= (Add 3 2) (Num 5))
+    (Rule
+      (= (Num 5) (Add 3 2))
+      (name "rw2")
+      (premises prf0 (Fiat (= () ())))
+      (substitution (a 3) (b 2)))))
 ((Add 2)
  (Num 1))

--- a/tests/snapshots/files__shared_snapshot_primitive_args.snap
+++ b/tests/snapshots/files__shared_snapshot_primitive_args.snap
@@ -2,31 +2,16 @@
 source: tests/files.rs
 expression: snapshot_content_across_treatments
 ---
-(let t0 (Add (Const 5) (Const 1)))
-(let t1 (MathU t0))
-(let prop0 (= t1 t1))
-(let t2 (premises (Fiat (= (MathU (Const 5)) (MathU (Const 5)))) (Fiat (= () ()))))
-(Congr
-  prop0
-  (Rule
-    prop0
-    (name
-      "(rule ((MathU (Const a))
+(let t0 (MathU (Add (Const 5) (Const 1))))
+(Rule
+  (= t0 t0)
+  (name
+    "(rule ((MathU (Const a))
        (> (+ a 1) 5))
       ((MathU (Add (Const a) (Const 1))))
          )")
-    t2
-    (substitution (a 5)))
-  (Rule
-    (= t0 t0)
-    (name
-      "(rule ((MathU (Const a))
-       (> (+ a 1) 5))
-      ((MathU (Add (Const a) (Const 1))))
-         )")
-    t2
-    (substitution (a 5)))
-  0)
+  (premises (Fiat (= (MathU (Const 5)) (MathU (Const 5)))) (Fiat (= () ())))
+  (substitution (a 5)))
 ((Add 1)
  (Const 2)
  (MathU 2)


### PR DESCRIPTION
I believe there is a bug currently where it simplifies the proof and checks that simplification but still returns the un simplified version.

This fixes it and updates the snapshots which should now show the simplified version.