### PR TITLE
Clean up ExecutionState Refactor PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,7 @@ dependencies = [
  "egglog-numeric-id",
  "egglog-reports",
  "egraph-serialize",
+ "enum-map",
  "env_logger",
  "glob",
  "hashbrown 0.16.0",
@@ -683,6 +684,26 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "env_filter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rustc-hash = "2.1"
 thiserror = "2.0"
 web-time = "1.1"
 dyn-clone = "1.0.17"
+enum-map = "2.7"
 rayon = "1.10.0"
 mimalloc = "0.1"
 quote = "1.0"
@@ -144,6 +145,7 @@ rustc-hash = { workspace = true }
 thiserror = { workspace = true }
 web-time = { workspace = true }
 dyn-clone = { workspace = true }
+enum-map = { workspace = true }
 mimalloc = { workspace = true, optional = true }
 csv = { workspace = true }
 egglog-core-relations = { workspace = true }

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -948,13 +948,12 @@ fn get_atom_application_constraints(
 
     // primitive atom constraints
     if let Some(primitives) = type_info.get_prims(head) {
-        // Each `add_*_primitive` call commits one registration per
-        // context the trait permits, with disjoint `selection_ctx`
-        // values. For a given (name, signature, ctx) tuple at most
-        // one variant survives this filter and the XOR resolves
-        // cleanly.
+        // Each primitive definition records the runtime contexts its
+        // trait permits. For a given (name, signature, ctx) tuple at
+        // most one definition should survive this filter and the XOR
+        // resolves cleanly.
         for p in primitives {
-            if p.selection_ctx != ctx {
+            if p.context_ids[ctx].is_none() {
                 continue;
             }
             let constraints = p.primitive.get_type_constraints(span).get(args, type_info);

--- a/src/core.rs
+++ b/src/core.rs
@@ -160,40 +160,23 @@ impl ResolvedCall {
             }
         }
 
-        // For a given (signature, context) pair, exactly one primitive
-        // definition must match. Each definition carries the runtime ids
-        // for the contexts it permits. If two definitions accept the
-        // same signature in the same context, registration was
-        // ambiguous (e.g. the same primitive added twice); panic here
-        // rather than silently picking one.
-        if let Some(primitives) = typeinfo.get_prims(head) {
-            let matches: Vec<_> = primitives
-                .iter()
-                .filter(|p| p.context_ids[ctx].is_some() && p.accept(types, typeinfo))
-                .collect();
-            match matches.as_slice() {
-                [] => {}
-                [picked] => {
-                    let (out, inp) = types.split_last().unwrap();
-                    return ResolvedCall::Primitive(SpecializedPrimitive {
-                        prim_with_id: (*picked).clone(),
-                        input: inp.to_vec(),
-                        output: out.clone(),
-                    });
-                }
-                multiple => {
-                    let sig: Vec<_> = types.iter().map(|s| s.name().to_string()).collect();
-                    panic!(
-                        "Ambiguous primitive resolution for {head:?} in context {ctx:?} \
-                         with signature [{}]: {} registrations accept this call. \
-                         Each (name, signature, context) tuple must map to a unique \
-                         primitive — was {head:?} registered more than once with the \
-                         same type?",
-                        sig.join(", "),
-                        multiple.len(),
-                    );
-                }
+        let mut primitives = typeinfo
+            .get_prims(head)
+            .into_iter()
+            .flatten()
+            .filter(|p| p.context_ids[ctx].is_some() && p.accept(types, typeinfo));
+        if let Some(picked) = primitives.next() {
+            if primitives.next().is_some() {
+                panic!(
+                    "Ambiguous primitive resolution for {head:?} in direct call context {ctx:?}"
+                );
             }
+            let (out, inp) = types.split_last().unwrap();
+            return ResolvedCall::Primitive(SpecializedPrimitive {
+                prim_with_id: picked.clone(),
+                input: inp.to_vec(),
+                output: out.clone(),
+            });
         }
 
         panic!("No resolution for {head:?} in context {ctx:?}");

--- a/src/core.rs
+++ b/src/core.rs
@@ -81,7 +81,20 @@ impl SpecializedPrimitive {
 
 impl PartialEq for SpecializedPrimitive {
     fn eq(&self, other: &Self) -> bool {
+        // This is the key used when resolved atoms are deduplicated by
+        // `(head, inputs)`. The context-id map identifies the primitive
+        // registration, while the concrete input/output sorts identify the
+        // specialization of generic primitives. The primitive name and
+        // validator are registration metadata, so they are intentionally not
+        // separate key fields.
         self.prim_with_id.context_ids == other.prim_with_id.context_ids
+            && self.output.name() == other.output.name()
+            && self.input.len() == other.input.len()
+            && self
+                .input
+                .iter()
+                .zip(&other.input)
+                .all(|(a, b)| a.name() == b.name())
     }
 }
 
@@ -90,6 +103,11 @@ impl Eq for SpecializedPrimitive {}
 impl Hash for SpecializedPrimitive {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.prim_with_id.context_ids.hash(state);
+        self.output.name().hash(state);
+        self.input.len().hash(state);
+        for input in &self.input {
+            input.name().hash(state);
+        }
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -64,8 +64,13 @@ impl SpecializedPrimitive {
     }
 
     /// Get the external function ID of this primitive
-    pub(crate) fn external_id(&self) -> ExternalFunctionId {
-        self.prim_with_id.id
+    pub(crate) fn external_id(&self, ctx: crate::Context) -> ExternalFunctionId {
+        self.prim_with_id.context_ids[ctx].unwrap_or_else(|| {
+            panic!(
+                "primitive {:?} is not valid in context {ctx:?}",
+                self.prim_with_id.primitive.name()
+            )
+        })
     }
 
     /// Get the validator function of this primitive, if any
@@ -76,7 +81,7 @@ impl SpecializedPrimitive {
 
 impl PartialEq for SpecializedPrimitive {
     fn eq(&self, other: &Self) -> bool {
-        self.prim_with_id.id == other.prim_with_id.id
+        self.prim_with_id.context_ids == other.prim_with_id.context_ids
     }
 }
 
@@ -84,7 +89,7 @@ impl Eq for SpecializedPrimitive {}
 
 impl Hash for SpecializedPrimitive {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.prim_with_id.id.hash(state);
+        self.prim_with_id.context_ids.hash(state);
     }
 }
 
@@ -155,17 +160,16 @@ impl ResolvedCall {
             }
         }
 
-        // For a given (signature, context) pair, exactly one
-        // registration must match. Each `add_*_primitive` call commits
-        // one id per context the trait permits, with disjoint
-        // `selection_ctx` values. If two primitives accept the same
-        // signature in the same context, registration was ambiguous
-        // (e.g. the same primitive added twice); panic here rather
-        // than silently picking one.
+        // For a given (signature, context) pair, exactly one primitive
+        // definition must match. Each definition carries the runtime ids
+        // for the contexts it permits. If two definitions accept the
+        // same signature in the same context, registration was
+        // ambiguous (e.g. the same primitive added twice); panic here
+        // rather than silently picking one.
         if let Some(primitives) = typeinfo.get_prims(head) {
             let matches: Vec<_> = primitives
                 .iter()
-                .filter(|p| p.selection_ctx == ctx && p.accept(types, typeinfo))
+                .filter(|p| p.context_ids[ctx].is_some() && p.accept(types, typeinfo))
                 .collect();
             match matches.as_slice() {
                 [] => {}

--- a/src/exec_state.rs
+++ b/src/exec_state.rs
@@ -195,7 +195,7 @@ pub trait Core<'a, 'db: 'a>: Internal<'a, 'db> {
     ) -> Option<Value> {
         let ctx = self.ctx();
         let mut pure = PureState::wrap(self.raw_exec_state(), ctx);
-        fc.apply(&mut pure, ctx, args)
+        fc.apply(&mut pure, args)
     }
 }
 

--- a/src/exec_state.rs
+++ b/src/exec_state.rs
@@ -42,10 +42,9 @@ use egglog_bridge::{ActionRegistry, TableAction};
 /// capability profile they grant. Each variant maps 1:1 to one of the
 /// state wrappers below: `Pure` ↔ [`PureState`], `Write` ↔ [`WriteState`],
 /// `Read` ↔ [`ReadState`], `Full` ↔ [`FullState`]. The egglog
-/// typechecker filters primitive registrations by their
-/// `selection_ctx` against the surrounding `Context` at each call
-/// site.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+/// typechecker filters primitive definitions by whether they carry a
+/// runtime id for the surrounding `Context` at each call site.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, enum_map::Enum)]
 pub enum Context {
     /// No DB reads, no DB writes. The body (LHS) of a rule running
     /// under seminaive evaluation: a body read of live state means

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1218,10 +1218,10 @@ impl EGraph {
                 "this function will never panic".to_string()
             });
         let id = translator.build();
-        let _ = self.backend.run_rules(&[id]).unwrap();
+        let run_result = self.backend.run_rules(&[id]);
         self.backend.free_rule(id);
-
         self.backend.free_external_func(ext_id);
+        run_result.map_err(|e| Error::BackendError(e.to_string()))?;
 
         let ext_sc_val = ext_sc.lock().unwrap().take();
         let matched = matches!(ext_sc_val, Some(()));
@@ -2077,8 +2077,7 @@ impl<'a> BackendRule<'a> {
             // `run_rules` rather than a thread unwind.
             let panic_id = self.rb.new_panic(format!(
                 "unstable-fn over `{name}` was applied in a context where its wrapped \
-                 function is not valid; if the call should be sound, add `:naive` to the \
-                 surrounding rule"
+                 function is not valid for this call site, if in a rule, add :naive."
             ));
 
             qe_args[0] = self.rb.egraph().base_value_constant(ResolvedFunction {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -702,7 +702,7 @@ impl EGraph {
                     .map(|arg| self.translate_expr_to_mergefn(arg))
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(egglog_bridge::MergeFn::Primitive(
-                    p.external_id(),
+                    p.external_id(crate::Context::Full),
                     translated_args,
                 ))
             }
@@ -1926,8 +1926,8 @@ struct BackendRule<'a> {
     /// (b) rules with the `:naive` option,
     /// (c) `EGraph::seminaive == false` (the global opt-out).
     /// Combined with whether we're in the query or action phase, this
-    /// picks the [`crate::Context`] used to select primitive
-    /// registrations by `selection_ctx` at each call site.
+    /// picks the [`crate::Context`] used to select a primitive's
+    /// context-specific runtime id at each call site.
     seminaive: bool,
 }
 
@@ -1999,10 +1999,10 @@ impl<'a> BackendRule<'a> {
         args: &[core::ResolvedAtomTerm],
         ctx: crate::Context,
     ) -> (ExternalFunctionId, Vec<QueryEntry>, ColumnTy) {
-        // The typechecker has already picked the context-best
-        // registration via `ResolvedCall::from_resolution`; we just
-        // use its id directly.
-        let resolved_id = prim.external_id();
+        // The typechecker has already checked that this primitive is
+        // valid in `ctx`; pick the runtime id that stamps the same ctx
+        // onto the state wrapper when invoked.
+        let resolved_id = prim.external_id(ctx);
 
         let mut qe_args = self.args(args);
 
@@ -2026,24 +2026,21 @@ impl<'a> BackendRule<'a> {
                     ast::FunctionSubtype::Custom => ResolvedFunctionId::Function(action),
                 }
             } else if let Some(possible) = self.type_info.get_prims(name) {
-                let mut ps: Vec<_> = possible.iter().collect();
-                ps.retain(|p| {
-                    self.type_info
-                        .get_sorts::<FunctionSort>()
-                        .into_iter()
-                        .any(|f| {
-                            let types: Vec<_> = prim
-                                .input()
-                                .iter()
-                                .skip(1)
-                                .chain(f.inputs())
-                                .chain([&f.output()])
-                                .cloned()
-                                .collect();
-                            p.accept(&types, self.type_info)
-                        })
-                });
-                // Bake every signature-matching registration. The
+                let fn_sort = Arc::downcast::<FunctionSort>(prim.output().clone().as_arc_any())
+                    .unwrap_or_else(|_| panic!("expected `unstable-fn` to return a function sort"));
+                let types: Vec<_> = prim
+                    .input()
+                    .iter()
+                    .skip(1)
+                    .cloned()
+                    .chain(fn_sort.inputs().iter().cloned())
+                    .chain(std::iter::once(fn_sort.output()))
+                    .collect();
+                let ps: Vec<_> = possible
+                    .iter()
+                    .filter(|p| p.accept(&types, self.type_info))
+                    .collect();
+                // Bake every exact-signature registration. The
                 // build-site `ctx` here is intentionally unused: the
                 // *application*-time context (carried on `state.ctx`
                 // by the wrapping HOF body) selects which candidate
@@ -2052,10 +2049,32 @@ impl<'a> BackendRule<'a> {
                 // was constructed in (e.g. a `let`-bound function value
                 // built at top-level `Full` couldn't be applied later
                 // from a `Read` query).
-                let _ = ctx;
-                assert!(!ps.is_empty(), "no callable for {name}");
-                let candidates: Vec<_> = ps.into_iter().map(|p| (p.id, p.selection_ctx)).collect();
-                ResolvedFunctionId::Primitive { candidates }
+                // Per application context, zero matching runtime ids means
+                // the wrapped primitive is not callable there and will hit
+                // the mismatch path later; one id is the dispatch target; more
+                // than one is ambiguous and should panic.
+                let context_ids = enum_map::EnumMap::from_fn(|runtime_ctx| {
+                    let mut matching_ids = ps.iter().filter_map(|p| p.context_ids[runtime_ctx]);
+                    match (matching_ids.next(), matching_ids.next()) {
+                        (None, _) => None,
+                        (Some(id), None) => Some(id),
+                        (Some(_), Some(_)) => {
+                            let sig: Vec<_> = types.iter().map(|s| s.name().to_string()).collect();
+                            panic!(
+                                "Ambiguous primitive resolution for {name:?} in unstable-fn \
+                                 context {runtime_ctx:?} with wrapped signature [{}]: {} \
+                                 registrations accept this call",
+                                sig.join(", "),
+                                matching_ids.count() + 2,
+                            )
+                        }
+                    }
+                });
+                assert!(
+                    context_ids.iter().any(|(_, id)| id.is_some()),
+                    "no callable for {name}"
+                );
+                ResolvedFunctionId::Primitive { context_ids }
             } else {
                 panic!("no callable for {name}");
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2025,7 +2025,7 @@ impl<'a> BackendRule<'a> {
                     ast::FunctionSubtype::Constructor => ResolvedFunctionId::Constructor(action),
                     ast::FunctionSubtype::Custom => ResolvedFunctionId::Function(action),
                 }
-            } else if let Some(possible) = self.type_info.get_prims(name) {
+            } else {
                 let fn_sort = Arc::downcast::<FunctionSort>(prim.output().clone().as_arc_any())
                     .unwrap_or_else(|_| panic!("expected `unstable-fn` to return a function sort"));
                 let types: Vec<_> = prim
@@ -2036,10 +2036,6 @@ impl<'a> BackendRule<'a> {
                     .chain(fn_sort.inputs().iter().cloned())
                     .chain(std::iter::once(fn_sort.output()))
                     .collect();
-                let ps: Vec<_> = possible
-                    .iter()
-                    .filter(|p| p.accept(&types, self.type_info))
-                    .collect();
                 // Bake every exact-signature registration. The
                 // build-site `ctx` here is intentionally unused: the
                 // *application*-time context (carried on `state.ctx`
@@ -2049,25 +2045,21 @@ impl<'a> BackendRule<'a> {
                 // was constructed in (e.g. a `let`-bound function value
                 // built at top-level `Full` couldn't be applied later
                 // from a `Read` query).
-                // Per application context, zero matching runtime ids means
-                // the wrapped primitive is not callable there and will hit
-                // the mismatch path later; one id is the dispatch target; more
-                // than one is ambiguous and should panic.
+                let ps: Vec<_> = self
+                    .type_info
+                    .get_prims(name)
+                    .into_iter()
+                    .flatten()
+                    .filter(|p| p.accept(&types, self.type_info))
+                    .collect();
                 let context_ids = enum_map::EnumMap::from_fn(|runtime_ctx| {
-                    let mut matching_ids = ps.iter().filter_map(|p| p.context_ids[runtime_ctx]);
-                    match (matching_ids.next(), matching_ids.next()) {
+                    let mut ids = ps.iter().filter_map(|p| p.context_ids[runtime_ctx]);
+                    match (ids.next(), ids.next()) {
                         (None, _) => None,
                         (Some(id), None) => Some(id),
-                        (Some(_), Some(_)) => {
-                            let sig: Vec<_> = types.iter().map(|s| s.name().to_string()).collect();
-                            panic!(
-                                "Ambiguous primitive resolution for {name:?} in unstable-fn \
-                                 context {runtime_ctx:?} with wrapped signature [{}]: {} \
-                                 registrations accept this call",
-                                sig.join(", "),
-                                matching_ids.count() + 2,
-                            )
-                        }
+                        (Some(_), Some(_)) => panic!(
+                            "Ambiguous primitive resolution for {name:?} in unstable-fn context {runtime_ctx:?}"
+                        ),
                     }
                 });
                 assert!(
@@ -2075,8 +2067,6 @@ impl<'a> BackendRule<'a> {
                     "no callable for {name}"
                 );
                 ResolvedFunctionId::Primitive { context_ids }
-            } else {
-                panic!("no callable for {name}");
             };
             let partial_arcsorts = prim.input().iter().skip(1).cloned().collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -702,7 +702,7 @@ impl EGraph {
                     .map(|arg| self.translate_expr_to_mergefn(arg))
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(egglog_bridge::MergeFn::Primitive(
-                    p.external_id(crate::Context::Full),
+                    p.external_id(crate::Context::Write),
                     translated_args,
                 ))
             }

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -13,6 +13,7 @@
 use std::sync::Mutex;
 
 use crate::exec_state::Internal;
+use enum_map::EnumMap;
 
 use super::*;
 
@@ -455,15 +456,14 @@ pub enum ResolvedFunctionId {
     /// context except `Pure` (where it would be an untracked
     /// seminaive read).
     Function(egglog_bridge::TableAction),
-    /// Wraps a primitive. Carries every signature-matching
-    /// registration the typechecker found at build time, paired with
-    /// its `selection_ctx`. At dispatch time `FunctionContainer::apply`
-    /// picks the candidate whose `selection_ctx` matches the
-    /// application context — so the runtime selection is independent
-    /// of the build-site context, and an `unstable-fn` value may flow
-    /// freely from one context to another.
+    /// Wraps a primitive. Carries the unique exact-signature runtime
+    /// id found for each context at build time. At dispatch time
+    /// `FunctionContainer::apply` picks the id for the application
+    /// context — so the runtime selection is independent of the
+    /// build-site context, and an `unstable-fn` value may flow freely
+    /// from one context to another.
     Primitive {
-        candidates: Vec<(ExternalFunctionId, crate::Context)>,
+        context_ids: EnumMap<crate::Context, Option<ExternalFunctionId>>,
     },
 }
 
@@ -553,17 +553,11 @@ impl FunctionContainer {
                     mismatch(state)
                 }
             }
-            ResolvedFunctionId::Primitive { candidates } => {
-                // Pick the registration whose `selection_ctx` equals
-                // the application ctx. Each `add_*_primitive` commits
-                // disjoint singletons across the trait's valid ctxs,
-                // so exactly one candidate matches.
-                debug_assert!(
-                    candidates.iter().filter(|(_, c)| *c == ctx).count() <= 1,
-                    "more than one primitive candidate matches ctx {ctx:?}"
-                );
-                match candidates.iter().find(|(_, c)| *c == ctx) {
-                    Some((id, _)) => state.call_external_func(*id, &args),
+            ResolvedFunctionId::Primitive { context_ids } => {
+                // Pick the runtime id whose context matches the
+                // application ctx.
+                match context_ids[ctx] {
+                    Some(id) => state.call_external_func(id, &args),
                     None => mismatch(state),
                 }
             }

--- a/src/sort/fn.rs
+++ b/src/sort/fn.rs
@@ -451,10 +451,9 @@ pub enum ResolvedFunctionId {
     /// eclass the user asked for, so the call is rejected outright.
     Constructor(egglog_bridge::TableAction),
     /// Wraps a `(function …)` lookup — any non-constructor function,
-    /// regardless of its `:merge` strategy. Pure read returning `None`
-    /// on miss. `FunctionContainer::apply` allows this in every
-    /// context except `Pure` (where it would be an untracked
-    /// seminaive read).
+    /// regardless of its `:merge` strategy. `FunctionContainer::apply`
+    /// allows this only in DB-read-capable contexts (`Read`/`Full`);
+    /// `Pure` and `Write` would be untracked seminaive reads.
     Function(egglog_bridge::TableAction),
     /// Wraps a primitive. Carries the unique exact-signature runtime
     /// id found for each context at build time. At dispatch time
@@ -511,22 +510,19 @@ impl PurePrim for Apply {
 
 impl FunctionContainer {
     /// Apply the wrapped function. `state` is always a `PureState`
-    /// (the type every primitive's `apply` receives); the real
-    /// surrounding context is carried separately in `ctx`, and
-    /// read/write capabilities are reached through `raw_exec_state()`
-    /// gated by the `ctx`-derived checks below.
+    /// (the type every primitive's `apply` receives). The surrounding
+    /// context is stamped onto that state by the primitive wrapper, so
+    /// callers do not pass a second copy of the same context.
     pub(crate) fn apply<'a, 'db>(
         &self,
         state: &mut crate::PureState<'a, 'db>,
-        ctx: crate::Context,
         args: &[Value],
     ) -> Option<Value>
     where
         'db: 'a,
     {
+        let ctx = state.ctx();
         let args: Vec<_> = self.1.iter().map(|(_, x)| x).chain(args).copied().collect();
-        // See [`Context`] for why each capability is admitted only in
-        // these contexts.
         let can_mint = matches!(ctx, crate::Context::Write | crate::Context::Full);
         let can_read = matches!(ctx, crate::Context::Read | crate::Context::Full);
         let panic_id = self.3;

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -425,25 +425,21 @@ impl EGraph {
                     unionable: *unionable,
                 }
             }
-            NCommand::CoreAction(Action::Let(span, var, expr)) => {
-                let expr = self.type_info.typecheck_standalone_expr(
+            NCommand::CoreAction(action @ Action::Let(span, var, _)) => {
+                let action = self.type_info.typecheck_standalone_action(
                     symbol_gen,
-                    expr,
+                    action,
                     &Default::default(),
                     Context::Full,
                 )?;
-                let output_type = expr.output_type();
                 self.ensure_global_name_prefix(span, var)?;
+                let ResolvedAction::Let(_, resolved_var, _) = &action else {
+                    unreachable!("typechecking an Action::Let should return ResolvedAction::Let")
+                };
                 self.type_info
                     .global_sorts
-                    .insert(var.clone(), output_type.clone());
-                let var = ResolvedVar {
-                    name: var.clone(),
-                    sort: output_type,
-                    // not a global reference, but a global binding
-                    is_global_ref: false,
-                };
-                ResolvedNCommand::CoreAction(ResolvedAction::Let(span.clone(), var, expr))
+                    .insert(resolved_var.name.clone(), resolved_var.sort.clone());
+                ResolvedNCommand::CoreAction(action)
             }
             NCommand::CoreAction(action) => {
                 ResolvedNCommand::CoreAction(self.type_info.typecheck_standalone_action(

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -9,6 +9,7 @@ use ast::{ResolvedAction, ResolvedExpr, ResolvedFact, ResolvedRule, ResolvedVar,
 use core_relations::ExternalFunction;
 use egglog_ast::generic_ast::GenericAction;
 use egglog_bridge::ActionRegistry;
+use enum_map::EnumMap;
 use std::sync::{Arc, RwLock};
 
 // `ExternalFunction` wrapper for `PurePrim`. Holds the primitive
@@ -155,14 +156,12 @@ pub type PrimitiveValidator = Arc<dyn Fn(&mut TermDag, &[TermId]) -> Option<Term
 #[derive(Clone)]
 pub struct PrimitiveWithId {
     pub(crate) primitive: Arc<dyn Primitive>,
-    pub(crate) id: ExternalFunctionId,
     pub(crate) validator: Option<PrimitiveValidator>,
-    /// The single context this registration was created for. Each
-    /// `add_*_primitive` call commits one registration per context
-    /// the trait permits, so the constraint solver filters by
-    /// `selection_ctx == ambient_ctx` to pick exactly one id per
-    /// call site.
-    pub(crate) selection_ctx: Context,
+    /// Runtime entrypoints for the contexts this primitive is valid in.
+    /// The primitive definition is stored once, while each context keeps
+    /// its own backend id so higher-order dispatch can still recover the
+    /// application context at runtime.
+    pub(crate) context_ids: EnumMap<Context, Option<ExternalFunctionId>>,
 }
 
 impl PrimitiveWithId {
@@ -330,11 +329,15 @@ impl EGraph {
         });
     }
 
-    /// Shared registration engine. Registers `x` once per `Context` in
-    /// `valid_ctxs`, with each wrapper carrying its specific context
-    /// stamped onto the state wrapper at invoke time. The typechecker's
-    /// `selection_ctx` filter picks exactly one candidate at each call
-    /// site.
+    /// Shared registration engine. Stores one primitive definition, plus
+    /// one runtime id per valid [`Context`]. Each wrapper carries its
+    /// specific context stamped onto the state wrapper at invoke time.
+    ///
+    /// The typechecker filters by the context-id mask at each call site;
+    /// an `unstable-fn` value built around the primitive bakes *all*
+    /// signature-matching context ids, and `FunctionContainer::apply`
+    /// picks the one whose context matches the application ctx — so
+    /// values flow freely across contexts.
     fn register_per_context<T, F>(
         &mut self,
         x: T,
@@ -347,51 +350,22 @@ impl EGraph {
     {
         let primitive: Arc<dyn Primitive> = Arc::new(x.clone());
         let name = primitive.name().to_owned();
-        for &ctx in valid_ctxs {
-            let id = self
-                .backend
-                .register_external_func(build_wrapper(x.clone(), ctx));
-            self.commit_primitive(PendingPrimitive {
-                primitive: primitive.clone(),
-                id,
-                validator: validator.clone(),
-                selection_ctx: ctx,
-                name: name.clone(),
-            });
-        }
-    }
-
-    fn commit_primitive(&mut self, entry: PendingPrimitive) {
-        let PendingPrimitive {
-            primitive,
-            id,
-            validator,
-            selection_ctx,
-            name,
-        } = entry;
+        let context_ids = EnumMap::from_fn(|ctx| {
+            valid_ctxs.contains(&ctx).then(|| {
+                self.backend
+                    .register_external_func(build_wrapper(x.clone(), ctx))
+            })
+        });
         self.type_info
             .primitives
             .entry(name)
             .or_default()
             .push(PrimitiveWithId {
                 primitive,
-                id,
                 validator,
-                selection_ctx,
+                context_ids,
             });
     }
-}
-
-/// A primitive that's been registered with the bridge but not yet
-/// pushed into the `TypeInfo` registry. The four `add_*_primitive`
-/// helpers commit one of these per [`Context`] variant the trait
-/// supports.
-struct PendingPrimitive {
-    primitive: Arc<dyn Primitive>,
-    id: ExternalFunctionId,
-    validator: Option<PrimitiveValidator>,
-    selection_ctx: Context,
-    name: String,
 }
 
 impl EGraph {
@@ -1010,7 +984,7 @@ impl TypeInfo {
         self.primitives
             .values()
             .flat_map(|v| v.iter())
-            .any(|p| p.id == id && p.validator.is_some())
+            .any(|p| p.context_ids.iter().any(|(_, pid)| *pid == Some(id)) && p.validator.is_some())
     }
 
     pub fn get_func_type(&self, sym: &str) -> Option<&FuncType> {

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -284,15 +284,11 @@ impl EGraph {
     where
         T: WritePrim + Clone,
     {
-        let registry = self.backend.action_registry().clone();
-        self.register_per_context(x, validator, WriteState::valid_contexts(), move |x, ctx| {
-            Box::new(RegistryPrimWrapper::<T, WrapWrite> {
-                prim: x,
-                registry: registry.clone(),
-                ctx,
-                _wrap: std::marker::PhantomData,
-            })
-        });
+        self.register_registry_primitive::<T, WrapWrite>(
+            x,
+            validator,
+            WriteState::valid_contexts(),
+        );
     }
 
     /// Register a [`ReadPrim`]. Pass `None` for the validator if not
@@ -301,15 +297,7 @@ impl EGraph {
     where
         T: ReadPrim + Clone,
     {
-        let registry = self.backend.action_registry().clone();
-        self.register_per_context(x, validator, ReadState::valid_contexts(), move |x, ctx| {
-            Box::new(RegistryPrimWrapper::<T, WrapRead> {
-                prim: x,
-                registry: registry.clone(),
-                ctx,
-                _wrap: std::marker::PhantomData,
-            })
-        });
+        self.register_registry_primitive::<T, WrapRead>(x, validator, ReadState::valid_contexts());
     }
 
     /// Register a [`FullPrim`]. Pass `None` for the validator if not
@@ -318,9 +306,21 @@ impl EGraph {
     where
         T: FullPrim + Clone,
     {
+        self.register_registry_primitive::<T, WrapFull>(x, validator, FullState::valid_contexts());
+    }
+
+    fn register_registry_primitive<T, S>(
+        &mut self,
+        x: T,
+        validator: Option<PrimitiveValidator>,
+        valid_ctxs: &[Context],
+    ) where
+        T: Primitive + Clone,
+        S: RegistryWrap<T> + 'static,
+    {
         let registry = self.backend.action_registry().clone();
-        self.register_per_context(x, validator, FullState::valid_contexts(), move |x, ctx| {
-            Box::new(RegistryPrimWrapper::<T, WrapFull> {
+        self.register_per_context(x, validator, valid_ctxs, move |x, ctx| {
+            Box::new(RegistryPrimWrapper::<T, S> {
                 prim: x,
                 registry: registry.clone(),
                 ctx,

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -426,9 +426,12 @@ impl EGraph {
                 }
             }
             NCommand::CoreAction(Action::Let(span, var, expr)) => {
-                let expr = self
-                    .type_info
-                    .typecheck_expr(symbol_gen, expr, &Default::default())?;
+                let expr = self.type_info.typecheck_standalone_expr(
+                    symbol_gen,
+                    expr,
+                    &Default::default(),
+                    Context::Full,
+                )?;
                 let output_type = expr.output_type();
                 self.ensure_global_name_prefix(span, var)?;
                 self.type_info
@@ -442,18 +445,28 @@ impl EGraph {
                 };
                 ResolvedNCommand::CoreAction(ResolvedAction::Let(span.clone(), var, expr))
             }
-            NCommand::CoreAction(action) => ResolvedNCommand::CoreAction(
-                self.type_info
-                    .typecheck_action(symbol_gen, action, &Default::default())?,
-            ),
+            NCommand::CoreAction(action) => {
+                ResolvedNCommand::CoreAction(self.type_info.typecheck_standalone_action(
+                    symbol_gen,
+                    action,
+                    &Default::default(),
+                    Context::Full,
+                )?)
+            }
             NCommand::Extract(span, expr, variants) => {
-                let res_expr =
-                    self.type_info
-                        .typecheck_expr(symbol_gen, expr, &Default::default())?;
+                let res_expr = self.type_info.typecheck_standalone_expr(
+                    symbol_gen,
+                    expr,
+                    &Default::default(),
+                    Context::Full,
+                )?;
 
-                let res_variants =
-                    self.type_info
-                        .typecheck_expr(symbol_gen, variants, &Default::default())?;
+                let res_variants = self.type_info.typecheck_standalone_expr(
+                    symbol_gen,
+                    variants,
+                    &Default::default(),
+                    Context::Full,
+                )?;
                 if res_variants.output_type().name() != I64Sort.name() {
                     return Err(TypeError::Mismatch {
                         expr: variants.clone(),
@@ -519,8 +532,12 @@ impl EGraph {
                 let exprs = exprs
                     .iter()
                     .map(|expr| {
-                        self.type_info
-                            .typecheck_expr(symbol_gen, expr, &Default::default())
+                        self.type_info.typecheck_standalone_expr(
+                            symbol_gen,
+                            expr,
+                            &Default::default(),
+                            Context::Full,
+                        )
                     })
                     .collect::<Result<Vec<_>, _>>()?;
                 ResolvedNCommand::Output {
@@ -733,7 +750,15 @@ impl TypeInfo {
             schema: fdecl.schema.clone(),
             resolved_schema: ResolvedCall::Func(self.func_types.get(&fdecl.name).unwrap().clone()),
             merge: match &fdecl.merge {
-                Some(merge) => Some(self.typecheck_expr(symbol_gen, merge, &bound_vars)?),
+                // Merge expressions run as part of action-side table updates:
+                // writes are allowed, but live DB reads would be untracked by
+                // seminaive rule execution.
+                Some(merge) => Some(self.typecheck_standalone_expr(
+                    symbol_gen,
+                    merge,
+                    &bound_vars,
+                    Context::Write,
+                )?),
                 None => None,
             },
             cost: fdecl.cost,
@@ -909,11 +934,15 @@ impl TypeInfo {
         Ok(annotated_facts)
     }
 
-    fn typecheck_actions(
+    // Standalone expressions/actions use action lowering. Top-level commands
+    // pass `Full`; function `:merge` reuses this path with `Write` because
+    // merge expressions run during table updates.
+    fn typecheck_standalone_actions(
         &self,
         symbol_gen: &mut SymbolGen,
         actions: &Actions,
         binding: &IndexMap<&str, (Span, ArcSort)>,
+        context: Context,
     ) -> Result<ResolvedActions, TypeError> {
         let mut binding_set: IndexSet<String> =
             binding.keys().copied().map(str::to_string).collect();
@@ -923,10 +952,7 @@ impl TypeInfo {
         let (actions, mapped_action) = actions.to_core_actions(&mut ctx)?;
         let mut problem = Problem::default();
 
-        // Top-level action-shaped commands (e.g. `eval`, `let`) get the
-        // most permissive context: primitives may both read and write
-        // the database.
-        problem.add_actions(&actions, self, symbol_gen, Context::Full)?;
+        problem.add_actions(&actions, self, symbol_gen, context)?;
 
         // add bindings from the context
         for (var, (span, sort)) in binding {
@@ -937,35 +963,43 @@ impl TypeInfo {
             .solve(|sort: &ArcSort| sort.name())
             .map_err(|e| e.to_type_error())?;
 
-        let annotated_actions = assignment.annotate_actions(&mapped_action, self, Context::Full)?;
+        let annotated_actions = assignment.annotate_actions(&mapped_action, self, context)?;
         Ok(annotated_actions)
     }
 
-    fn typecheck_expr(
+    fn typecheck_standalone_expr(
         &self,
         symbol_gen: &mut SymbolGen,
         expr: &Expr,
         binding: &IndexMap<&str, (Span, ArcSort)>,
+        context: Context,
     ) -> Result<ResolvedExpr, TypeError> {
         let action = Action::Expr(expr.span(), expr.clone());
-        let typechecked_action = self.typecheck_action(symbol_gen, &action, binding)?;
+        let typechecked_action =
+            self.typecheck_standalone_action(symbol_gen, &action, binding, context)?;
         match typechecked_action {
             ResolvedAction::Expr(_, expr) => Ok(expr),
             _ => unreachable!(),
         }
     }
 
-    fn typecheck_action(
+    fn typecheck_standalone_action(
         &self,
         symbol_gen: &mut SymbolGen,
         action: &Action,
         binding: &IndexMap<&str, (Span, ArcSort)>,
+        context: Context,
     ) -> Result<ResolvedAction, TypeError> {
-        self.typecheck_actions(symbol_gen, &Actions::singleton(action.clone()), binding)
-            .map(|v| {
-                assert_eq!(v.len(), 1);
-                v.0.into_iter().next().unwrap()
-            })
+        self.typecheck_standalone_actions(
+            symbol_gen,
+            &Actions::singleton(action.clone()),
+            binding,
+            context,
+        )
+        .map(|v| {
+            assert_eq!(v.len(), 1);
+            v.0.into_iter().next().unwrap()
+        })
     }
 
     pub fn get_sort_by_name(&self, sym: &str) -> Option<&ArcSort> {

--- a/tests/typed_primitive.rs
+++ b/tests/typed_primitive.rs
@@ -468,26 +468,10 @@ fn matrix_program(ctx: AppCtx) -> String {
 fn run_matrix_cell(register: impl FnOnce(&mut EGraph), ctx: AppCtx) -> Result<(), String> {
     let mut egraph = EGraph::default();
     register(&mut egraph);
-    // Dispatch mismatch usually surfaces as `Err` from
-    // `parse_and_run_program` (via the egglog panic side channel),
-    // but in a `check` it can bubble up as a thread panic because
-    // `EGraph::check_facts` unwraps the underlying `run_rules`
-    // result. Treat either signal as a dispatch failure here.
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        egraph.parse_and_run_program(None, &matrix_program(ctx))
-    }));
-    match result {
-        Ok(Ok(_)) => Ok(()),
-        Ok(Err(e)) => Err(format!("{e}")),
-        Err(p) => {
-            let msg = p
-                .downcast_ref::<String>()
-                .cloned()
-                .or_else(|| p.downcast_ref::<&'static str>().map(|s| s.to_string()))
-                .unwrap_or_else(|| "<non-string panic>".to_string());
-            Err(format!("panic: {msg}"))
-        }
-    }
+    egraph
+        .parse_and_run_program(None, &matrix_program(ctx))
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 #[test]

--- a/tests/typed_primitive.rs
+++ b/tests/typed_primitive.rs
@@ -381,6 +381,38 @@ fn full_primitive_accepted_only_in_global_action() {
         .unwrap();
 }
 
+/// Merge expressions are action-side writes, not top-level full actions:
+/// they may use pure/write primitives, but not primitives that read live DB
+/// state.
+#[test]
+fn merge_primitives_use_write_context() {
+    let mut egraph = EGraph::default();
+    egraph.add_write_primitive(WriteEcho("w-echo"), None);
+    egraph
+        .parse_and_run_program(None, "(function g () i64 :merge (w-echo old))")
+        .unwrap();
+
+    let mut egraph2 = EGraph::default();
+    egraph2.add_read_primitive(
+        ReadLookup {
+            name: "lookup-f",
+            table_name: "f",
+        },
+        None,
+    );
+    let result = egraph2.parse_and_run_program(
+        None,
+        "(function f (i64) i64 :no-merge)\n\
+         (function g () i64 :merge (lookup-f old))",
+    );
+    assert!(result.is_err(), "ReadPrim must be rejected in :merge");
+
+    let mut egraph3 = EGraph::default();
+    egraph3.add_full_primitive(FullEcho("f-echo"), None);
+    let result = egraph3.parse_and_run_program(None, "(function g () i64 :merge (f-echo old))");
+    assert!(result.is_err(), "FullPrim must be rejected in :merge");
+}
+
 // `unstable-app` dispatch tests live in
 // `tests/typed_primitive_unstable_app.egg` — they only need built-in
 // primitives, so the `.egg` form is more direct than building an

--- a/tests/typed_primitive.rs
+++ b/tests/typed_primitive.rs
@@ -4,11 +4,13 @@
 //! Covers:
 //! - Pure / write / read / full primitives accepted only in their
 //!   respective valid contexts (typechecker rejects others).
-//! - `unstable-fn` over a constructor in a query context is filtered
-//!   (does NOT mint an eclass), but works in actions.
-//! - `unstable-fn` over a custom function is filtered in rule queries.
-//! - Two same-signature registrations: ambiguity is rejected
-//!   (regression guard).
+//! - Higher-order primitive values carry runtime ids for every context where
+//!   the wrapped primitive is valid; application in other contexts hits the
+//!   mismatch path.
+//! - `unstable-fn` over constructors and custom functions preserves the
+//!   existing function/container runtime checks.
+//! - Duplicate same-signature primitive registrations are ambiguous for direct
+//!   calls and higher-order primitive dispatch.
 
 use egglog::ast::Span;
 use egglog::constraint::{SimpleTypeConstraint, TypeConstraint};
@@ -386,13 +388,10 @@ fn full_primitive_accepted_only_in_global_action() {
 
 // --- duplicate registration regression ---
 
-/// Two same-name same-signature primitives registered separately
-/// pass the constraint-builder context filter (both are valid in
-/// every context) and the typechecker doesn't reject equivalent XOR
-/// branches when the surrounding constraints pin the sort assignment.
-/// `ResolvedCall::from_resolution` catches this on the use site by
-/// requiring exactly one match for `(name, signature, context)` and
-/// panicking with a clear message otherwise.
+/// Direct primitive resolution requires exactly one matching registration for
+/// `(name, signature, context)`. Two independently registered pure primitives
+/// both carry valid runtime ids for every context, so a same-signature direct
+/// call is ambiguous instead of silently picking one registration.
 #[test]
 #[should_panic(expected = "Ambiguous primitive resolution")]
 fn two_same_signature_registrations_panic_on_use() {
@@ -403,18 +402,33 @@ fn two_same_signature_registrations_panic_on_use() {
     let _ = egraph.parse_and_run_program(None, "(check (= (dup-add 1 2) 3))");
 }
 
+/// `unstable-fn` over a primitive must preserve the same exact-one ambiguity
+/// rule as direct primitive calls. The wrapped value records valid runtime ids
+/// per application context, and duplicate same-signature registrations are
+/// ambiguous for every context where more than one runtime id matches.
+#[test]
+#[should_panic(expected = "Ambiguous primitive resolution")]
+fn unstable_fn_duplicate_primitive_registration_panics_on_build() {
+    let mut egraph = EGraph::default();
+    egraph.add_pure_primitive(PureEcho("dup-echo"), None);
+    egraph.add_pure_primitive(PureEcho("dup-echo"), None);
+
+    let _ = egraph.parse_and_run_program(
+        None,
+        "(sort Fn (UnstableFn (i64) i64))\n\
+         (let $f (unstable-fn \"dup-echo\"))\n\
+         (check (= (unstable-app $f 7) 7))",
+    );
+}
+
 // --- 4x4 unstable-app dispatch matrix ---
 //
-// `ResolvedFunctionId::Primitive` is built only on the `unstable-fn` path
-// (`src/lib.rs` around L2103), and at dispatch time
-// `FunctionContainer::apply` (`src/sort/fn.rs` around L560-569)
-// picks the candidate whose `selection_ctx` equals the application
-// ctx. For each registration kind we wrap a uniform (i64)->i64
-// echo primitive in `unstable-fn` and apply it from each of the
-// four application contexts, asserting the outcome matches the
-// trait's `valid_contexts`. Dispatch succeeds iff the application
-// ctx is in the trait's valid set; otherwise the pre-registered
-// panic surfaces as an Err.
+// `unstable-fn` over a primitive builds a per-context runtime id table, and
+// `unstable-app` selects the id for the application context. For each
+// registration kind we wrap a uniform (i64)->i64 echo primitive and apply it
+// from all four application contexts. Dispatch succeeds iff the application
+// context has a runtime id; otherwise the pre-registered mismatch panic
+// surfaces as an error.
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AppCtx {

--- a/tests/typed_primitive_unstable_app.egg
+++ b/tests/typed_primitive_unstable_app.egg
@@ -1,10 +1,9 @@
 ; Tests for typed-primitive dispatch of `unstable-app` (#772).
 ;
-; `unstable-app` is registered via `add_higher_order_primitive`, which
-; produces one `ExternalFunctionId` per `Context` variant. At runtime
-; the closure for the chosen id stamps its specific context onto the
-; `ExecutionState`, and `FunctionContainer::apply` reads it back and
-; chooses pure-side vs action-side dispatch.
+; `unstable-app` dispatches using the application-time context:
+; `Context::{Pure, Read, Write, Full}`. If the wrapped function is not valid in
+; that context, `FunctionContainer::apply` takes the runtime mismatch/panic path.
+; These cases verify context dispatch, not source-line or tagged-variant routing.
 
 ; --- 1. unstable-app over a pure primitive (`+`) works in a query.
 (sort IntFn (UnstableFn (i64 i64) i64))
@@ -52,9 +51,8 @@
 (check (= (dbl-out 7) 14))
 
 ; --- 5. The same custom-function lookup in a top-level `check`
-;     (GlobalQuery) succeeds — top-level queries don't have
-;     seminaive's "untracked read" concern, so reading the existing
-;     row's value is sound. (Inside a rule LHS the typechecker emits
-;     the RuleQuery-tagged variant of `unstable-app`, whose body
-;     refuses custom-function reads — see [`FunctionContainer::apply`].)
+;     succeeds in `Context::Read`: top-level checks don't have seminaive's
+;     "untracked read" concern, so reading the existing row's value is sound.
+;     In a default seminaive rule LHS the application context is `Context::Pure`,
+;     so the same read would hit the runtime mismatch/panic path instead.
 (check (= (unstable-app twice 7) 14))


### PR DESCRIPTION
Changes to #856 to:

* Register only one primitive instead of four, one per context
* Change to use EnumMap instead of Vec<(Enum, T))> for clearer semantics
* Clean up the resolution for unstable function to make the errors more explicit

I pushed this branch by accident to Oliver's branch so the old PR https://github.com/egraphs-good/egglog/pull/873 got closed. This is a replacement for that one.