### PR TITLE
Cardinality-aware tree decomposition

### DIFF
--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -1572,6 +1572,81 @@ impl<'a> JoinState<'a> {
                 mode,
                 bind,
                 to_intersect,
+            } if leaf_scans[cur]
+                && to_intersect.is_empty()
+                && matches!(
+                    mode,
+                    MatScanMode::Full | MatScanMode::KeyOnly | MatScanMode::Value(_)
+                ) =>
+            {
+                // Leaf-scan factorization for FusedIntersectMat: flatten the materialization into
+                // one `TaggedRowBuffer`, push it onto `binding_sets`, and recurse to the leaf once.
+                let cover_mat = binding_info.materializations[*cover].clone();
+                let vars: SmallVec<[Variable; 4]> = bind.iter().map(|(_, v)| *v).collect();
+                let mut buf = TaggedRowBuffer::new_inline(bind.len());
+                let mut row_scratch: SmallVec<[Value; 8]> = SmallVec::new();
+                match mode {
+                    MatScanMode::Full => {
+                        for group in cover_mat.iter() {
+                            let group_key = group.0;
+                            let group_key_len = group_key.len();
+                            for non_keys in group.1.iter() {
+                                row_scratch.clear();
+                                for (col, _) in bind.iter() {
+                                    let val = if col.index() < group_key_len {
+                                        group_key[col.index()]
+                                    } else {
+                                        non_keys[col.index() - group_key_len]
+                                    };
+                                    row_scratch.push(val);
+                                }
+                                buf.add_row(RowId::new(0), &row_scratch);
+                            }
+                        }
+                    }
+                    MatScanMode::KeyOnly => {
+                        for group in cover_mat.iter() {
+                            let group_key = group.0;
+                            row_scratch.clear();
+                            for (col, _) in bind.iter() {
+                                debug_assert!(col.index() < group_key.len());
+                                row_scratch.push(group_key[col.index()]);
+                            }
+                            buf.add_row(RowId::new(0), &row_scratch);
+                        }
+                    }
+                    MatScanMode::Value(index_vars) => {
+                        let keys: Vec<Value> = index_vars
+                            .iter()
+                            .map(|var| binding_info.bindings[*var])
+                            .collect();
+                        if let Some(group) = cover_mat.get(&keys) {
+                            for vals in group.iter() {
+                                debug_assert!(vals.len() == bind.len());
+                                row_scratch.clear();
+                                for (col, _) in bind.iter() {
+                                    row_scratch.push(vals[col.index()]);
+                                }
+                                buf.add_row(RowId::new(0), &row_scratch);
+                            }
+                        }
+                    }
+                    MatScanMode::Lookup(_) => unreachable!("guarded above"),
+                }
+                if buf.is_empty() {
+                    return;
+                }
+                binding_info.binding_sets.push((vars, Arc::new(buf)));
+                let mut updates = FrameUpdates::with_capacity(1);
+                updates.finish_frame();
+                drain_updates!(updates);
+                binding_info.binding_sets.pop();
+            }
+            JoinStage::FusedIntersectMat {
+                cover,
+                mode,
+                bind,
+                to_intersect,
             } => {
                 let cover_mat = binding_info.materializations[*cover].clone();
                 let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
@@ -2234,9 +2309,11 @@ fn sort_plan_by_size(
 }
 
 /// Recompute `leaf_scans[i]` for every position `i` in `[start, order.len())` against the
-/// current order. A position is a leaf scan iff its stage is a `FusedIntersect` with empty
-/// `to_intersect`, no later stage references the same cover atom, and no later
-/// `FusedIntersectMat { mode: Value | Lookup }` reads any of the bound variables.
+/// current order. A position is a leaf scan iff its stage is either a `FusedIntersect` or a
+/// `FusedIntersectMat { mode: Full | KeyOnly | Value }`, both with empty `to_intersect`, AND no
+/// later stage either (a) for `FusedIntersect`, references the same cover atom, or (b) reads
+/// any of the bound variables as a scalar via `FusedIntersectMat { mode: Value | Lookup }`.
+/// `FusedIntersectMat::Lookup` itself binds nothing, so it is never marked a leaf scan.
 fn recompute_leaf_scans(
     order: &InstrOrder,
     leaf_scans: &mut LeafScans,
@@ -2252,7 +2329,21 @@ fn recompute_leaf_scans(
                 to_intersect,
             } if to_intersect.is_empty() => {
                 let vars: SmallVec<[Variable; 4]> = bind.iter().map(|(_, v)| *v).collect();
-                (cover.to_index.atom, vars)
+                (Some(cover.to_index.atom), vars)
+            }
+            JoinStage::FusedIntersectMat {
+                mode,
+                bind,
+                to_intersect,
+                ..
+            } if to_intersect.is_empty()
+                && matches!(
+                    mode,
+                    MatScanMode::Full | MatScanMode::KeyOnly | MatScanMode::Value(_)
+                ) =>
+            {
+                let vars: SmallVec<[Variable; 4]> = bind.iter().map(|(_, v)| *v).collect();
+                (None, vars)
             }
             _ => {
                 leaf_scans[i] = false;
@@ -2263,7 +2354,9 @@ fn recompute_leaf_scans(
         for j in (i + 1)..order.len() {
             match &instrs[order.get(j)] {
                 JoinStage::Intersect { scans, .. } => {
-                    if scans.iter().any(|scan| scan.atom == cover_atom) {
+                    if let Some(ca) = cover_atom
+                        && scans.iter().any(|scan| scan.atom == ca)
+                    {
                         blocked = true;
                         break;
                     }
@@ -2273,10 +2366,9 @@ fn recompute_leaf_scans(
                     to_intersect,
                     ..
                 } => {
-                    if cover.to_index.atom == cover_atom
-                        || to_intersect
-                            .iter()
-                            .any(|(s, _)| s.to_index.atom == cover_atom)
+                    if let Some(ca) = cover_atom
+                        && (cover.to_index.atom == ca
+                            || to_intersect.iter().any(|(s, _)| s.to_index.atom == ca))
                     {
                         blocked = true;
                         break;
@@ -2285,9 +2377,8 @@ fn recompute_leaf_scans(
                 JoinStage::FusedIntersectMat {
                     mode, to_intersect, ..
                 } => {
-                    if to_intersect
-                        .iter()
-                        .any(|(s, _)| s.to_index.atom == cover_atom)
+                    if let Some(ca) = cover_atom
+                        && to_intersect.iter().any(|(s, _)| s.to_index.atom == ca)
                     {
                         blocked = true;
                         break;

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -920,12 +920,14 @@ impl<'a> JoinState<'a> {
             }
         }
         let mut order = InstrOrder::from_iter(0..stages.instrs.len());
-        sort_plan_by_size(&mut order, 0, &stages.instrs, binding_info);
+        let mut leaf_scans: LeafScans = smallvec::smallvec![false; stages.instrs.len()];
+        sort_plan_by_size(&mut order, &mut leaf_scans, 0, &stages.instrs, binding_info);
         self.run_plan(
             stages,
             atoms,
             action,
             &mut order,
+            &mut leaf_scans,
             0,
             binding_info,
             action_buf,
@@ -947,6 +949,7 @@ impl<'a> JoinState<'a> {
         atoms: &'buf Arc<DenseIdMap<AtomId, Atom>>,
         action: A,
         instr_order: &mut InstrOrder,
+        leaf_scans: &mut LeafScans,
         cur: usize,
         binding_info: &mut BindingInfo,
         action_buf: &mut BUF,
@@ -971,7 +974,7 @@ impl<'a> JoinState<'a> {
         if cur_size > 32 && cur % 3 == 1 && cur < instr_order.len() - 1 {
             // If we have a reasonable number of tuples to process, adjust the variable order every
             // 3 rounds, but always make sure to readjust on the second roung.
-            sort_plan_by_size(instr_order, cur, &stages.instrs, binding_info);
+            sort_plan_by_size(instr_order, leaf_scans, cur, &stages.instrs, binding_info);
             cur_size = estimate_size(&stages.instrs[instr_order.get(cur)], binding_info);
         }
 
@@ -1014,6 +1017,7 @@ impl<'a> JoinState<'a> {
                                     atoms,
                                     action,
                                     instr_order,
+                                    leaf_scans,
                                     cur + 1,
                                     binding_info,
                                     action_buf,
@@ -1036,12 +1040,14 @@ impl<'a> JoinState<'a> {
                     BorrowedLocalState {
                         binding_info,
                         instr_order,
+                        leaf_scans,
                         updates: &mut $updates,
                     },
                     move || exec_state_for_factory.clone(),
                     move |BorrowedLocalState {
                               binding_info,
                               instr_order,
+                              leaf_scans,
                               updates,
                           },
                           buf| {
@@ -1069,6 +1075,7 @@ impl<'a> JoinState<'a> {
                                     atoms,
                                     action,
                                     instr_order,
+                                    leaf_scans,
                                     cur + 1,
                                     binding_info,
                                     buf,
@@ -1370,92 +1377,86 @@ impl<'a> JoinState<'a> {
                 cover,
                 bind,
                 to_intersect,
-                is_leaf_scan: true,
             } if to_intersect.is_empty() => {
+                let is_leaf_scan = leaf_scans[cur];
                 let cover_atom = cover.to_index.atom;
                 if binding_info.has_empty_subset(cover_atom) {
                     return;
                 }
-                let table = self.db.tables[atoms[cover_atom].table].table.as_ref();
-                let cover_node = binding_info.unwrap_val(cover_atom);
-                let cover_subset = cover_node.subset.as_ref();
+                if is_leaf_scan {
+                    let table = self.db.tables[atoms[cover_atom].table].table.as_ref();
+                    let cover_node = binding_info.unwrap_val(cover_atom);
+                    let cover_subset = cover_node.subset.as_ref();
 
-                let proj = SmallVec::<[ColumnId; 4]>::from_iter(bind.iter().map(|(col, _)| *col));
-                let vars = bind.iter().map(|(_, var)| *var).collect();
-                let mut buf = TaggedRowBuffer::new_inline(bind.len());
-                table.scan_project(
-                    cover_subset,
-                    &proj,
-                    Offset::new(0),
-                    usize::MAX,
-                    &cover.constraints,
-                    &mut buf,
-                );
-
-                if buf.is_empty() {
-                    return;
-                }
-
-                binding_info.binding_sets.push((vars, Arc::new(buf)));
-                let mut updates = FrameUpdates::with_capacity(1);
-                updates.finish_frame();
-                drain_updates!(updates);
-                binding_info.binding_sets.pop();
-                binding_info.move_back_node(cover_atom, cover_node);
-            }
-            JoinStage::FusedIntersect {
-                cover,
-                bind,
-                to_intersect,
-                is_leaf_scan: false,
-            } if to_intersect.is_empty() => {
-                let cover_atom = cover.to_index.atom;
-                if binding_info.has_empty_subset(cover_atom) {
-                    return;
-                }
-                let proj = SmallVec::<[ColumnId; 4]>::from_iter(bind.iter().map(|(col, _)| *col));
-                let cover_node = binding_info.unwrap_val(cover_atom);
-                let cover_subset = cover_node.subset.as_ref();
-                let mut cur = Offset::new(0);
-                let mut buffer = TaggedRowBuffer::new(bind.len());
-                let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
-                loop {
-                    buffer.clear();
-                    let table = &self.db.tables[atoms[cover_atom].table].table;
-                    let next = table.scan_project(
+                    let proj =
+                        SmallVec::<[ColumnId; 4]>::from_iter(bind.iter().map(|(col, _)| *col));
+                    let vars = bind.iter().map(|(_, var)| *var).collect();
+                    let mut buf = TaggedRowBuffer::new_inline(bind.len());
+                    table.scan_project(
                         cover_subset,
                         &proj,
-                        cur,
-                        chunk_size,
+                        Offset::new(0),
+                        usize::MAX,
                         &cover.constraints,
-                        &mut buffer,
+                        &mut buf,
                     );
-                    for (row, key) in buffer.iter() {
-                        updates.refine_atom_dense(cover_atom, OffsetRange::new(row, row.inc()));
-                        // bind the values
-                        for (i, (_, var)) in bind.iter().enumerate() {
-                            updates.push_binding(*var, key[i]);
-                        }
-                        updates.finish_frame();
-                        if updates.frames() >= chunk_size {
-                            drain_updates!(updates);
-                        }
+
+                    if buf.is_empty() {
+                        binding_info.move_back_node(cover_atom, cover_node);
+                        return;
                     }
-                    if let Some(next) = next {
-                        cur = next;
-                        continue;
+
+                    binding_info.binding_sets.push((vars, Arc::new(buf)));
+                    let mut updates = FrameUpdates::with_capacity(1);
+                    updates.finish_frame();
+                    drain_updates!(updates);
+                    binding_info.binding_sets.pop();
+                    binding_info.move_back_node(cover_atom, cover_node);
+                } else {
+                    let proj =
+                        SmallVec::<[ColumnId; 4]>::from_iter(bind.iter().map(|(col, _)| *col));
+                    let cover_node = binding_info.unwrap_val(cover_atom);
+                    let cover_subset = cover_node.subset.as_ref();
+                    let mut offset = Offset::new(0);
+                    let mut buffer = TaggedRowBuffer::new(bind.len());
+                    let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
+                    loop {
+                        buffer.clear();
+                        let table = &self.db.tables[atoms[cover_atom].table].table;
+                        let next = table.scan_project(
+                            cover_subset,
+                            &proj,
+                            offset,
+                            chunk_size,
+                            &cover.constraints,
+                            &mut buffer,
+                        );
+                        for (row, key) in buffer.iter() {
+                            updates.refine_atom_dense(cover_atom, OffsetRange::new(row, row.inc()));
+                            // bind the values
+                            for (i, (_, var)) in bind.iter().enumerate() {
+                                updates.push_binding(*var, key[i]);
+                            }
+                            updates.finish_frame();
+                            if updates.frames() >= chunk_size {
+                                drain_updates!(updates);
+                            }
+                        }
+                        if let Some(next) = next {
+                            offset = next;
+                            continue;
+                        }
+                        break;
                     }
-                    break;
+                    drain_updates!(updates);
+                    // Restore the subsets we swapped out.
+                    binding_info.move_back_node(cover_atom, cover_node);
                 }
-                drain_updates!(updates);
-                // Restore the subsets we swapped out.
-                binding_info.move_back_node(cover_atom, cover_node);
             }
             JoinStage::FusedIntersect {
                 cover,
                 bind,
                 to_intersect,
-                is_leaf_scan: _,
             } => {
                 let cover_atom = cover.to_index.atom;
                 if binding_info.has_empty_subset(cover_atom) {
@@ -2209,6 +2210,7 @@ fn num_intersected_rels(join_stage: &JoinStage) -> i32 {
 
 fn sort_plan_by_size(
     order: &mut InstrOrder,
+    leaf_scans: &mut LeafScans,
     start: usize,
     instrs: &[JoinStage],
     binding_info: &mut BindingInfo,
@@ -2228,6 +2230,79 @@ fn sort_plan_by_size(
         }
     }
     sort_plan_by_size_inner(order, last_pos..instrs.len(), instrs, binding_info);
+    recompute_leaf_scans(order, leaf_scans, instrs, start);
+}
+
+/// Recompute `leaf_scans[i]` for every position `i` in `[start, order.len())` against the
+/// current order. A position is a leaf scan iff its stage is a `FusedIntersect` with empty
+/// `to_intersect`, no later stage references the same cover atom, and no later
+/// `FusedIntersectMat { mode: Value | Lookup }` reads any of the bound variables.
+fn recompute_leaf_scans(
+    order: &InstrOrder,
+    leaf_scans: &mut LeafScans,
+    instrs: &[JoinStage],
+    start: usize,
+) {
+    for i in start..order.len() {
+        let stage_idx = order.get(i);
+        let (cover_atom, bind_vars) = match &instrs[stage_idx] {
+            JoinStage::FusedIntersect {
+                cover,
+                bind,
+                to_intersect,
+            } if to_intersect.is_empty() => {
+                let vars: SmallVec<[Variable; 4]> = bind.iter().map(|(_, v)| *v).collect();
+                (cover.to_index.atom, vars)
+            }
+            _ => {
+                leaf_scans[i] = false;
+                continue;
+            }
+        };
+        let mut blocked = false;
+        for j in (i + 1)..order.len() {
+            match &instrs[order.get(j)] {
+                JoinStage::Intersect { scans, .. } => {
+                    if scans.iter().any(|scan| scan.atom == cover_atom) {
+                        blocked = true;
+                        break;
+                    }
+                }
+                JoinStage::FusedIntersect {
+                    cover,
+                    to_intersect,
+                    ..
+                } => {
+                    if cover.to_index.atom == cover_atom
+                        || to_intersect
+                            .iter()
+                            .any(|(s, _)| s.to_index.atom == cover_atom)
+                    {
+                        blocked = true;
+                        break;
+                    }
+                }
+                JoinStage::FusedIntersectMat {
+                    mode, to_intersect, ..
+                } => {
+                    if to_intersect
+                        .iter()
+                        .any(|(s, _)| s.to_index.atom == cover_atom)
+                    {
+                        blocked = true;
+                        break;
+                    }
+                    if let MatScanMode::Value(vars) | MatScanMode::Lookup(vars) = mode
+                        && vars.iter().any(|v| bind_vars.contains(v))
+                    {
+                        blocked = true;
+                        break;
+                    }
+                }
+            }
+        }
+        leaf_scans[i] = !blocked;
+    }
 }
 
 fn sort_plan_by_size_inner(
@@ -2365,8 +2440,14 @@ impl InstrOrder {
     }
 }
 
+/// Per-position leaf-scan flags. `leaf_scans[i] == true` means the stage currently scheduled at
+/// position `i` (i.e. `instrs[instr_order.get(i)]`) can take the factorized-binding fast path.
+/// Recomputed by [`sort_plan_by_size`] whenever the order changes.
+type LeafScans = SmallVec<[bool; 8]>;
+
 struct BorrowedLocalState<'a> {
     instr_order: &'a mut InstrOrder,
+    leaf_scans: &'a mut LeafScans,
     binding_info: &'a mut BindingInfo,
     updates: &'a mut FrameUpdates,
 }
@@ -2375,6 +2456,7 @@ impl BorrowedLocalState<'_> {
     fn clone_state(&mut self) -> LocalState {
         LocalState {
             instr_order: self.instr_order.clone(),
+            leaf_scans: self.leaf_scans.clone(),
             binding_info: self.binding_info.clone(),
             updates: std::mem::take(self.updates),
         }
@@ -2383,6 +2465,7 @@ impl BorrowedLocalState<'_> {
 
 struct LocalState {
     instr_order: InstrOrder,
+    leaf_scans: LeafScans,
     binding_info: BindingInfo,
     updates: FrameUpdates,
 }
@@ -2391,6 +2474,7 @@ impl LocalState {
     fn borrow_mut<'a>(&'a mut self) -> BorrowedLocalState<'a> {
         BorrowedLocalState {
             instr_order: &mut self.instr_order,
+            leaf_scans: &mut self.leaf_scans,
             binding_info: &mut self.binding_info,
             updates: &mut self.updates,
         }

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -886,8 +886,6 @@ impl ColumnCardEst<'_> {
     }
 
     pub fn col_uniqueness(&self, table: TableId, col: ColumnId) -> ColUniqueness {
-        // dbg!(self.db.tables.iter().map(|(id, info)| (id, info.name.as_deref())).collect::<Vec<_>>());
-        // dbg!(table, col);
         let col_idx = get_column_index_from_tableinfo(&self.db.tables[table], col);
         let table = &self.db.tables[table].table;
         ColUniqueness {
@@ -903,6 +901,17 @@ impl std::fmt::Debug for ColumnCardEst<'_> {
     }
 }
 
+/// A coarse cardinality estimate for a column of a table, used by the query
+/// planner to decide which variable to eliminate next during tree
+/// decomposition.
+///
+/// `table_size` is the number of rows in the (sub)table and `col_size` is the
+/// number of distinct values in the column. Their ratio
+/// (`table_size / col_size`) approximates the average number of rows that share
+/// a given value of the column: a smaller ratio means the column is closer to
+/// being unique and therefore cheaper to join on. [`ColUniqueness`] is ordered
+/// by this ratio (see the [`Ord`] impl), so the planner prefers variables with
+/// the most selective (most unique) columns.
 #[derive(Copy, Clone, Debug)]
 pub struct ColUniqueness {
     table_size: usize,
@@ -919,6 +928,7 @@ impl Default for ColUniqueness {
 }
 
 impl ColUniqueness {
+    #[allow(dead_code)] // not yet wired up into the planner
     fn scale(&self, subset_size: usize) -> ColUniqueness {
         if self.table_size == 0 || subset_size == 0 {
             return ColUniqueness {
@@ -928,16 +938,17 @@ impl ColUniqueness {
         }
         ColUniqueness {
             table_size: subset_size,
-            col_size: self.col_size * subset_size / self.table_size,
+            col_size: self.col_size.saturating_mul(subset_size) / self.table_size,
         }
     }
     fn join(&self, other: &ColUniqueness) -> ColUniqueness {
         ColUniqueness {
-            table_size: self.table_size * other.table_size,
+            table_size: self.table_size.saturating_mul(other.table_size),
             col_size: self.col_size.max(other.col_size),
         }
     }
 
+    #[allow(dead_code)] // not yet wired up into the planner
     fn col_size(&self) -> usize {
         self.col_size
     }

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -816,7 +816,7 @@ impl Database {
     }
 
     pub(crate) fn plan_query(&mut self, query: Query) -> Plan {
-        plan::plan_query(query)
+        plan::plan_query(query, ColumnCardEst::new(self))
     }
 }
 
@@ -873,4 +873,93 @@ fn get_column_index_from_tableinfo(table_info: &TableInfo, col: ColumnId) -> Has
             .needs_refresh(table_info.table.as_ref())
     );
     index
+}
+
+#[derive(Clone)]
+pub struct ColumnCardEst<'a> {
+    db: &'a Database,
+}
+
+impl ColumnCardEst<'_> {
+    pub fn new(db: &Database) -> ColumnCardEst<'_> {
+        ColumnCardEst { db }
+    }
+
+    pub fn col_uniqueness(&self, table: TableId, col: ColumnId) -> ColUniqueness {
+        // dbg!(self.db.tables.iter().map(|(id, info)| (id, info.name.as_deref())).collect::<Vec<_>>());
+        // dbg!(table, col);
+        let col_idx = get_column_index_from_tableinfo(&self.db.tables[table], col);
+        let table = &self.db.tables[table].table;
+        ColUniqueness {
+            col_size: col_idx.get().unwrap().len(),
+            table_size: table.len(),
+        }
+    }
+}
+
+impl std::fmt::Debug for ColumnCardEst<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ColumnCardEst").finish_non_exhaustive()
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct ColUniqueness {
+    table_size: usize,
+    col_size: usize,
+}
+
+impl Default for ColUniqueness {
+    fn default() -> ColUniqueness {
+        ColUniqueness {
+            table_size: 1,
+            col_size: 1,
+        }
+    }
+}
+
+impl ColUniqueness {
+    fn scale(&self, subset_size: usize) -> ColUniqueness {
+        if self.table_size == 0 || subset_size == 0 {
+            return ColUniqueness {
+                table_size: 0,
+                col_size: 0,
+            };
+        }
+        ColUniqueness {
+            table_size: subset_size,
+            col_size: self.col_size * subset_size / self.table_size,
+        }
+    }
+    fn join(&self, other: &ColUniqueness) -> ColUniqueness {
+        ColUniqueness {
+            table_size: self.table_size * other.table_size,
+            col_size: self.col_size.max(other.col_size),
+        }
+    }
+
+    fn col_size(&self) -> usize {
+        self.col_size
+    }
+}
+
+impl PartialEq for ColUniqueness {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for ColUniqueness {}
+
+impl PartialOrd for ColUniqueness {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ColUniqueness {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.table_size.saturating_mul(other.col_size))
+            .cmp(&(other.table_size.saturating_mul(self.col_size)))
+    }
 }

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -48,7 +48,7 @@ use std::{collections::BTreeMap, iter, mem, sync::Arc};
 
 use crate::{
     TableId,
-    free_join::ProcessedConstraints,
+    free_join::{ColUniqueness, ColumnCardEst, ProcessedConstraints},
     numeric_id::{DenseIdMap, NumericId},
     query::{FunDeps, SymbolMap},
 };
@@ -147,7 +147,6 @@ pub(crate) enum JoinStage {
         bind: SmallVec<[(ColumnId, Variable); 2]>,
         // to_intersect.1 is the index into the cover atom.
         to_intersect: Vec<(ScanSpec, SmallVec<[ColumnId; 2]>)>,
-        is_leaf_scan: bool,
     },
     FusedIntersectMat {
         cover: MatId,
@@ -157,62 +156,55 @@ pub(crate) enum JoinStage {
     },
 }
 
-impl JoinStage {
-    /// Attempt to fuse two stages into one.
-    ///
-    /// This operation is very conservative right now, it only fuses multiple
-    /// scans that do no filtering whatsoever.
-    fn fuse(&mut self, other: &JoinStage) -> bool {
-        use JoinStage::*;
-        match (&*self, other) {
-            (
-                FusedIntersect {
-                    cover: cover1,
-                    bind: bind1,
-                    to_intersect: to_intersect1,
-                    is_leaf_scan: is_leaf_scan1,
-                },
-                FusedIntersect {
-                    cover: cover2,
-                    bind: bind2,
-                    to_intersect: to_intersect2,
-                    is_leaf_scan: is_leaf_scan2,
-                },
-            ) if cover1.to_index.atom == cover2.to_index.atom
-                && to_intersect1.is_empty()
-                && to_intersect2.is_empty()
-                && (cover1.constraints.is_empty() || cover2.constraints.is_empty()) =>
-            {
-                assert!(!*is_leaf_scan1 && !is_leaf_scan2);
-                let to_index = SubAtom {
-                    atom: cover1.to_index.atom,
-                    vars: cover1
-                        .to_index
-                        .vars
-                        .iter()
-                        .chain(cover2.to_index.vars.iter())
-                        .copied()
-                        .collect(),
-                };
-                let bind = bind1.iter().chain(bind2.iter()).copied().collect();
-                *self = FusedIntersect {
-                    cover: ScanSpec {
-                        to_index,
-                        constraints: cover1
-                            .constraints
-                            .iter()
-                            .chain(cover2.constraints.iter())
-                            .cloned()
-                            .collect(),
-                    },
-                    bind,
-                    to_intersect: Default::default(),
-                    is_leaf_scan: false,
-                };
-                true
+/// Merge every `FusedIntersect { to_intersect: [] }` into the first earlier such stage on the
+/// same cover atom, so each atom contributes at most one single-scan stage. Same-atom no-
+/// `to_intersect` covers can always be merged: their projections share an atom and any
+/// per-atom constraints are produced exactly once by `take_atom_constraints_if_new`.
+fn fuse_single_scans(stages: &mut Vec<JoinStage>) {
+    let mut i = 0;
+    while i < stages.len() {
+        let cur_atom = match &stages[i] {
+            JoinStage::FusedIntersect {
+                cover,
+                to_intersect,
+                ..
+            } if to_intersect.is_empty() => cover.to_index.atom,
+            _ => {
+                i += 1;
+                continue;
             }
-            _ => false,
-        }
+        };
+        let target = (0..i).find(|&j| {
+            matches!(
+                &stages[j],
+                JoinStage::FusedIntersect { cover, to_intersect, .. }
+                    if to_intersect.is_empty() && cover.to_index.atom == cur_atom
+            )
+        });
+        let Some(j) = target else {
+            i += 1;
+            continue;
+        };
+        let JoinStage::FusedIntersect {
+            cover: cover_i,
+            bind: bind_i,
+            ..
+        } = stages.remove(i)
+        else {
+            unreachable!("checked above")
+        };
+        let JoinStage::FusedIntersect {
+            cover: cover_j,
+            bind: bind_j,
+            ..
+        } = &mut stages[j]
+        else {
+            unreachable!("checked above")
+        };
+        cover_j.to_index.vars.extend(cover_i.to_index.vars);
+        cover_j.constraints.extend(cover_i.constraints);
+        bind_j.extend(bind_i);
+        // Don't advance `i`: stages.remove shifts later entries down by one.
     }
 }
 
@@ -341,7 +333,6 @@ impl SinglePlan {
                     cover,
                     bind: _,
                     to_intersect,
-                    is_leaf_scan: _,
                 } => {
                     let cover_atom_name = get_atom(cover.to_index.atom);
                     let cover_cols: Vec<(String, i64)> = cover
@@ -430,6 +421,7 @@ fn next_var_to_eliminate(
     vars: &DenseIdMap<Variable, VarInfo>,
     atoms: &DenseIdMap<AtomId, Atom>,
     fun_deps: &FunDeps,
+    col_est: &ColumnCardEst<'_>,
 ) -> Option<IndexSet<Variable>> {
     let (_var, subquery_vars) = vars
         .iter()
@@ -444,11 +436,28 @@ fn next_var_to_eliminate(
             // Optimization: use functional dependencies to find all variables inferred by the
             // current neightborhood.
             let subquery_vars = fun_deps.closure(subquery_vars);
+            // let subquery_vars:DenseIdMap<_, ()> = subquery_vars.map(|v| (v, ())).collect();
 
             let occ = atoms
                 .iter()
                 .filter(|(_, atom)| atom.vars().any(|v| subquery_vars.contains_key(v)))
                 .count();
+            let inv_selectivity = _vinfo
+                .occurrences
+                .iter()
+                .filter_map(|occ| {
+                    let atom = &atoms[occ.atom];
+                    let table = atom.table;
+                    if table.is_dummy() {
+                        return None;
+                    }
+                    let col = atom.get_col(var).unwrap();
+                    // TODO: plan header before query decomposition so we know the exact
+                    // subset we are handling
+                    Some(col_est.col_uniqueness(table, col))
+                })
+                .fold(ColUniqueness::default(), |a, b| a.join(&b));
+            // ((occ, inv_selectivity), var, subquery_vars)
             (occ, var, subquery_vars)
         })
         .min_by_key(|a| a.0)
@@ -554,7 +563,7 @@ fn update_hypergraph(
 ///
 /// Another invariant we maintain is higher-indexed bags are heavier (closer to the root of the tree decomposition), so they will be evaluated later and constrained
 /// by evaluation of earlier bags.
-fn decompose_into_bags(original_ctx: &PlanningContext) -> Vec<PlanningContext> {
+fn decompose_into_bags<'a>(original_ctx: &PlanningContext<'a>) -> Vec<PlanningContext<'a>> {
     let mut atoms = original_ctx.atoms.clone();
     let mut vars = original_ctx.vars.clone();
 
@@ -568,7 +577,9 @@ fn decompose_into_bags(original_ctx: &PlanningContext) -> Vec<PlanningContext> {
     let mut bags = Vec::new();
 
     // Variable elimination loop
-    while let Some(subquery_vars) = next_var_to_eliminate(&vars, &atoms, &original_ctx.fun_deps) {
+    while let Some(subquery_vars) =
+        next_var_to_eliminate(&vars, &atoms, &original_ctx.fun_deps, &original_ctx.col_est)
+    {
         // Create a fake covering atom to bridge back to the main query
         // Remove hyperedges that only contain subquery variables.
         update_hypergraph(&subquery_vars, &mut vars, &mut atoms);
@@ -594,6 +605,7 @@ fn decompose_into_bags(original_ctx: &PlanningContext) -> Vec<PlanningContext> {
             vars: subquery_var_map,
             atoms: subquery_atoms,
             fun_deps: original_ctx.fun_deps.clone(),
+            col_est: original_ctx.col_est.clone(),
         });
     }
 
@@ -674,14 +686,11 @@ fn decompose_into_bags(original_ctx: &PlanningContext) -> Vec<PlanningContext> {
 
             // Invariant: bigger-numbered bags are heavier and should stay at the root of the tree
             if i < j {
-                let bag = mem::take(&mut bags[i]);
-                bags[j].merge_bag(&bag);
-                bags.remove(i);
+                let bag = bags.remove(i);
+                bags[j - 1].merge_bag(&bag);
             } else {
-                let bag = mem::take(&mut bags[j]);
-                bags[i].merge_bag(&bag);
-                bags.remove(j);
-                i += 1;
+                let bag = bags.remove(j);
+                bags[i - 1].merge_bag(&bag);
             }
             changed = true;
         }
@@ -952,13 +961,6 @@ fn plan_single_bag(
     let (header, mut instrs) = plan_stages(&stripped_bag, strat);
     instrs.splice(0..0, prologue);
     instrs.extend(epilogue);
-    // `plan_gj` decides `is_leaf_scan` based only on the stages it produces, so it cannot
-    // see the prologue/epilogue stages we just spliced in. A leaf scan factorizes its
-    // bound variables into `binding_info.binding_sets` rather than `binding_info.bindings`,
-    // which breaks any later `FusedIntersectMat::Value`/`Lookup` that reads those variables
-    // directly from `bindings`. Downgrade bad leaf scans now that the full instruction
-    // sequence is known.
-    revert_bad_leaf_scans(&mut instrs);
 
     let stages = JoinStages {
         instrs: Arc::new(instrs),
@@ -1051,66 +1053,6 @@ fn fuse_last_stage(
     last_block.instrs = Arc::new(instrs);
 
     (blocks, last_block)
-}
-
-/// Downgrade any `FusedIntersect { is_leaf_scan: true, .. }` whose factorized bindings
-/// would be observed as missing by a later stage.
-///
-/// `is_leaf_scan` instructs the executor to factorize the stage's bindings into
-/// `BindingInfo::binding_sets` instead of materializing them into `BindingInfo::bindings`.
-/// That is OK only if no subsequent stage in the same `JoinStages` reads any of those
-/// variables as a scalar value from `bindings`. The only stages that do so are
-/// `FusedIntersectMat::Value` / `Lookup`, whose `index_vars` are looked up directly.
-///
-/// `plan_gj` performs its own (cover-atom-based) check, but that runs before prologue /
-/// epilogue stages are spliced into the instruction list, so it cannot detect
-/// `FusedIntersectMat` lookups that come from the epilogue. This pass closes that gap.
-///
-/// # Example
-///
-/// Suppose `plan_gj` produces the following two stages for a bag, where stage 0 is
-/// the last `FusedIntersect` and binds variable `y` from atom `A` via a leaf scan
-/// (no atom later in `plan_gj`'s output reuses `A`):
-///
-/// ```text
-///   stage 0: FusedIntersect { cover: A, bind: [(col, y)], is_leaf_scan: true, ... }
-/// ```
-///
-/// `plan_single_bag` then splices an epilogue that looks up an earlier block's
-/// materialization keyed on `y`:
-///
-/// ```text
-///   stage 0: FusedIntersect { cover: A, bind: [(col, y)], is_leaf_scan: true, ... }
-///   stage 1: FusedIntersectMat { mode: Lookup([y]), ... }
-/// ```
-///
-/// With `is_leaf_scan: true`, stage 0 puts `y` into `binding_sets` instead of
-/// `bindings`. Stage 1 then tries `binding_info.bindings[y]` and panics on a missing
-/// entry. This pass detects the overlap (`y ∈ bound_vars ∩ Lookup`'s index_vars) and
-/// flips stage 0's `is_leaf_scan` back to `false`.
-fn revert_bad_leaf_scans(stages: &mut [JoinStage]) {
-    for i in 0..stages.len() {
-        let bound_vars: SmallVec<[Variable; 4]> = match &stages[i] {
-            JoinStage::FusedIntersect {
-                bind,
-                is_leaf_scan: true,
-                ..
-            } => bind.iter().map(|(_, v)| *v).collect(),
-            _ => continue,
-        };
-
-        let needs_scalar = ((i + 1)..stages.len()).any(|j| match &stages[j] {
-            JoinStage::FusedIntersectMat {
-                mode: MatScanMode::Value(vars) | MatScanMode::Lookup(vars),
-                ..
-            } => vars.iter().any(|v| bound_vars.contains(v)),
-            _ => false,
-        });
-
-        if needs_scalar && let JoinStage::FusedIntersect { is_leaf_scan, .. } = &mut stages[i] {
-            *is_leaf_scan = false;
-        }
-    }
 }
 
 /// Eagerly lift materialization lookups up
@@ -1235,12 +1177,13 @@ pub(crate) fn tree_decompose_and_plan(
     })
 }
 
-pub(crate) fn plan_query(query: Query) -> Plan {
+pub(crate) fn plan_query<'a>(query: Query, col_est: ColumnCardEst<'a>) -> Plan {
     let atoms = query.atoms;
     let ctx = PlanningContext {
         vars: query.var_info,
         atoms,
         fun_deps: Arc::new(query.fun_deps),
+        col_est,
     };
     tree_decompose_and_plan(ctx, query.plan_strategy, query.action, query.no_decomp)
 }
@@ -1262,15 +1205,16 @@ struct StageInfo {
 }
 
 /// Immutable context for query planning containing references to query metadata.
-#[derive(Debug, Clone, Default)]
-pub(crate) struct PlanningContext {
+#[derive(Debug, Clone)]
+pub(crate) struct PlanningContext<'a> {
     vars: DenseIdMap<Variable, VarInfo>,
     atoms: DenseIdMap<AtomId, Atom>,
     fun_deps: Arc<FunDeps>,
+    col_est: ColumnCardEst<'a>,
 }
 
-impl PlanningContext {
-    fn is_subsumed_by(&self, bag2: &PlanningContext) -> bool {
+impl<'a> PlanningContext<'a> {
+    fn is_subsumed_by(&self, bag2: &PlanningContext<'a>) -> bool {
         self.is_subsumed_by_vars(&bag2.vars)
     }
 
@@ -1278,7 +1222,7 @@ impl PlanningContext {
         self.vars.iter().all(|(var, _)| bag2.contains_key(var))
     }
 
-    fn merge_bag(&mut self, bag2: &PlanningContext) {
+    fn merge_bag(&mut self, bag2: &PlanningContext<'a>) {
         for (var, vinfo) in bag2.vars.iter() {
             if self.vars.contains_key(var) {
                 for new_occ in vinfo.occurrences.iter().cloned() {
@@ -1302,10 +1246,10 @@ impl PlanningContext {
         }
     }
 
-    fn common_vars_with<'a>(
+    fn common_vars_with<'b>(
         &'a self,
-        other: &'a PlanningContext,
-    ) -> impl Iterator<Item = Variable> + 'a {
+        other: &'b PlanningContext<'a>,
+    ) -> impl Iterator<Item = Variable> + 'b {
         self.vars
             .iter()
             .filter(|(var, _)| other.vars.contains_key(*var))
@@ -1420,15 +1364,15 @@ impl<'a> BucketQueue<'a> {
 
 /// Build join headers from fast constraints and compute remaining constraints for planning.
 /// Returns (headers, remaining_constraints) tuple.
-fn plan_headers(
-    ctx: &PlanningContext,
+fn plan_headers<'a, 'b>(
+    ctx: &'b PlanningContext<'a>,
 ) -> (
     Vec<JoinHeader>,
     DenseIdMap<
         AtomId,
         (
             usize, /* The approx size of the subset matching the constraints. */
-            &Pooled<Vec<Constraint>>,
+            &'b Pooled<Vec<Constraint>>,
         ),
     >,
 ) {
@@ -1578,50 +1522,45 @@ fn get_next_freejoin_stage(
 }
 
 /// Plan generic join queries (one variable per stage).
+///
+/// Variables are visited in their natural id order. Runtime `sort_plan_by_size` reorders stages
+/// anyway, so static ordering only needs to be deterministic; [`fuse_single_scans`] collapses
+/// any same-atom single-scans afterwards regardless of where they ended up.
 fn plan_gj(
     ctx: &PlanningContext,
     state: &mut PlanningState,
-    remaining_constraints: &DenseIdMap<AtomId, (usize, &Pooled<Vec<Constraint>>)>,
+    _remaining_constraints: &DenseIdMap<AtomId, (usize, &Pooled<Vec<Constraint>>)>,
     stages: &mut Vec<JoinStage>,
 ) {
-    // First, map all variables to the size of the smallest atom in which they appear:
-    let mut min_sizes = Vec::with_capacity(ctx.vars.n_ids());
+    let mut planned_vars = Vec::with_capacity(ctx.vars.n_ids());
     let mut atoms_hit = AtomSet::with_capacity(ctx.atoms.n_ids());
     for (var, var_info) in ctx.vars.iter() {
         let n_occs = var_info.occurrences.len();
-        if n_occs == 1 && !var_info.used_in_rhs {
-            // Do not plan this one. Unless (see below).
+        if n_occs == 0 {
+            // No occurrences: ignore (may be bound on the RHS or simply unused).
             continue;
         }
-        if let Some(min_size) = var_info
-            .occurrences
-            .iter()
-            .map(|subatom| {
-                atoms_hit.set(subatom.atom.index(), true);
-                remaining_constraints[subatom.atom].0
-            })
-            .min()
-        {
-            min_sizes.push((var, min_size, n_occs));
+        if n_occs == 1 && !var_info.used_in_rhs {
+            // Skip for now; we'll plan it below only if its atom is otherwise unmentioned.
+            continue;
         }
-        // If the variable has no ocurrences, it may be bound on the RHS of a
-        // rule (or it may just be unused). Either way, we will ignore it when
-        // planning the query.
+        for subatom in var_info.occurrences.iter() {
+            atoms_hit.set(subatom.atom.index(), true);
+        }
+        planned_vars.push(var);
     }
     for (var, var_info) in ctx.vars.iter() {
         if var_info.occurrences.len() == 1 && !var_info.used_in_rhs {
-            // We skipped this variable the first time around because it
-            // looks "unused". If it belongs to an atom that otherwise has
-            // gone unmentioned, though, we need to plan it anyway.
-            let atom = var_info.occurrences[0].atom;
-            if !atoms_hit.contains(atom.index()) {
-                min_sizes.push((var, remaining_constraints[atom].0, 1));
+            // The variable looks "unused" but we still need to touch its atom if nothing else
+            // has so the join visits every relation.
+            let subatom = &var_info.occurrences[0];
+            if !atoms_hit.contains(subatom.atom.index()) {
+                atoms_hit.set(subatom.atom.index(), true);
+                planned_vars.push(var);
             }
         }
     }
-    // Sort ascending by size, then descending by number of occurrences.
-    min_sizes.sort_by_key(|(_, size, occs)| (*size, -(*occs as i64)));
-    for (var, _, _) in min_sizes {
+    for var in planned_vars {
         let occ = ctx.vars[var].occurrences[0].clone();
         let mut info = StageInfo {
             cover: occ,
@@ -1633,47 +1572,9 @@ fn plan_gj(
                 .push((occ.clone(), smallvec![ColumnId::new(0); occ.vars.len()]));
         }
 
-        let next_stage = compile_stage(ctx, state, info);
-        if let Some(prev) = stages.last_mut()
-            && prev.fuse(&next_stage)
-        {
-            continue;
-        }
-        stages.push(next_stage);
+        stages.push(compile_stage(ctx, state, info));
     }
-    for i in 0..stages.len() {
-        if let JoinStage::FusedIntersect {
-            cover,
-            to_intersect,
-            ..
-        } = &stages[i]
-            && to_intersect.is_empty()
-        {
-            let cover_atom = cover.to_index.atom;
-            let mut used_later = false;
-            for later_stage in &stages[i + 1..] {
-                used_later = used_later
-                    || match later_stage {
-                        JoinStage::Intersect { scans, .. } => {
-                            scans.iter().any(|scan| scan.atom == cover_atom)
-                        }
-                        JoinStage::FusedIntersect { cover, .. } => {
-                            cover.to_index.atom == cover_atom
-                        }
-                        JoinStage::FusedIntersectMat { .. } => unreachable!(),
-                    };
-                if used_later {
-                    break;
-                }
-            }
-            if !used_later {
-                let JoinStage::FusedIntersect { is_leaf_scan, .. } = &mut stages[i] else {
-                    unreachable!();
-                };
-                *is_leaf_scan = true;
-            }
-        }
-    }
+    fuse_single_scans(stages);
 }
 
 /// Compile a stage info into a concrete join stage, updating constraint state.
@@ -1747,6 +1648,5 @@ fn compile_stage(
         cover: cover_spec,
         bind,
         to_intersect,
-        is_leaf_scan: false,
     }
 }

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -1247,7 +1247,7 @@ impl<'a> PlanningContext<'a> {
     }
 
     fn common_vars_with<'b>(
-        &'a self,
+        &'b self,
         other: &'b PlanningContext<'a>,
     ) -> impl Iterator<Item = Variable> + 'b {
         self.vars

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -436,7 +436,7 @@ fn next_var_to_eliminate(
             // Optimization: use functional dependencies to find all variables inferred by the
             // current neightborhood.
             // let subquery_vars = fun_deps.closure(subquery_vars);
-            let subquery_vars:DenseIdMap<_, ()> = subquery_vars.map(|v| (v, ())).collect();
+            let subquery_vars: DenseIdMap<_, ()> = subquery_vars.map(|v| (v, ())).collect();
 
             let occ = atoms
                 .iter()
@@ -463,7 +463,10 @@ fn next_var_to_eliminate(
         .min_by_key(|a| a.0)
         .map(|a| (a.1, a.2))?;
     Some(IndexSet::from_iter(
-        fun_deps.closure(subquery_vars.iter().map(|(var, _)| var)).into_iter().map(|(var, _)| var),
+        fun_deps
+            .closure(subquery_vars.iter().map(|(var, _)| var))
+            .into_iter()
+            .map(|(var, _)| var),
     ))
 }
 

--- a/core-relations/src/free_join/plan.rs
+++ b/core-relations/src/free_join/plan.rs
@@ -425,7 +425,7 @@ fn next_var_to_eliminate(
 ) -> Option<IndexSet<Variable>> {
     let (_var, subquery_vars) = vars
         .iter()
-        .map(|(var, _vinfo)| {
+        .map(|(var, vinfo)| {
             let subquery_vars = atoms
                 .iter()
                 // every atom that contains this variable
@@ -435,14 +435,14 @@ fn next_var_to_eliminate(
 
             // Optimization: use functional dependencies to find all variables inferred by the
             // current neightborhood.
-            let subquery_vars = fun_deps.closure(subquery_vars);
-            // let subquery_vars:DenseIdMap<_, ()> = subquery_vars.map(|v| (v, ())).collect();
+            // let subquery_vars = fun_deps.closure(subquery_vars);
+            let subquery_vars:DenseIdMap<_, ()> = subquery_vars.map(|v| (v, ())).collect();
 
             let occ = atoms
                 .iter()
                 .filter(|(_, atom)| atom.vars().any(|v| subquery_vars.contains_key(v)))
                 .count();
-            let inv_selectivity = _vinfo
+            let size_estimation = vinfo
                 .occurrences
                 .iter()
                 .filter_map(|occ| {
@@ -457,13 +457,13 @@ fn next_var_to_eliminate(
                     Some(col_est.col_uniqueness(table, col))
                 })
                 .fold(ColUniqueness::default(), |a, b| a.join(&b));
-            // ((occ, inv_selectivity), var, subquery_vars)
-            (occ, var, subquery_vars)
+            ((occ, size_estimation), var, subquery_vars)
+            // (occ, var, subquery_vars)
         })
         .min_by_key(|a| a.0)
         .map(|a| (a.1, a.2))?;
     Some(IndexSet::from_iter(
-        subquery_vars.into_iter().map(|(var, _)| var),
+        fun_deps.closure(subquery_vars.iter().map(|(var, _)| var)).into_iter().map(|(var, _)| var),
     ))
 }
 

--- a/egglog-ast/src/generic_ast_helpers.rs
+++ b/egglog-ast/src/generic_ast_helpers.rs
@@ -159,37 +159,6 @@ where
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn display_nullary_call_without_trailing_space() {
-        let expr = GenericExpr::<String, String>::Call(Span::Panic, "foo".into(), vec![]);
-
-        assert_eq!(expr.to_string(), "(foo)");
-    }
-
-    #[test]
-    fn display_nullary_change_without_trailing_space() {
-        let delete = GenericAction::<String, String>::Change(
-            Span::Panic,
-            Change::Delete,
-            "foo".into(),
-            vec![],
-        );
-        let subsume = GenericAction::<String, String>::Change(
-            Span::Panic,
-            Change::Subsume,
-            "foo".into(),
-            vec![],
-        );
-
-        assert_eq!(delete.to_string(), "(delete (foo))");
-        assert_eq!(subsume.to_string(), "(subsume (foo))");
-    }
-}
-
 impl<Head, Leaf> Default for GenericActions<Head, Leaf>
 where
     Head: Clone + Display,
@@ -774,5 +743,36 @@ impl Display for Literal {
             Literal::String(s) => write!(f, "\"{s}\""),
             Literal::Unit => write!(f, "()"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_nullary_call_without_trailing_space() {
+        let expr = GenericExpr::<String, String>::Call(Span::Panic, "foo".into(), vec![]);
+
+        assert_eq!(expr.to_string(), "(foo)");
+    }
+
+    #[test]
+    fn display_nullary_change_without_trailing_space() {
+        let delete = GenericAction::<String, String>::Change(
+            Span::Panic,
+            Change::Delete,
+            "foo".into(),
+            vec![],
+        );
+        let subsume = GenericAction::<String, String>::Change(
+            Span::Panic,
+            Change::Subsume,
+            "foo".into(),
+            vec![],
+        );
+
+        assert_eq!(delete.to_string(), "(delete (foo))");
+        assert_eq!(subsume.to_string(), "(subsume (foo))");
     }
 }

--- a/egglog-bridge/src/rule.rs
+++ b/egglog-bridge/src/rule.rs
@@ -296,15 +296,10 @@ impl RuleBuilder<'_> {
             self.query.plan_strategy = PlanStrategy::MinCover;
         }
         let res = self.query.rule_id;
-        let cached_plan = self
-            .query
-            .build_cached_plan(&mut self.egraph.db, &self.desc)
-            .ok();
         let info = RuleInfo {
             last_run_at: Timestamp::new(0),
             query: self.query,
-            // cached_plan: None,
-            cached_plan,
+            cached_plan: None,
             desc: self.desc,
         };
         debug!("created rule {res:?} / {}", info.desc);


### PR DESCRIPTION
This PR does a few things

1. Add a simple cardinality estimator and use it to prioritize bags with smaller cardinality during tree decomposition.
2. Refactor and simplify single-bag planner `plan_stages` to get rid of the use of cardinality information, since we reorder join stages during query execution anyway.
3. Fix a bug in how is_leaf_scan is computed. It used to be computed during `plan_stages` and attached to each stage. However, this is unsound because we dynamically reoreder stages. This PR changes it to be computed during query execution.
4. Add factorized bindings to FusedIntersectMat. 
    * The reason for this is that the above changes caused eggcc-extraction's final "stitching" pass to be slow because our change switched the order of two Cartesian bags. Factorized bindings make the runtime of cartesian product less sensitive to which bag is evaluated first.



This PR addresses the slowdown reported in #872 and provides additional speedups. More detailed comparison:

<details>

```
  - old = 0a8cc35a (the pre-regression baseline the repro compares against)
  - local = current branch yihozhang-constant-fold-bound-vars (HEAD 63078fe3)

  ┌─────────────┬──────────────────────────┬─────────────────────┬──────────────┐
  │    file     │      old (baseline)      │ local (this branch) │   speedup    │
  ├─────────────┼──────────────────────────┼─────────────────────┼──────────────┤
  │ llama       │                   2.89 s │              1.01 s │         2.9× │
  ├─────────────┼──────────────────────────┼─────────────────────┼──────────────┤
  │ qwen        │                   3.57 s │              1.15 s │         3.1× │
  ├─────────────┼──────────────────────────┼─────────────────────┼──────────────┤
  │ paged_llama │                   2.83 s │              3.22 s │ 0.9× (≈flat) │
  ├─────────────┼──────────────────────────┼─────────────────────┼──────────────┤
  │ qwen3_moe   │                   5.37 s │              1.57 s │         3.4× │
  ├─────────────┼──────────────────────────┼─────────────────────┼──────────────┤
  │ whisper     │                   66.5 s │              3.56 s │        18.7× │
  ├─────────────┼──────────────────────────┼─────────────────────┼──────────────┤
  │ gemma       │                  166.3 s │             14.34 s │        11.6× │
  ├─────────────┼──────────────────────────┼─────────────────────┼──────────────┤
  │ gemma4_moe  │ never completed (>2 min) │              48.4 s │    completes │
  └─────────────┴──────────────────────────┴─────────────────────┴──────────────┘
```
</details>


Other than that, I have also tried to use the cardinality information to better estimate the sizes of variables in sort_plan_by_size than use `subset.size()`, but it does not help and has some small overhead.

This also enables periodic re-optimization of rules after some significant changes in the database.


**Latent bug fixes**

Along the way this PR also fixes two pre-existing bugs uncovered while reworking the planner:

* **Leaked cover node on empty leaf scans.** In `execute.rs`, the `FusedIntersect` leaf-scan path takes the cover atom's subset node out of `binding_info` via `unwrap_val`, but the old code returned early on an empty scan buffer *without* calling `move_back_node` to restore it (the non-leaf path always restored it). This left the atom's subset node missing for any later processing. The reworked leaf-scan path now restores the node before the empty-buffer early return.
* **Wrong bag index after `Vec::remove` in `decompose_into_bags`.** When merging an ear bag into its parent during tree decomposition, the old code merged into `bags[j]`/`bags[i]` and then removed the other bag, with an ad-hoc `i += 1`. This did not consistently account for the index shift that `Vec::remove` introduces. The new code removes first and merges into the shifted index (`bags[j - 1]` / `bags[i - 1]`), so the surviving bag is always the intended one.