### PR TITLE
Options to disable tree decomposition

### DIFF
--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -1159,6 +1159,7 @@ pub(crate) fn tree_decompose_and_plan(
     ctx: PlanningContext,
     strat: PlanStrategy,
     actions: ActionId,
+    no_decomp: bool,
 ) -> Plan {
     macro_rules! fast_path {
         () => {{
@@ -1175,7 +1176,7 @@ pub(crate) fn tree_decompose_and_plan(
             })
         }};
     }
-    if ctx.atoms.len() <= 2 {
+    if no_decomp || ctx.atoms.len() <= 2 {
         return fast_path!();
     }
 
@@ -1241,7 +1242,7 @@ pub(crate) fn plan_query(query: Query) -> Plan {
         atoms,
         fun_deps: Arc::new(query.fun_deps),
     };
-    tree_decompose_and_plan(ctx, query.plan_strategy, query.action)
+    tree_decompose_and_plan(ctx, query.plan_strategy, query.action, query.no_decomp)
 }
 
 /// StageInfo is an intermediate stage used to describe the ordering of

--- a/core-relations/src/query.rs
+++ b/core-relations/src/query.rs
@@ -125,6 +125,7 @@ impl<'outer> RuleSetBuilder<'outer> {
                 action: ActionId::new(u32::MAX),
                 plan_strategy: Default::default(),
                 fun_deps: Default::default(),
+                no_decomp: false,
             },
         }
     }
@@ -297,6 +298,12 @@ impl<'outer, 'a> QueryBuilder<'outer, 'a> {
     /// Set the target plan strategy to use to execute this query.
     pub fn set_plan_strategy(&mut self, strategy: PlanStrategy) {
         self.query.plan_strategy = strategy;
+    }
+
+    /// If `true`, the query planner will skip tree-decomposition
+    /// for query decomposition and always use evaluate the query as a single bag.
+    pub fn set_no_decomp(&mut self, no_decomp: bool) {
+        self.query.no_decomp = no_decomp;
     }
 
     /// Create a new variable of the given type.
@@ -1036,4 +1043,9 @@ pub(crate) struct Query {
     pub(crate) action: ActionId,
     pub(crate) plan_strategy: PlanStrategy,
     pub(crate) fun_deps: FunDeps,
+    /// If `true`, skip tree-decomposition during query planning and
+    /// always use the single-bag fast path in
+    /// [`crate::free_join::plan::tree_decompose_and_plan`]. Set via
+    /// [`QueryBuilder::set_no_decomp`].
+    pub(crate) no_decomp: bool,
 }

--- a/egglog-ast/src/generic_ast.rs
+++ b/egglog-ast/src/generic_ast.rs
@@ -99,6 +99,10 @@ where
     /// contexts, allowing primitives that read or write the database
     /// inside queries and actions. Set via the `:naive` rule option.
     pub naive: bool,
+    /// If `true`, this rule skips tree-decomposition during query
+    /// planning and evaluate rules as a single-bag (without decomposing
+    /// it into smaller queries). Set via the `:no-decomp` rule option.
+    pub no_decomp: bool,
 }
 
 /// Change a function entry.

--- a/egglog-ast/src/generic_ast_helpers.rs
+++ b/egglog-ast/src/generic_ast_helpers.rs
@@ -71,7 +71,8 @@ where
             "".into()
         };
         let naive = if self.naive { " :naive" } else { "" };
-        write!(f, ")\n{indent} {ruleset} {name}{naive})")
+        let no_decomp = if self.no_decomp { " :no-decomp" } else { "" };
+        write!(f, ")\n{indent} {ruleset} {name}{naive}{no_decomp})")
     }
 }
 
@@ -184,6 +185,7 @@ where
             name: self.name.clone(),
             ruleset: self.ruleset.clone(),
             naive: self.naive,
+            no_decomp: self.no_decomp,
         }
     }
 
@@ -199,6 +201,7 @@ where
             name: self.name,
             ruleset: self.ruleset,
             naive: self.naive,
+            no_decomp: self.no_decomp,
         }
     }
 
@@ -223,6 +226,7 @@ where
             name: self.name,
             ruleset: self.ruleset,
             naive: self.naive,
+            no_decomp: self.no_decomp,
         }
     }
 

--- a/egglog-bridge/src/rule.rs
+++ b/egglog-bridge/src/rule.rs
@@ -117,6 +117,9 @@ pub(crate) struct Query {
     sole_focus: Option<usize>,
     seminaive: bool,
     plan_strategy: PlanStrategy,
+    /// If `true`, skip tree-decomposition during query planning. See
+    /// [`core_relations::QueryBuilder::set_no_decomp`].
+    no_decomp: bool,
 }
 
 pub struct RuleBuilder<'a> {
@@ -147,6 +150,7 @@ impl EGraph {
                 atoms: Default::default(),
                 add_rule: Default::default(),
                 plan_strategy: Default::default(),
+                no_decomp: false,
             },
         }
     }
@@ -180,6 +184,14 @@ impl RuleBuilder<'_> {
 
     pub(crate) fn set_plan_strategy(&mut self, strategy: PlanStrategy) {
         self.query.plan_strategy = strategy;
+    }
+
+    /// If `true`, the query planner will skip tree-decomposition for
+    /// this rule. Mirrors
+    /// [`core_relations::QueryBuilder::set_no_decomp`]; set from the
+    /// `:no-decomp` rule option or the egglog `--no-decomp` CLI flag.
+    pub fn set_no_decomp(&mut self, no_decomp: bool) {
+        self.query.no_decomp = no_decomp;
     }
 
     /// Get the canonical value of an id in the union-find. An internal-only
@@ -715,6 +727,7 @@ impl Query {
     ) -> (QueryBuilder<'outer, 'a>, Bindings) {
         let mut qb = rsb.new_rule();
         qb.set_plan_strategy(self.plan_strategy);
+        qb.set_no_decomp(self.no_decomp);
         let mut inner = Bindings {
             uf_table: self.uf_table,
             next_ts: None,

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -260,6 +260,7 @@ fn desugar_prove(parser: &mut Parser, span: Span, query: Vec<Fact>) -> Vec<NComm
                 ruleset: ruleset.clone(),
                 name,
                 naive: false,
+                no_decomp: false,
             },
         },
         // run the rule
@@ -348,6 +349,7 @@ fn desugar_rewrite(
             ruleset,
             name,
             naive: false,
+            no_decomp: false,
         },
     }]
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1724,6 +1724,7 @@ where
                     head: rule.head,
                     body: rule.body,
                     naive: rule.naive,
+                    no_decomp: rule.no_decomp,
                 };
                 GenericCommand::Rule { rule }
             }

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -476,11 +476,13 @@ impl Parser {
                     let mut ruleset = String::new();
                     let mut name = String::new();
                     let mut naive = false;
+                    let mut no_decomp = false;
                     for option in self.parse_options(rest)? {
                         match option {
                             (":ruleset", [r]) => ruleset = r.expect_atom("ruleset name")?,
                             (":name", [s]) => name = s.expect_string("rule name")?,
                             (":naive", []) => naive = true,
+                            (":no-decomp", []) => no_decomp = true,
                             _ => return error!(span, "could not parse rule option"),
                         }
                     }
@@ -493,6 +495,7 @@ impl Parser {
                             name,
                             ruleset,
                             naive,
+                            no_decomp,
                         },
                     }]
                 }

--- a/src/ast/proof_global_remover.rs
+++ b/src/ast/proof_global_remover.rs
@@ -125,6 +125,7 @@ fn remove_globals_cmd(cmd: ResolvedNCommand) -> Vec<ResolvedNCommand> {
                 name: rule.name.clone(),
                 ruleset: rule.ruleset.clone(),
                 naive: rule.naive,
+                no_decomp: rule.no_decomp,
             };
             vec![GenericNCommand::NormRule { rule: new_rule }]
         }

--- a/src/ast/remove_globals.rs
+++ b/src/ast/remove_globals.rs
@@ -179,6 +179,7 @@ impl GlobalRemover<'_> {
                     name: rule.name.clone(),
                     ruleset: rule.ruleset.clone(),
                     naive: rule.naive,
+                    no_decomp: rule.no_decomp,
                 };
                 vec![GenericNCommand::NormRule { rule: new_rule }]
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,19 @@ struct Args {
     /// Turns off the seminaive optimization
     #[clap(long)]
     naive: bool,
+    /// Skips tree-decomposition during query planning. Tree decomposition
+    /// tries to decompose complex queries into smaller independent subqueries,
+    /// and evaluate them separately. It has a better theoretical guarantee,
+    /// but sometimes the decomposed subqueries (called "bags") can be much larger
+    /// than the final output, which leads to worse performance sometimes.
+    ///
+    /// Setting this flag forces the query planner to skip tree decomposition and
+    /// evaluate the query as a single bag.
+    ///
+    /// You can also disable tree decomposition on a per-rule basis with the `:no-decomp` label
+    /// on rules.
+    #[clap(long)]
+    no_decomp: bool,
     /// Prints extra information, which can be useful for debugging
     #[clap(long, default_value_t = RunMode::Normal)]
     mode: RunMode,
@@ -93,6 +106,7 @@ pub fn cli(mut egraph: EGraph) {
     EGraph::set_num_threads(args.threads);
     egraph.fact_directory.clone_from(&args.fact_directory);
     egraph.seminaive = !args.naive;
+    egraph.no_decomp = args.no_decomp;
     egraph.set_report_level(args.report_level);
     if args.strict_mode {
         egraph.set_strict_mode(true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,7 @@ pub struct EGraph {
     rulesets: IndexMap<String, Ruleset>,
     pub fact_directory: Option<PathBuf>,
     pub seminaive: bool,
+    pub no_decomp: bool,
     type_info: TypeInfo,
     /// The run report unioned over all runs so far.
     overall_run_report: RunReport,
@@ -379,6 +380,7 @@ impl Default for EGraph {
             rulesets: Default::default(),
             fact_directory: None,
             seminaive: true,
+            no_decomp: false,
             overall_run_report: Default::default(),
             type_info: Default::default(),
             schedulers: Default::default(),
@@ -1013,14 +1015,15 @@ impl EGraph {
         // Pure/Write to Read/Full, so primitives that read or write the
         // database can run inside this rule.
         let seminaive = self.seminaive && !rule.naive;
+        // The `:no-decomp` rule option (and the global `--no-decomp`
+        // flag) skips tree-decomposition in query planning, forcing
+        // the single-bag fast path.
+        let no_decomp = self.no_decomp || rule.no_decomp;
 
         let rule_id = {
-            let mut translator = BackendRule::new(
-                self.backend.new_rule(&rule.name, seminaive),
-                &self.functions,
-                &self.type_info,
-                seminaive,
-            );
+            let mut rb = self.backend.new_rule(&rule.name, seminaive);
+            rb.set_no_decomp(no_decomp);
+            let mut translator = BackendRule::new(rb, &self.functions, &self.type_info, seminaive);
             translator.query(query, false);
             translator.actions(actions)?;
             translator.build()
@@ -1207,6 +1210,7 @@ impl EGraph {
             name: fresh_name.clone(),
             ruleset: fresh_ruleset.clone(),
             naive: false,
+            no_decomp: false,
         };
         let core_rule = rule.to_canonicalized_core_rule(
             &self.type_info,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -325,6 +325,7 @@ pub fn rule(
         name: "".into(),
         ruleset: ruleset.into(),
         naive: false,
+        no_decomp: false,
     };
 
     egraph.run_program(vec![Command::Rule { rule }])
@@ -494,6 +495,7 @@ pub fn rust_rule(
         name: egraph.parser.symbol_gen.fresh(rule_name),
         ruleset: ruleset.into(),
         naive: false,
+        no_decomp: false,
     };
 
     egraph.run_program(vec![Command::Rule { rule }])
@@ -596,6 +598,7 @@ pub fn rust_rule_full(
         // FullPrim action requires `Context::Full`, which is only
         // available in `:naive` rules.
         naive: true,
+        no_decomp: false,
     };
 
     egraph.run_program(vec![Command::Rule { rule }])

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -819,6 +819,7 @@ impl TypeInfo {
             name,
             ruleset,
             naive,
+            no_decomp,
         } = rule;
         let mut constraints = vec![];
 
@@ -874,6 +875,7 @@ impl TypeInfo {
             name: name.clone(),
             ruleset: ruleset.clone(),
             naive: *naive,
+            no_decomp: *no_decomp,
         })
     }
 


### PR DESCRIPTION
This is a temporary fix for #872 and avoids future issues caused by tree decomposition by giving the user the ability to disable it.