### PR TITLE
Fix multi-column column index rebuild ordering

### DIFF
--- a/core-relations/src/hash_index/mod.rs
+++ b/core-relations/src/hash_index/mod.rs
@@ -350,6 +350,11 @@ impl IndexBase for ColumnIndex {
 
         radix_sort_pairs_by_value(&mut pairs);
         if cols.len() > 1 {
+            // Multi-column collection is column-major, so a stable value sort
+            // can leave each value's rows out of order across columns.
+            for group in pairs.chunk_by_mut(|a, b| a.0 == b.0) {
+                group.sort_unstable_by_key(|&(_, row)| row);
+            }
             // Remove duplicates (same value in multiple columns of the same row).
             pairs.dedup();
         }

--- a/core-relations/src/hash_index/tests.rs
+++ b/core-relations/src/hash_index/tests.rs
@@ -1,7 +1,8 @@
-use crate::numeric_id::NumericId;
+use crate::{numeric_id::NumericId, offsets::Offsets};
 
 use crate::{
     TupleIndex,
+    hash_index::ColumnIndex,
     table_shortcuts::{fill_table, v},
     table_spec::{ColumnId, WrappedTable},
 };
@@ -88,4 +89,45 @@ fn basic_updates() {
             });
         }
     }
+}
+
+#[test]
+fn multi_column_column_index_rebuild_orders_each_value_by_row() {
+    let rows = (0..128).map(|i| {
+        let left = if i >= 96 { v(7) } else { v(1_000 + i) };
+        let right = if i < 32 { v(7) } else { v(2_000 + i) };
+        vec![v(i), left, right]
+    });
+    let mut table = WrappedTable::new(fill_table(rows, 1, None, |old, new| {
+        assert_eq!(old, new, "no conflicts in this test");
+        None
+    }));
+    let mut index = Index::new(vec![ColumnId::new(1), ColumnId::new(2)], ColumnIndex::new());
+    index.refresh(table.as_ref());
+
+    empty_execution_state!(es);
+    let start_version = table.version().major;
+    while table.version().major == start_version {
+        table.new_buffer().stage_remove(&[v(0)]);
+        table.merge(&mut es);
+        table.new_buffer().stage_insert(&[v(0), v(1000), v(7)]);
+        table.merge(&mut es);
+    }
+
+    index.refresh(table.as_ref());
+    let key = v(7);
+    let subset = index.get_subset(&key).unwrap();
+    let mut row_ids = Vec::new();
+    subset.offsets(|row_id| row_ids.push(row_id.index()));
+
+    let mut expected = Vec::new();
+    table
+        .scan(table.all().as_ref())
+        .iter()
+        .for_each(|(row_id, row)| {
+            if row[1] == key || row[2] == key {
+                expected.push(row_id.index());
+            }
+        });
+    assert_eq!(row_ids, expected);
 }


### PR DESCRIPTION
## Summary

Fixes a debug-only panic in `ColumnIndex::rebuild_full` for multi-column indexes after a major table-version rebuild.

The regression comes from egraphs-good/egglog#862, specifically commit `70677c590534ba06ecebdaa9f16ac3bb8b1c8a0c` (`cleanup`). That commit switched multi-column `ColumnIndex::rebuild_full` to the value-only radix sort path. Multi-column collection is column-major, so rows for the same value can be ordered like `95..126, 0..30, 127`; `BufferedSubset::Sparse` then creates a `SortedOffsetSlice` from unsorted row IDs.

## Why this stayed hidden

The invariant violation is caught by a `debug_assert!` in `core-relations/src/offsets/mod.rs:136`. The `egglog-experimental` CI job runs `make test`, which uses `cargo nextest run --release`, so that debug assertion is disabled in CI. In release mode, the `math_backoff` test passes even though the sorted-offset invariant is violated.

This was investigated while updating egraphs-good/egglog-experimental#46, but it is not caused by that PR. A clean `egglog-experimental` `origin/main` checkout at `1530719693f56c1186ab867629140c0db185783a`, pinned to egg-smol `codex/split-scheduler-can-stop-report#ebba7bb902bdc1b0f377b6bb22c06ac305912674`, already reproduces the same debug-mode `math_backoff` panic in `core-relations/src/offsets/mod.rs:136`.

So the timeline is:

1. egraphs-good/egglog#862 introduced the multi-column ordering bug.
2. `egglog-experimental` picked up an egg-smol commit containing that bug.
3. `egglog-experimental` CI stayed green because it runs release tests.
4. Local debug-mode validation for egraphs-good/egglog-experimental#46 exposed the latent invariant violation.

## Changes

- For multi-column `ColumnIndex::rebuild_full`, sort each equal-`Value` group by `RowId` before deduplicating.
- Add a regression test that forces a major-version rebuild and checks a multi-column column index returns sorted row IDs.

## Validation

- Confirmed the new test fails on unmodified current `main` with `slice is not sorted`.
- Confirmed `egglog-experimental` `origin/main` fails `cargo test -q math_backoff --test files -- --exact` in debug mode with the same upstream panic.
- Confirmed `egglog-experimental` `origin/main` passes `cargo test --release -q math_backoff --test files -- --exact`, matching CI's release-mode behavior.
- `cargo fmt --check`
- `cargo check -q -p egglog-core-relations`
- `cargo test -q -p egglog-core-relations --lib multi_column_column_index_rebuild_orders_each_value_by_row`
- `cargo test -q -p egglog-core-relations --lib`
