### PR TITLE
Report the actual type name when a primitive references an unregistered sort

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1843,6 +1843,11 @@ impl EGraph {
         self.type_info.get_arcsort_by(f)
     }
 
+    /// Returns the unique sort whose runtime values have Rust type `T`.
+    pub fn get_arcsort_for_value_type<T: 'static>(&self) -> ArcSort {
+        self.type_info.get_arcsort_for_value_type::<T>()
+    }
+
     /// Returns all sorts that satisfy the predicate.
     pub fn get_arcsorts_by(&self, f: impl Fn(&ArcSort) -> bool) -> Vec<ArcSort> {
         self.type_info.get_arcsorts_by(f)

--- a/src/sort/add_primitive/src/lib.rs
+++ b/src/sort/add_primitive/src/lib.rs
@@ -430,7 +430,7 @@ impl Parse for Type {
             Some((field_def, field_use))
         } else if let Some((t, _)) = &cast {
             let field_use = Expr::Verbatim(quote! {
-                eg.get_arcsort_by(|s| s.value_type() == Some(TypeId::of::<#t>()))
+                eg.get_arcsort_for_value_type::<#t>()
             });
 
             Some((field_def, field_use))

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -655,8 +655,19 @@ impl TypeInfo {
         assert_eq!(
             results.len(),
             1,
-            "Expected exactly one sort for type {}",
-            std::any::type_name::<S>()
+            "Expected exactly one sort matching the given predicate"
+        );
+        results.into_iter().next().unwrap()
+    }
+
+    /// Returns the unique sort whose runtime values have Rust type `T`.
+    pub fn get_arcsort_for_value_type<T: 'static>(&self) -> ArcSort {
+        let results = self.get_arcsorts_by(|s| s.value_type() == Some(std::any::TypeId::of::<T>()));
+        assert_eq!(
+            results.len(),
+            1,
+            "Expected exactly one sort for type `{}`",
+            std::any::type_name::<T>()
         );
         results.into_iter().next().unwrap()
     }

--- a/tests/typed_primitive.rs
+++ b/tests/typed_primitive.rs
@@ -12,6 +12,7 @@
 //! - Duplicate same-signature primitive registrations are ambiguous for direct
 //!   calls and higher-order primitive dispatch.
 
+use egglog::add_primitive;
 use egglog::ast::Span;
 use egglog::constraint::{SimpleTypeConstraint, TypeConstraint};
 use egglog::sort::{I64Sort, S, StringSort};
@@ -494,6 +495,15 @@ fn two_same_signature_registrations_panic_on_use() {
     egraph.add_pure_primitive(PureAdd("dup-add"), None);
 
     let _ = egraph.parse_and_run_program(None, "(check (= (dup-add 1 2) 3))");
+}
+
+/// Registering a primitive whose argument type has no corresponding sort must
+/// fail with a message naming the missing type.
+#[test]
+#[should_panic(expected = "Expected exactly one sort for type `u32`")]
+fn missing_sort_panics_with_type_name() {
+    let mut egraph = EGraph::default();
+    add_primitive!(&mut egraph, "u32-id" = |a: u32| -> i64 { a as i64 });
 }
 
 /// `unstable-fn` over a primitive must preserve the same exact-one ambiguity


### PR DESCRIPTION
Adds a dedicated `get_arcsort_for_value_type::<T>()` so `add_primitive!` reports the real missing type name.

Fixes #732