### PR TITLE
Report scheduler can-stop separately from updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased] - ReleaseDate
 
+- Add `RunReport::can_stop` so scheduler progress can be reported separately from database updates.
 - Desugar `relation`s to `constructor`s to simplify the language and implementation. Relations no longer return unit `()` values.
 - Refactored API to use [`TermId`] more consistently instead of `Term` where possible, simplifying egglog code.
 - **Typed primitive surface for seminaive safety (#772).** Custom primitives now pick one of `PurePrim` / `ReadPrim` / `WritePrim` / `FullPrim` based on what the body needs, and register via the matching `add_*_primitive`. Rust enforces capability bounds via the state wrapper passed to the body; the egglog typechecker enforces context bounds. See the `egglog::exec_state` module docs and the `*Prim` trait docs for the full picture. Migration: `rust_rule` callbacks now take `&mut WriteState` (replacing `RustRuleContext`); a new `rust_rule_full` gives action callbacks read access. Higher-order primitives over `unstable-fn` values dispatch via `state.apply_function(&fc, args)`.

--- a/egglog-reports/src/lib.rs
+++ b/egglog-reports/src/lib.rs
@@ -115,18 +115,36 @@ impl IterationReport {
 /// the database was updated.
 /// Calling `union` on two run reports adds the timing
 /// information together.
-#[derive(Debug, Serialize, Clone, Default)]
+#[derive(Debug, Serialize, Clone)]
 pub struct RunReport {
     // Since `IterationReport`s are immutable, we can reference count them to avoid
     // expensive cloning when e-graphs are cloned.
     pub iterations: Vec<Arc<IterationReport>>,
     /// If any changes were made to the database.
     pub updated: bool,
+    /// True if this run observed no database changes and there is no deferred
+    /// scheduler work requiring another iteration.
+    pub can_stop: bool,
     pub search_and_apply_time_per_rule: HashMap<Arc<str>, Duration>,
     pub num_matches_per_rule: HashMap<Arc<str>, usize>,
     pub search_and_apply_time_per_ruleset: HashMap<Arc<str>, Duration>,
     pub merge_time_per_ruleset: HashMap<Arc<str>, Duration>,
     pub rebuild_time_per_ruleset: HashMap<Arc<str>, Duration>,
+}
+
+impl Default for RunReport {
+    fn default() -> Self {
+        Self {
+            iterations: Vec::new(),
+            updated: false,
+            can_stop: true,
+            search_and_apply_time_per_rule: HashMap::default(),
+            num_matches_per_rule: HashMap::default(),
+            search_and_apply_time_per_ruleset: HashMap::default(),
+            merge_time_per_ruleset: HashMap::default(),
+            rebuild_time_per_ruleset: HashMap::default(),
+        }
+    }
 }
 
 impl Display for RunReport {
@@ -228,6 +246,7 @@ impl RunReport {
         report.merge_time_per_ruleset = per_ruleset(iteration.rule_set_report.merge_time);
         report.rebuild_time_per_ruleset = per_ruleset(iteration.rebuild_time);
         report.updated = iteration.changed();
+        report.can_stop = !report.updated;
         report.iterations.push(Arc::new(iteration));
 
         report
@@ -241,6 +260,7 @@ impl RunReport {
     pub fn union(&mut self, other: Self) {
         self.iterations.extend(other.iterations);
         self.updated |= other.updated;
+        self.can_stop &= other.can_stop;
         RunReport::union_times(
             &mut self.search_and_apply_time_per_rule,
             other.search_and_apply_time_per_rule,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -892,9 +892,9 @@ impl EGraph {
                 let mut report = RunReport::default();
                 for _i in 0..*limit {
                     let rec = self.run_schedule(sched)?;
-                    let updated = rec.updated;
+                    let can_stop = rec.can_stop;
                     report.union(rec);
-                    if !updated {
+                    if can_stop {
                         break;
                     }
                 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -15,8 +15,8 @@ use crate::{ast::ResolvedVar, core::GenericAtomTerm, core::ResolvedCoreRule, uti
 /// The matches that are not chosen in this iteration will be delayed
 /// to the next iteration.
 pub trait Scheduler: dyn_clone::DynClone + Send + Sync {
-    /// Whether or not the rules can be considered as saturated (i.e.,
-    /// `run_report.updated == false`).
+    /// Whether or not the rules can be considered as saturated once no database
+    /// changes were made in the current iteration.
     ///
     /// This is only called when the runner is otherwise saturated.
     /// Default implementation just returns `true`.
@@ -259,10 +259,11 @@ impl EGraph {
         // query matches don't count
         query_report.updated = false;
         query_report.num_matches_per_rule.clear();
-        // if the scheduler says it shouldn't stop, then it's considered updated (unsaturated)
-        action_report.updated = action_report.updated || {
+        // Scheduler state should not count as database progress. Instead it
+        // determines whether a no-op iteration can be treated as fully stopped.
+        action_report.can_stop = !action_report.updated && {
             let rule_ids = rules.iter().map(|(id, _)| id.as_str()).collect::<Vec<_>>();
-            !record.scheduler.can_stop(&rule_ids, ruleset)
+            record.scheduler.can_stop(&rule_ids, ruleset)
         };
 
         query_report.union(action_report);
@@ -469,11 +470,53 @@ mod test {
                 [&"test".into()]
             );
 
-            if !report.updated {
+            if report.can_stop {
                 break;
             }
         }
 
         assert_eq!(iter, 12);
+    }
+
+    #[derive(Clone, Default)]
+    struct DelayStopScheduler {
+        can_stop_calls: usize,
+    }
+
+    impl Scheduler for DelayStopScheduler {
+        fn can_stop(&mut self, _rules: &[&str], _ruleset: &str) -> bool {
+            self.can_stop_calls += 1;
+            self.can_stop_calls > 1
+        }
+
+        fn filter_matches(&mut self, _rule: &str, _ruleset: &str, _matches: &mut Matches) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn test_scheduler_progress_is_separate_from_database_progress() {
+        let mut egraph = EGraph::default();
+        let scheduler_id = egraph.add_scheduler(Box::new(DelayStopScheduler::default()));
+        let input = r#"
+        (ruleset test)
+        (relation R (i64))
+        (rule ((R x)) ((R x)) :ruleset test :name "noop")
+        (R 1)
+        (R 2)
+        (R 3)
+        (R 4)
+        "#;
+        egraph.parse_and_run_program(None, input).unwrap();
+
+        let before = egraph.get_size("R");
+        let report = egraph
+            .step_rules_with_scheduler(scheduler_id, "test")
+            .unwrap();
+        let after = egraph.get_size("R");
+
+        assert_eq!(before, after);
+        assert!(!report.updated);
+        assert!(!report.can_stop);
     }
 }


### PR DESCRIPTION
## Context

Custom schedulers can have deferred work even when an iteration makes no database changes. Treating scheduler state as database progress made reports harder to interpret and confused saturation loops.

Companion experimental PR: https://github.com/egraphs-good/egglog-experimental/pull/47.

## Changes

- Adds `RunReport::can_stop`.
- Updates report union/singleton logic so database updates and scheduler stop state are tracked separately.
- Uses `can_stop` in bounded/saturating schedule loops.
- Adds a scheduler regression test for no database progress with deferred scheduler work.

## Validation

- `cargo test --lib scheduler`
- `cargo fmt`
- `git diff --check`
