### PR TITLE
[codex] Gate CodSpeed walltime runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,12 @@ on:
     branches:
       - "main"
   pull_request:
+  issue_comment:
+    types: [created]
   workflow_dispatch:
 jobs:
   test:
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
@@ -18,6 +21,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: make test
   coverage:
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
@@ -34,6 +38,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   nits:
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
@@ -41,10 +46,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: make nits
   benchmark:
+    if: |
+      github.event_name != 'issue_comment' ||
+      (
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@codspeed walltime') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: [codspeed-macro, ubuntu-latest]
+        runner: ${{ fromJSON(github.event_name == 'push' && '["codspeed-macro", "ubuntu-latest"]' || github.event_name == 'issue_comment' && '["codspeed-macro"]' || '["ubuntu-latest"]') }}
         benchmark:
           - math-microbenchmark
           - cykjson
@@ -73,6 +92,8 @@ jobs:
     steps:
       - run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || github.ref }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-codspeed@4.0.1
@@ -83,6 +104,7 @@ jobs:
           run: cargo codspeed run ${{ matrix.benchmark }}
           mode: ${{ matrix.runner == 'ubuntu-latest' && 'simulation' || 'walltime' }}
   wasm:
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - run: echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       )
     permissions:
       contents: read
-      id-token: write
+      id-token: write # OIDC auth for CodSpeed
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:


### PR DESCRIPTION
This is so that we don't keep running out of our codspeed budget. We can trigger the walltime runs manually only when we want them on performance critical PRs, instead of for every push to every PR. It will also run them on all commits to main, so that we keep historical performance and can still get a nice diff of performance against main when we do trigger one.

## Summary

- keep the existing CodSpeed simulation benchmark matrix running on GitHub-hosted runners for normal PRs
- add an issue-comment trigger so maintainers can request walltime runs with `@codspeed walltime`
- only include `codspeed-macro` runner matrix rows on pushes to `main` or those explicit walltime comments

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "yaml ok"'`
- `git diff --check`

## Notes

The walltime comment trigger is limited to PR comments from `OWNER`, `MEMBER`, or `COLLABORATOR` accounts so arbitrary commenters cannot schedule the CodSpeed Macro runner.