### PR TITLE
Replace Rayon with our own, non-workstealing thread pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `make nightly` and `scripts/nightly_bench.py`, a hyperfine-based benchmark harness that measures every `tests/**/*.egg` program at 1/2/4/8 threads and (where supported) in proof-testing mode, caps each run at a 2-minute timeout, skips sub-50ms programs, and emits an HTML dashboard (one row per benchmark, one column per configuration) for nightly.cs.washington.edu. The dashboard uses [eval-live](https://github.com/oflatt/eval-live) for interactive filtering and sorting.
 - Add typed `EGraph` extension state that clones with `EGraph` and is restored by `push`/`pop`.
 - Fix custom scheduler queries so subsumed rows are not offered as fresh matches.
+- Add `egglog-concurrency` scoped `ThreadPool` support backed by a crossbeam channel.
 - Report full source file paths in egglog span and error messages.
 - Fix seminaive matching after nested containers rebuild in place by propagating dirty container ids through parent containers.
 - Render nullary AST calls without a trailing space, e.g. (foo) instead of (foo ).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add `make nightly` and `scripts/nightly_bench.py`, a hyperfine-based benchmark harness that measures every `tests/**/*.egg` program at 1/2/4/8 threads and (where supported) in proof-testing mode, caps each run at a 2-minute timeout, skips sub-50ms programs, and emits an HTML dashboard (one row per benchmark, one column per configuration) for nightly.cs.washington.edu. The dashboard uses [eval-live](https://github.com/oflatt/eval-live) for interactive filtering and sorting.
 - Add typed `EGraph` extension state that clones with `EGraph` and is restored by `push`/`pop`.
 - Fix custom scheduler queries so subsumed rows are not offered as fresh matches.
-- Add `egglog-concurrency` scoped `ThreadPool` support backed by a crossbeam channel.
+- Replace the global Rayon thread pool with an `egglog-concurrency` scoped `ThreadPool`; configure parallelism per `EGraph` via `with_num_threads` / `set_num_threads`.
 - Report full source file paths in egglog span and error messages.
 - Fix seminaive matching after nested containers rebuild in place by propagating dirty container ids through parent containers.
 - Render nullary AST calls without a trailing space, e.g. (foo) instead of (foo ).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,6 @@ dependencies = [
  "mimalloc",
  "num",
  "ordered-float",
- "rayon",
  "rustc-hash",
  "serde_json",
  "serial_test",
@@ -516,6 +515,7 @@ version = "2.0.0"
 dependencies = [
  "anyhow",
  "dyn-clone",
+ "egglog-concurrency",
  "egglog-core-relations",
  "egglog-numeric-id",
  "egglog-reports",
@@ -529,7 +529,6 @@ dependencies = [
  "once_cell",
  "ordered-float",
  "rand 0.9.2",
- "rayon",
  "smallvec",
  "thiserror",
  "web-time",
@@ -582,9 +581,6 @@ dependencies = [
 [[package]]
 name = "egglog-numeric-id"
 version = "2.0.0"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "egglog-reports"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "arc-swap",
  "bumpalo",
  "codspeed-divan-compat",
+ "crossbeam",
  "egglog-numeric-id",
  "proptest",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,6 @@ egglog-bridge = { workspace = true }
 egglog-numeric-id = { workspace = true }
 egglog-add-primitive = { workspace = true }
 egglog-reports = { workspace = true }
-rayon = { workspace = true }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,10 +1,8 @@
 use egglog::EGraph;
-use std::{fmt, sync::Once};
+use std::fmt;
 
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-static CONFIGURE_RAYON: Once = Once::new();
 
 pub fn run_example(filename: &str, program: &str, proof_testing: bool) {
     let mut egraph = if proof_testing {
@@ -36,8 +34,6 @@ impl fmt::Display for BenchCase {
 }
 
 pub fn bench_cases(glob: &str) -> Vec<BenchCase> {
-    configure_rayon_once();
-
     let mut cases = Vec::new();
 
     // Add regular test cases
@@ -81,8 +77,6 @@ const PROOF_UNSUPPORTED_FILES: &[&str] = &[
 ];
 
 pub fn bench_cases_proof_testing(glob: &str) -> Vec<BenchCase> {
-    configure_rayon_once();
-
     glob::glob(glob)
         .unwrap()
         .filter_map(Result::ok)
@@ -112,16 +106,5 @@ fn proof_benchmark_supported(path: &std::path::Path) -> bool {
 }
 
 pub fn bench_case(case: &BenchCase) {
-    configure_rayon_once();
-
     run_example(&case.filename, &case.program, case.proof_testing);
-}
-
-pub fn configure_rayon_once() {
-    CONFIGURE_RAYON.call_once(|| {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build_global()
-            .unwrap();
-    });
 }

--- a/benches/rust_api_benchmarking.rs
+++ b/benches/rust_api_benchmarking.rs
@@ -1,5 +1,3 @@
-mod common;
-
 #[derive(Clone, Copy)]
 struct RustRuleBenchCase {
     n_facts_input: Option<usize>,
@@ -293,14 +291,12 @@ impl std::fmt::Display for ReadScanBenchCase {
 fn read_scan_setup(case: ReadScanBenchCase) -> egglog::EGraph {
     use std::fmt::Write;
 
-    common::configure_rayon_once();
-
     let mut program = String::from("(sort Math)\n(constructor Add (i64 i64) Math)\n");
     for i in 0..case.n_enodes {
         let _ = writeln!(&mut program, "(Add {} {})", i as i64, (i + 1) as i64);
     }
 
-    let mut egraph = egglog::EGraph::default();
+    let mut egraph = egglog::EGraph::new(1);
     egraph.parse_and_run_program(None, &program).unwrap();
     egraph
 }

--- a/benches/rust_api_benchmarking.rs
+++ b/benches/rust_api_benchmarking.rs
@@ -23,8 +23,6 @@ struct RustRuleBenchInput {
 fn match_only_rust_rule_setup(case: RustRuleBenchCase) -> RustRuleBenchInput {
     use egglog::prelude::*;
 
-    common::configure_rayon_once();
-
     let mut program = String::new();
     program.push_str("(relation R (i64))\n");
 
@@ -120,8 +118,6 @@ fn rust_rule_match_with_serialize(bencher: divan::Bencher, case: RustRuleBenchCa
 fn insert_loop_setup(case: RustRuleInsertLoopBenchCase) -> RustRuleBenchInput {
     use egglog::prelude::*;
 
-    common::configure_rayon_once();
-
     let mut program = String::new();
     program.push_str("(relation R (i64))\n");
     program.push_str("(function f (i64) i64 :no-merge)\n");
@@ -161,8 +157,6 @@ fn insert_loop_setup(case: RustRuleInsertLoopBenchCase) -> RustRuleBenchInput {
 
 fn tableaction_hot_path_setup(case: RustRuleTableActionBenchCase) -> RustRuleBenchInput {
     use egglog::prelude::*;
-
-    common::configure_rayon_once();
 
     let mut program = String::new();
     program.push_str("(relation R (i64))\n");
@@ -340,8 +334,6 @@ fn main() {
 
 fn fib_setup() -> RustRuleBenchInput {
     use egglog::prelude::*;
-    common::configure_rayon_once();
-
     let mut program = String::new();
     program.push_str("(function fib (i64) i64 :no-merge)");
     program.push_str("(set (fib 0) 0)\n");

--- a/concurrency/Cargo.toml
+++ b/concurrency/Cargo.toml
@@ -24,3 +24,7 @@ rayon = { workspace = true}
 [[bench]]
 name = "simple_read"
 harness = false
+
+[[bench]]
+name = "sum_vector"
+harness = false

--- a/concurrency/Cargo.toml
+++ b/concurrency/Cargo.toml
@@ -12,7 +12,6 @@ readme = { workspace = true }
 arc-swap = { workspace = true}
 bumpalo = { workspace = true}
 crossbeam = { workspace = true}
-rayon = { workspace = true}
 egglog-numeric-id = { workspace = true }
 smallvec = { workspace = true }
 

--- a/concurrency/Cargo.toml
+++ b/concurrency/Cargo.toml
@@ -11,6 +11,7 @@ readme = { workspace = true }
 [dependencies]
 arc-swap = { workspace = true}
 bumpalo = { workspace = true}
+crossbeam = { workspace = true}
 rayon = { workspace = true}
 egglog-numeric-id = { workspace = true }
 smallvec = { workspace = true }

--- a/concurrency/benches/sum_vector.rs
+++ b/concurrency/benches/sum_vector.rs
@@ -1,0 +1,133 @@
+use std::{
+    env,
+    sync::{
+        OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
+    thread,
+};
+
+use divan::{Bencher, counter::ItemsCount};
+use egglog_concurrency::ThreadPool;
+use rayon::prelude::*;
+
+const DEFAULT_ITEMS: usize = 256_000_000;
+const DEFAULT_SAMPLE_COUNT: u32 = 5;
+
+fn main() {
+    divan::main()
+}
+
+#[divan::bench(sample_count = DEFAULT_SAMPLE_COUNT)]
+fn single_threaded_sum(bencher: Bencher) {
+    let data = data();
+    let expected = expected_sum();
+
+    bencher
+        .with_inputs(|| data)
+        .input_counter(|data| ItemsCount::new(data.len()))
+        .bench_values(|data| {
+            let sum = sum_slice(divan::black_box(data));
+            assert_eq!(sum, expected);
+            divan::black_box(sum)
+        });
+}
+
+#[divan::bench(sample_count = DEFAULT_SAMPLE_COUNT)]
+fn rayon_sum(bencher: Bencher) {
+    let data = data();
+    let expected = expected_sum();
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(thread_count())
+        .build()
+        .unwrap();
+
+    bencher
+        .with_inputs(|| data)
+        .input_counter(|data| ItemsCount::new(data.len()))
+        .bench_values(|data| {
+            let sum = pool.install(|| {
+                divan::black_box(data)
+                    .par_iter()
+                    .map(|&value| value as u64)
+                    .sum::<u64>()
+            });
+            assert_eq!(sum, expected);
+            divan::black_box(sum)
+        });
+}
+
+#[divan::bench(
+    consts = [
+        1024,
+        4096,
+        16384,
+        65536,
+        262144,
+        1048576,
+        4194304,
+        16777216,
+    ],
+    sample_count = DEFAULT_SAMPLE_COUNT,
+)]
+fn threadpool_chunked_sum<const CHUNK: usize>(bencher: Bencher) {
+    let data = data();
+    let expected = expected_sum();
+    let pool = ThreadPool::new(thread_count());
+
+    bencher
+        .with_inputs(|| data)
+        .input_counter(|data| ItemsCount::new(data.len()))
+        .bench_values(|data| {
+            let total = AtomicU64::new(0);
+            pool.scope(|scope| {
+                for chunk in divan::black_box(data).chunks(CHUNK) {
+                    let total = &total;
+                    scope.spawn(move |_| {
+                        total.fetch_add(sum_slice(chunk), Ordering::Relaxed);
+                    });
+                }
+            });
+
+            let sum = total.load(Ordering::Relaxed);
+            assert_eq!(sum, expected);
+            divan::black_box(sum)
+        });
+}
+
+fn data() -> &'static [u32] {
+    static DATA: OnceLock<Vec<u32>> = OnceLock::new();
+    DATA.get_or_init(|| {
+        (0..data_len())
+            .map(|i| {
+                let value = i as u32;
+                value.wrapping_mul(1_664_525).wrapping_add(1_013_904_223)
+            })
+            .collect()
+    })
+}
+
+fn expected_sum() -> u64 {
+    static EXPECTED: OnceLock<u64> = OnceLock::new();
+    *EXPECTED.get_or_init(|| sum_slice(data()))
+}
+
+fn sum_slice(data: &[u32]) -> u64 {
+    data.iter().map(|&value| value as u64).sum()
+}
+
+fn data_len() -> usize {
+    env_usize("EGGLOG_SUM_BENCH_LEN").unwrap_or(DEFAULT_ITEMS)
+}
+
+fn thread_count() -> usize {
+    env_usize("EGGLOG_SUM_BENCH_THREADS")
+        .unwrap_or_else(|| thread::available_parallelism().map_or(1, usize::from))
+}
+
+fn env_usize(name: &str) -> Option<usize> {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.replace('_', "").parse().ok())
+        .filter(|&value| value > 0)
+}

--- a/concurrency/benches/sum_vector.rs
+++ b/concurrency/benches/sum_vector.rs
@@ -1,11 +1,4 @@
-use std::{
-    env,
-    sync::{
-        OnceLock,
-        atomic::{AtomicU64, Ordering},
-    },
-    thread,
-};
+use std::{env, sync::OnceLock, thread};
 
 use divan::{Bencher, counter::ItemsCount};
 use egglog_concurrency::ThreadPool;
@@ -79,17 +72,19 @@ fn threadpool_chunked_sum<const CHUNK: usize>(bencher: Bencher) {
         .with_inputs(|| data)
         .input_counter(|data| ItemsCount::new(data.len()))
         .bench_values(|data| {
-            let total = AtomicU64::new(0);
+            let mut partials = vec![0_u64; data.len().div_ceil(CHUNK)];
             pool.scope(|scope| {
-                for chunk in divan::black_box(data).chunks(CHUNK) {
-                    let total = &total;
+                for (slot, chunk) in partials
+                    .iter_mut()
+                    .zip(divan::black_box(data).chunks(CHUNK))
+                {
                     scope.spawn(move |_| {
-                        total.fetch_add(sum_slice(chunk), Ordering::Relaxed);
+                        *slot = sum_slice(chunk);
                     });
                 }
             });
 
-            let sum = total.load(Ordering::Relaxed);
+            let sum: u64 = partials.into_iter().sum();
             assert_eq!(sum, expected);
             divan::black_box(sum)
         });

--- a/concurrency/src/lib.rs
+++ b/concurrency/src/lib.rs
@@ -7,6 +7,7 @@ pub(crate) mod notification_list;
 pub mod parallel_writer;
 pub(crate) mod resettable_oncelock;
 mod shared_arena;
+pub mod threadpool;
 use arc_swap::{ArcSwap, Guard};
 
 pub use bitset::BitSet;
@@ -16,6 +17,7 @@ pub use notification_list::NotificationList;
 pub use parallel_writer::ParallelVecWriter;
 pub use resettable_oncelock::ResettableOnceLock;
 pub use shared_arena::{Handle, SharedArena, SharedRef};
+pub use threadpool::{Scope, ThreadPool, current_num_threads, scope};
 
 #[cfg(test)]
 mod tests;

--- a/concurrency/src/lib.rs
+++ b/concurrency/src/lib.rs
@@ -17,7 +17,7 @@ pub use notification_list::NotificationList;
 pub use parallel_writer::ParallelVecWriter;
 pub use resettable_oncelock::ResettableOnceLock;
 pub use shared_arena::{Handle, SharedArena, SharedRef};
-pub use threadpool::{Scope, ThreadPool, current_num_threads, scope};
+pub use threadpool::{Scope, ThreadPool, current_num_threads, scope, without_current_pool};
 
 #[cfg(test)]
 mod tests;

--- a/concurrency/src/threadpool/mod.rs
+++ b/concurrency/src/threadpool/mod.rs
@@ -1,0 +1,704 @@
+//! A small scoped thread pool backed by a shared crossbeam channel.
+//!
+//! [`ThreadPool`] owns a fixed set of worker threads. Each worker receives
+//! boxed `'static` jobs from a shared channel and exits when the channel is
+//! closed. [`Scope`] provides the safe scoped API on top of those `'static`
+//! jobs by erasing task lifetimes when work is sent to the channel, then
+//! waiting for all work in the scope before returning to the caller.
+//!
+//! The root callback runs on the caller thread, and spawned callbacks run on
+//! worker threads. Spawned callbacks receive the same scope reference as the
+//! root callback, so they can add nested work. The high half of the scope
+//! counter tracks expected work and is incremented before each task is
+//! enqueued; the low half tracks completed work. The root callback is counted
+//! as one expected item, so the scope is complete once the callback and every
+//! spawned task have completed.
+//!
+//! # Examples
+//!
+//! ```
+//! use std::sync::atomic::{AtomicUsize, Ordering};
+//! use egglog_concurrency::ThreadPool;
+//!
+//! let pool = ThreadPool::new(4);
+//! let values = [1, 2, 3, 4];
+//! let sum = AtomicUsize::new(0);
+//!
+//! pool.scope(|scope| {
+//!     for value in &values {
+//!         scope.spawn(|_| {
+//!             sum.fetch_add(*value, Ordering::Relaxed);
+//!         });
+//!     }
+//! });
+//!
+//! assert_eq!(sum.load(Ordering::Relaxed), 10);
+//! ```
+//!
+//! A spawned callback cannot store references that would outlive the borrowed
+//! data, even though the implementation erases the callback's lifetime before
+//! sending it to a worker:
+//!
+//! ```compile_fail
+//! use egglog_concurrency::ThreadPool;
+//!
+//! let pool = ThreadPool::new(1);
+//! let mut escaped = None;
+//!
+//! pool.scope(|scope| {
+//!     let local = 10;
+//!     scope.spawn(|_| {
+//!         escaped = Some(&local);
+//!     });
+//! });
+//!
+//! assert_eq!(escaped, Some(&10));
+//! ```
+//!
+//! Nested spawned callbacks cannot borrow data owned by the parent spawned
+//! callback, because the parent callback may return before its nested work runs:
+//!
+//! ```compile_fail
+//! use egglog_concurrency::ThreadPool;
+//!
+//! let pool = ThreadPool::new(1);
+//! pool.scope(|scope| {
+//!     scope.spawn(|scope| {
+//!         let local = 10;
+//!         scope.spawn(|_| {
+//!             println!("{local}");
+//!         });
+//!     });
+//! });
+//! ```
+//!
+//! The scope itself also cannot be stored outside the call to
+//! [`ThreadPool::scope`]:
+//!
+//! ```compile_fail
+//! use egglog_concurrency::{Scope, ThreadPool};
+//!
+//! let pool = ThreadPool::new(1);
+//! let mut escaped: Option<&Scope<'_>> = None;
+//!
+//! pool.scope(|scope| {
+//!     scope.spawn(|scope| {
+//!         escaped = Some(scope);
+//!     });
+//! });
+//!
+//! escaped.unwrap().spawn(|_| {});
+//! ```
+
+use std::{
+    any::Any,
+    cell::Cell,
+    marker::PhantomData,
+    mem,
+    panic::{self, AssertUnwindSafe},
+    ptr::{self, NonNull},
+    sync::{
+        Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    thread::{self, JoinHandle},
+};
+
+use crossbeam::channel::{Receiver, Sender, unbounded};
+
+use crate::Notification;
+
+const EXPECTED_SHIFT: u32 = 32;
+const COMPLETED_MASK: u64 = u32::MAX as u64;
+
+type Job = Box<dyn FnOnce() + Send + 'static>;
+type ScopedJob<'scope> = Box<dyn FnOnce() + Send + 'scope>;
+type PanicPayload = Box<dyn Any + Send + 'static>;
+
+thread_local! {
+    static CURRENT_POOL: Cell<*const ThreadPoolState> = const { Cell::new(ptr::null()) };
+}
+
+/// Return the number of threads in the currently installed thread pool.
+///
+/// Returns `1` when called outside [`ThreadPool::install`], [`ThreadPool::scope`],
+/// a free [`scope`] callback, or a worker callback spawned from an installed
+/// pool.
+///
+/// # Examples
+///
+/// ```
+/// use egglog_concurrency::{ThreadPool, current_num_threads};
+///
+/// assert_eq!(current_num_threads(), 1);
+///
+/// let pool = ThreadPool::new(2);
+/// pool.install(|| {
+///     assert_eq!(current_num_threads(), 2);
+/// });
+///
+/// assert_eq!(current_num_threads(), 1);
+/// ```
+pub fn current_num_threads() -> usize {
+    with_current_pool(|pool| pool.map_or(1, ThreadPoolState::thread_count))
+}
+
+/// Run `f` in a scope on the currently installed thread pool.
+///
+/// This is the free-function counterpart to [`ThreadPool::scope`]. It keeps the
+/// same in-place semantics: the root callback runs on the caller thread, and
+/// spawned work runs on the installed pool's workers.
+///
+/// # Panics
+///
+/// Panics if no thread pool is currently installed.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::atomic::{AtomicUsize, Ordering};
+/// use egglog_concurrency::{ThreadPool, scope};
+///
+/// let pool = ThreadPool::new(2);
+/// let counter = AtomicUsize::new(0);
+///
+/// pool.install(|| {
+///     scope(|scope| {
+///         scope.spawn(|_| {
+///             counter.fetch_add(1, Ordering::Relaxed);
+///         });
+///     });
+/// });
+///
+/// assert_eq!(counter.load(Ordering::Relaxed), 1);
+/// ```
+///
+/// ```should_panic
+/// egglog_concurrency::scope(|_| {});
+/// ```
+pub fn scope<'scope, F, R>(f: F) -> R
+where
+    F: FnOnce(&Scope<'scope>) -> R,
+{
+    with_current_pool(|pool| match pool {
+        Some(pool) => pool.scope(f),
+        None => panic!("no egglog thread pool is currently installed"),
+    })
+}
+
+/// A fixed-size thread pool using a single shared work queue.
+///
+/// # Examples
+///
+/// ```
+/// use egglog_concurrency::ThreadPool;
+///
+/// let pool = ThreadPool::new(2);
+/// pool.scope(|scope| {
+///     scope.spawn(|_| {});
+/// });
+/// ```
+pub struct ThreadPool {
+    state: Box<ThreadPoolState>,
+    workers: Vec<JoinHandle<()>>,
+}
+
+impl ThreadPool {
+    /// Create a thread pool with `thread_count` worker threads.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `thread_count` is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use egglog_concurrency::ThreadPool;
+    ///
+    /// let pool = ThreadPool::new(2);
+    /// assert_eq!(pool.thread_count(), 2);
+    /// ```
+    pub fn new(thread_count: usize) -> Self {
+        assert!(
+            thread_count > 0,
+            "thread pool must have at least one worker"
+        );
+
+        let (sender, receiver) = unbounded();
+        let state = Box::new(ThreadPoolState {
+            sender: Some(sender),
+            thread_count,
+        });
+        let state_ptr = ThreadPoolStatePtr::new(&state);
+        let workers = (0..thread_count)
+            .map(|_| spawn_worker(receiver.clone(), state_ptr))
+            .collect();
+
+        Self { state, workers }
+    }
+
+    /// Return the number of worker threads owned by this pool.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use egglog_concurrency::ThreadPool;
+    ///
+    /// let pool = ThreadPool::new(3);
+    /// assert_eq!(pool.thread_count(), 3);
+    /// ```
+    pub fn thread_count(&self) -> usize {
+        self.state.thread_count()
+    }
+
+    /// Run `f` with this thread pool installed as the current pool.
+    ///
+    /// The callback runs on the caller thread. While it is running,
+    /// [`current_num_threads`] reports this pool's thread count, the free
+    /// [`scope`] function uses this pool, and worker callbacks spawned from this
+    /// pool also see this pool as current. If another pool was already
+    /// installed on the current thread, it is restored before this method
+    /// returns or unwinds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use egglog_concurrency::{ThreadPool, current_num_threads};
+    ///
+    /// let pool = ThreadPool::new(2);
+    /// assert_eq!(current_num_threads(), 1);
+    ///
+    /// let value = pool.install(|| current_num_threads());
+    ///
+    /// assert_eq!(value, 2);
+    /// assert_eq!(current_num_threads(), 1);
+    /// ```
+    pub fn install<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        install_pool(&self.state, f)
+    }
+
+    /// Run `f` in a scope and wait for all work spawned in that scope.
+    ///
+    /// The root callback runs on the caller thread. Tasks spawned from `f` may
+    /// borrow stack data owned by the caller. If a spawned task panics, this
+    /// method waits for all previously spawned work and then resumes unwinding
+    /// with one of the worker panic payloads. If `f` itself panics, the outer
+    /// panic is resumed after spawned work has completed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::atomic::{AtomicUsize, Ordering};
+    /// use egglog_concurrency::ThreadPool;
+    ///
+    /// let pool = ThreadPool::new(2);
+    /// let value = AtomicUsize::new(0);
+    ///
+    /// let result = pool.scope(|scope| {
+    ///     scope.spawn(|_| {
+    ///         value.store(7, Ordering::Relaxed);
+    ///     });
+    ///     11
+    /// });
+    ///
+    /// assert_eq!(result, 11);
+    /// assert_eq!(value.load(Ordering::Relaxed), 7);
+    /// ```
+    pub fn scope<'scope, F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&Scope<'scope>) -> R,
+    {
+        self.install(|| self.state.scope(f))
+    }
+
+    /// Apply `f` to each item in `iter` in parallel.
+    ///
+    /// Items are pulled from the iterator by the calling thread and enqueued
+    /// one by one. The method returns only after every enqueued callback has
+    /// completed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::atomic::{AtomicUsize, Ordering};
+    /// use egglog_concurrency::ThreadPool;
+    ///
+    /// let pool = ThreadPool::new(2);
+    /// let sum = AtomicUsize::new(0);
+    ///
+    /// pool.parallel_for_each(0..4, |value| {
+    ///     sum.fetch_add(value, Ordering::Relaxed);
+    /// });
+    ///
+    /// assert_eq!(sum.load(Ordering::Relaxed), 6);
+    /// ```
+    pub fn parallel_for_each<'scope, I, F>(&self, iter: I, f: F)
+    where
+        I: IntoIterator,
+        I::Item: Send + 'scope,
+        F: Fn(I::Item) + Sync + 'scope,
+    {
+        self.scope(|scope| {
+            let f = &f;
+            for item in iter {
+                scope.spawn(move |_| f(item));
+            }
+        });
+    }
+}
+
+impl Drop for ThreadPool {
+    fn drop(&mut self) {
+        self.state.sender.take();
+        for worker in self.workers.drain(..) {
+            let _ = worker.join();
+        }
+    }
+}
+
+struct ThreadPoolState {
+    sender: Option<Sender<Job>>,
+    thread_count: usize,
+}
+
+impl ThreadPoolState {
+    fn thread_count(&self) -> usize {
+        self.thread_count
+    }
+
+    fn scope<'scope, F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&Scope<'scope>) -> R,
+    {
+        let scope = Scope::new(self);
+        let result = panic::catch_unwind(AssertUnwindSafe(|| f(&scope)));
+        scope.complete_root_and_wait();
+        let worker_panic = scope.state.take_panic();
+
+        match result {
+            Ok(value) => {
+                if let Some(payload) = worker_panic {
+                    panic::resume_unwind(payload);
+                }
+                value
+            }
+            Err(payload) => panic::resume_unwind(payload),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ThreadPoolStatePtr(*const ThreadPoolState);
+
+impl ThreadPoolStatePtr {
+    fn new(state: &ThreadPoolState) -> Self {
+        Self(state)
+    }
+
+    unsafe fn as_ref(&self) -> &ThreadPoolState {
+        // SAFETY: callers only use this pointer while the owning `ThreadPool`
+        // is alive. Worker threads that hold this pointer are joined before the
+        // boxed state is dropped.
+        unsafe { &*self.0 }
+    }
+}
+
+// SAFETY: the pointer targets the boxed `ThreadPoolState` owned by
+// `ThreadPool`. `ThreadPool::drop` closes the work channel, joins all workers
+// holding this pointer, and only then drops the boxed state.
+unsafe impl Send for ThreadPoolStatePtr {}
+
+fn install_pool<F, R>(pool: &ThreadPoolState, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    install_pool_ptr(pool as *const ThreadPoolState, f)
+}
+
+fn install_pool_ptr<F, R>(pool: *const ThreadPoolState, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    CURRENT_POOL.with(|current| {
+        let previous = current.replace(pool);
+        let _guard = CurrentPoolGuard { current, previous };
+        f()
+    })
+}
+
+struct CurrentPoolGuard<'a> {
+    current: &'a Cell<*const ThreadPoolState>,
+    previous: *const ThreadPoolState,
+}
+
+impl Drop for CurrentPoolGuard<'_> {
+    fn drop(&mut self) {
+        self.current.set(self.previous);
+    }
+}
+
+fn with_current_pool<F, R>(f: F) -> R
+where
+    F: FnOnce(Option<&ThreadPoolState>) -> R,
+{
+    CURRENT_POOL.with(|current| {
+        let pool = current.get();
+        // SAFETY: installed pointers are set only by `install_pool` for a
+        // borrowed `ThreadPoolState`, or by worker threads whose owning
+        // `ThreadPool` joins them before dropping the boxed state. The returned
+        // reference is only exposed for the duration of this closure.
+        let pool = unsafe { pool.as_ref() };
+        f(pool)
+    })
+}
+
+/// A scoped handle for spawning non-`'static` work onto a [`ThreadPool`].
+///
+/// `Scope` has an invariant lifetime. This permits spawned callbacks to borrow
+/// local data while preventing nested callbacks from smuggling shorter-lived
+/// borrows into work that may outlive them.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::atomic::{AtomicUsize, Ordering};
+/// use egglog_concurrency::ThreadPool;
+///
+/// let pool = ThreadPool::new(2);
+/// let counter = AtomicUsize::new(0);
+///
+/// pool.scope(|scope| {
+///     scope.spawn(|_| {
+///         counter.fetch_add(1, Ordering::Relaxed);
+///     });
+/// });
+///
+/// assert_eq!(counter.load(Ordering::Relaxed), 1);
+/// ```
+pub struct Scope<'scope> {
+    sender: Sender<Job>,
+    state: ScopeState,
+    _scope: PhantomData<fn(&'scope ()) -> &'scope ()>,
+}
+
+impl<'scope> Scope<'scope> {
+    fn new(pool: &ThreadPoolState) -> Self {
+        Self {
+            sender: pool.sender.as_ref().unwrap().clone(),
+            state: ScopeState::new(),
+            _scope: PhantomData,
+        }
+    }
+
+    /// Spawn a callback onto the pool.
+    ///
+    /// The callback receives the current scope and may add nested work. It may
+    /// borrow values with the scope lifetime. The scope waits for the callback
+    /// before returning, so those borrows cannot outlive their owners.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::atomic::{AtomicUsize, Ordering};
+    /// use egglog_concurrency::ThreadPool;
+    ///
+    /// let pool = ThreadPool::new(2);
+    /// let counter = AtomicUsize::new(0);
+    ///
+    /// pool.scope(|scope| {
+    ///     scope.spawn(|scope| {
+    ///         counter.fetch_add(1, Ordering::Relaxed);
+    ///         scope.spawn(|_| {
+    ///             counter.fetch_add(1, Ordering::Relaxed);
+    ///         });
+    ///     });
+    /// });
+    ///
+    /// assert_eq!(counter.load(Ordering::Relaxed), 2);
+    /// ```
+    pub fn spawn<F>(&self, f: F)
+    where
+        F: FnOnce(&Scope<'scope>) + Send + 'scope,
+    {
+        let scope = ScopePtr::new(self);
+        let job: ScopedJob<'scope> = Box::new(move || {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                // SAFETY: `Scope::complete_root_and_wait` waits for this job
+                // to call `complete_one` before the stack-allocated scope can
+                // be destroyed.
+                let scope = unsafe { scope.as_ref() };
+                f(scope);
+            }));
+            // SAFETY: `Scope::complete_root_and_wait` waits for this job to call
+            // `complete_one` before the stack-allocated scope state can be
+            // destroyed.
+            let scope = unsafe { scope.as_ref() };
+            if let Err(payload) = result {
+                scope.state.record_panic(payload);
+            }
+            scope.state.complete_one();
+        });
+
+        self.state.expect_one();
+        // SAFETY: every erased job records completion in the scope state, and
+        // `Scope::complete_root_and_wait` waits for all expected completions
+        // before `ThreadPool::scope` returns.
+        enqueue(&self.sender, unsafe { erase_job_lifetime(job) });
+    }
+
+    fn complete_root_and_wait(&self) {
+        if !self.state.complete_one() {
+            self.state.wait();
+        }
+    }
+}
+
+struct ScopeState {
+    completion: AtomicCounts,
+    finished: Notification,
+    panic: Mutex<Option<PanicPayload>>,
+}
+
+impl ScopeState {
+    fn new() -> Self {
+        Self {
+            completion: AtomicCounts::with_root_callback(),
+            finished: Notification::new(),
+            panic: Mutex::new(None),
+        }
+    }
+
+    fn expect_one(&self) {
+        self.completion.expect_one();
+    }
+
+    fn complete_one(&self) -> bool {
+        let previous = self.completion.complete_one();
+        let completed = completed(previous) + 1;
+        let expected = expected(previous);
+        debug_assert!(completed <= expected);
+
+        if completed == expected {
+            self.finished.notify();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn wait(&self) {
+        self.finished.wait();
+    }
+
+    fn record_panic(&self, payload: PanicPayload) {
+        let mut slot = self.panic.lock().unwrap_or_else(|err| err.into_inner());
+        if slot.is_none() {
+            *slot = Some(payload);
+        }
+    }
+
+    fn take_panic(&self) -> Option<PanicPayload> {
+        self.panic
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .take()
+    }
+}
+
+struct AtomicCounts(AtomicU64);
+
+impl AtomicCounts {
+    fn with_root_callback() -> Self {
+        Self(AtomicU64::new(1 << EXPECTED_SHIFT))
+    }
+
+    fn expect_one(&self) {
+        loop {
+            let current = self.0.load(Ordering::Acquire);
+            let expected = expected(current);
+            assert!(
+                expected < u32::MAX,
+                "thread pool scope launched more than u32::MAX tasks"
+            );
+
+            let next = current + (1 << EXPECTED_SHIFT);
+            if self
+                .0
+                .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return;
+            }
+        }
+    }
+
+    fn complete_one(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::AcqRel)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ScopePtr<'scope>(NonNull<Scope<'scope>>);
+
+impl<'scope> ScopePtr<'scope> {
+    fn new(scope: &Scope<'scope>) -> Self {
+        Self(NonNull::from(scope))
+    }
+
+    unsafe fn as_ref(&self) -> &Scope<'scope> {
+        // SAFETY: callers only dereference this pointer from jobs whose
+        // completion is counted by the pointed-to scope. The parent scope waits
+        // for every counted completion before the stack-allocated scope is
+        // destroyed.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+// SAFETY: `ScopePtr` is only created for a live scope. Each job that receives
+// this pointer must call `complete_one`, and the parent scope waits for all
+// completions before the scope is destroyed.
+unsafe impl Send for ScopePtr<'_> {}
+
+unsafe fn erase_job_lifetime<'scope>(job: ScopedJob<'scope>) -> Job {
+    // SAFETY: `ThreadPool::scope` waits for the root callback and every
+    // dynamically expected spawned job to finish before returning to the
+    // caller, so the erased callback cannot run after its captured `'scope`
+    // borrows expire.
+    unsafe { mem::transmute::<ScopedJob<'scope>, Job>(job) }
+}
+
+fn spawn_worker(receiver: Receiver<Job>, pool: ThreadPoolStatePtr) -> JoinHandle<()> {
+    thread::spawn(move || {
+        // SAFETY: each worker is joined before the boxed pool state is dropped.
+        let pool = unsafe { pool.as_ref() };
+        install_pool(pool, || {
+            for job in receiver {
+                job();
+            }
+        });
+    })
+}
+
+fn enqueue(sender: &Sender<Job>, job: Job) {
+    match sender.send(job) {
+        Ok(()) => {}
+        Err(error) => {
+            let job = error.0;
+            job();
+        }
+    }
+}
+
+fn completed(value: u64) -> u32 {
+    (value & COMPLETED_MASK) as u32
+}
+
+fn expected(value: u64) -> u32 {
+    (value >> EXPECTED_SHIFT) as u32
+}
+
+#[cfg(test)]
+mod tests;

--- a/concurrency/src/threadpool/mod.rs
+++ b/concurrency/src/threadpool/mod.rs
@@ -752,6 +752,20 @@ unsafe fn erase_job_lifetime<'scope>(job: ScopedJob<'scope>) -> Job {
     unsafe { mem::transmute::<ScopedJob<'scope>, Job>(job) }
 }
 
+/// A short-lived queue consumer that replaces a blocked background worker.
+///
+/// Scoped work may itself open a nested scope. If the worker running that outer
+/// job blocks waiting for the nested scope to finish, the pool has one fewer
+/// thread draining the shared job queue. With a one-thread pool, that would
+/// deadlock: the only primary worker would be asleep while the nested job it is
+/// waiting for is still queued. `BackupWorker` temporarily clones the pool's
+/// receiver, installs the same current-pool and background-worker thread-local
+/// state as a primary worker, and runs queued jobs until the blocked worker
+/// finishes waiting.
+///
+/// The guard owns a shutdown channel and joins the spawned thread on drop, so a
+/// backup worker is tied to exactly one blocking wait. It also exits if the pool
+/// work channel is closed.
 struct BackupWorker {
     shutdown: Sender<()>,
     worker: Option<JoinHandle<()>>,

--- a/concurrency/src/threadpool/mod.rs
+++ b/concurrency/src/threadpool/mod.rs
@@ -1,10 +1,12 @@
 //! A small scoped thread pool backed by a shared crossbeam channel.
 //!
-//! [`ThreadPool`] owns a fixed set of worker threads. Each worker receives
-//! boxed `'static` jobs from a shared channel and exits when the channel is
-//! closed. [`Scope`] provides the safe scoped API on top of those `'static`
-//! jobs by erasing task lifetimes when work is sent to the channel, then
-//! waiting for all work in the scope before returning to the caller.
+//! [`ThreadPool`] owns a fixed set of primary worker threads. Each worker
+//! receives boxed `'static` jobs from a shared channel and exits when the
+//! channel is closed. A primary worker that blocks waiting for scoped work
+//! temporarily starts a backup worker so the pool can continue draining queued
+//! jobs. [`Scope`] provides the safe scoped API on top of those `'static` jobs
+//! by erasing task lifetimes when work is sent to the channel, then waiting for
+//! all work in the scope before returning to the caller.
 //!
 //! The root callback runs on the caller thread, and spawned callbacks run on
 //! worker threads. Spawned callbacks receive the same scope reference as the
@@ -104,7 +106,10 @@ use std::{
     thread::{self, JoinHandle},
 };
 
-use crossbeam::channel::{Receiver, Sender, unbounded};
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
+
+use crossbeam::channel::{Receiver, Sender, bounded, select_biased, unbounded};
 
 use crate::Notification;
 
@@ -117,6 +122,7 @@ type PanicPayload = Box<dyn Any + Send + 'static>;
 
 thread_local! {
     static CURRENT_POOL: Cell<*const ThreadPoolState> = const { Cell::new(ptr::null()) };
+    static IS_BACKGROUND_WORKER: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Return the number of threads in the currently installed thread pool.
@@ -186,7 +192,11 @@ where
     })
 }
 
-/// A fixed-size thread pool using a single shared work queue.
+/// A thread pool using a single shared work queue.
+///
+/// The pool owns a fixed number of primary workers. It may also create
+/// short-lived backup workers while a primary worker is blocked waiting for
+/// nested scoped work.
 ///
 /// # Examples
 ///
@@ -225,10 +235,7 @@ impl ThreadPool {
         );
 
         let (sender, receiver) = unbounded();
-        let state = Box::new(ThreadPoolState {
-            sender: Some(sender),
-            thread_count,
-        });
+        let state = Box::new(ThreadPoolState::new(sender, receiver.clone(), thread_count));
         let state_ptr = ThreadPoolStatePtr::new(&state);
         let workers = (0..thread_count)
             .map(|_| spawn_worker(receiver.clone(), state_ptr))
@@ -237,7 +244,7 @@ impl ThreadPool {
         Self { state, workers }
     }
 
-    /// Return the number of worker threads owned by this pool.
+    /// Return the number of primary worker threads owned by this pool.
     ///
     /// # Examples
     ///
@@ -361,10 +368,27 @@ impl Drop for ThreadPool {
 
 struct ThreadPoolState {
     sender: Option<Sender<Job>>,
+    receiver: Receiver<Job>,
     thread_count: usize,
+    #[cfg(test)]
+    backup_workers_spawned: AtomicUsize,
+    #[cfg(test)]
+    backup_workers_live: AtomicUsize,
 }
 
 impl ThreadPoolState {
+    fn new(sender: Sender<Job>, receiver: Receiver<Job>, thread_count: usize) -> Self {
+        Self {
+            sender: Some(sender),
+            receiver,
+            thread_count,
+            #[cfg(test)]
+            backup_workers_spawned: AtomicUsize::new(0),
+            #[cfg(test)]
+            backup_workers_live: AtomicUsize::new(0),
+        }
+    }
+
     fn thread_count(&self) -> usize {
         self.thread_count
     }
@@ -388,6 +412,26 @@ impl ThreadPoolState {
             Err(payload) => panic::resume_unwind(payload),
         }
     }
+
+    fn wait_for_notification(&self, notification: &Notification) {
+        if !is_background_worker_thread() || notification.has_been_notified() {
+            notification.wait();
+            return;
+        }
+
+        let _backup = BackupWorker::spawn(self);
+        notification.wait();
+    }
+
+    #[cfg(test)]
+    fn backup_workers_spawned(&self) -> usize {
+        self.backup_workers_spawned.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    fn backup_workers_live(&self) -> usize {
+        self.backup_workers_live.load(Ordering::Acquire)
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -410,6 +454,11 @@ impl ThreadPoolStatePtr {
 // `ThreadPool`. `ThreadPool::drop` closes the work channel, joins all workers
 // holding this pointer, and only then drops the boxed state.
 unsafe impl Send for ThreadPoolStatePtr {}
+
+// SAFETY: shared access through this pointer only reads immutable pool state or
+// uses internally synchronized channel and atomic operations. The pointed-to
+// boxed state remains alive until all worker threads have been joined.
+unsafe impl Sync for ThreadPoolStatePtr {}
 
 fn install_pool<F, R>(pool: &ThreadPoolState, f: F) -> R
 where
@@ -438,6 +487,32 @@ impl Drop for CurrentPoolGuard<'_> {
     fn drop(&mut self) {
         self.current.set(self.previous);
     }
+}
+
+fn install_background_worker<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    IS_BACKGROUND_WORKER.with(|current| {
+        let previous = current.replace(true);
+        let _guard = BackgroundWorkerGuard { current, previous };
+        f()
+    })
+}
+
+struct BackgroundWorkerGuard<'a> {
+    current: &'a Cell<bool>,
+    previous: bool,
+}
+
+impl Drop for BackgroundWorkerGuard<'_> {
+    fn drop(&mut self) {
+        self.current.set(self.previous);
+    }
+}
+
+fn is_background_worker_thread() -> bool {
+    IS_BACKGROUND_WORKER.with(Cell::get)
 }
 
 fn with_current_pool<F, R>(f: F) -> R
@@ -480,6 +555,7 @@ where
 /// ```
 pub struct Scope<'scope> {
     sender: Sender<Job>,
+    pool: ThreadPoolStatePtr,
     state: ScopeState,
     _scope: PhantomData<fn(&'scope ()) -> &'scope ()>,
 }
@@ -488,6 +564,7 @@ impl<'scope> Scope<'scope> {
     fn new(pool: &ThreadPoolState) -> Self {
         Self {
             sender: pool.sender.as_ref().unwrap().clone(),
+            pool: ThreadPoolStatePtr::new(pool),
             state: ScopeState::new(),
             _scope: PhantomData,
         }
@@ -551,7 +628,12 @@ impl<'scope> Scope<'scope> {
 
     fn complete_root_and_wait(&self) {
         if !self.state.complete_one() {
-            self.state.wait();
+            // SAFETY: the scope is created from a live `ThreadPoolState`, and
+            // `ThreadPool::drop` joins all workers before dropping that boxed
+            // state. Scopes cannot outlive the `ThreadPool::scope` call that
+            // created them.
+            let pool = unsafe { self.pool.as_ref() };
+            self.state.wait(pool);
         }
     }
 }
@@ -589,8 +671,8 @@ impl ScopeState {
         }
     }
 
-    fn wait(&self) {
-        self.finished.wait();
+    fn wait(&self, pool: &ThreadPoolState) {
+        pool.wait_for_notification(&self.finished);
     }
 
     fn record_panic(&self, payload: PanicPayload) {
@@ -670,14 +752,92 @@ unsafe fn erase_job_lifetime<'scope>(job: ScopedJob<'scope>) -> Job {
     unsafe { mem::transmute::<ScopedJob<'scope>, Job>(job) }
 }
 
+struct BackupWorker {
+    shutdown: Sender<()>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl BackupWorker {
+    fn spawn(pool: &ThreadPoolState) -> Self {
+        #[cfg(test)]
+        pool.backup_workers_spawned.fetch_add(1, Ordering::AcqRel);
+
+        let (shutdown, shutdown_receiver) = bounded(1);
+        let receiver = pool.receiver.clone();
+        let pool = ThreadPoolStatePtr::new(pool);
+        let worker = thread::spawn(move || {
+            // SAFETY: backup workers are joined by the worker that spawned them
+            // before that worker resumes, and primary workers are joined before
+            // the boxed pool state is dropped.
+            let pool = unsafe { pool.as_ref() };
+            #[cfg(test)]
+            let _live = BackupWorkerLiveGuard::new(pool);
+
+            install_pool(pool, || {
+                install_background_worker(|| {
+                    loop {
+                        select_biased! {
+                            recv(shutdown_receiver) -> _ => break,
+                            recv(receiver) -> message => match message {
+                                Ok(job) => job(),
+                                Err(_) => break,
+                            },
+                        }
+                    }
+                });
+            });
+        });
+
+        Self {
+            shutdown,
+            worker: Some(worker),
+        }
+    }
+
+    fn shutdown_and_join(&mut self) {
+        let _ = self.shutdown.send(());
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+impl Drop for BackupWorker {
+    fn drop(&mut self) {
+        self.shutdown_and_join();
+    }
+}
+
+#[cfg(test)]
+struct BackupWorkerLiveGuard<'a> {
+    pool: &'a ThreadPoolState,
+}
+
+#[cfg(test)]
+impl<'a> BackupWorkerLiveGuard<'a> {
+    fn new(pool: &'a ThreadPoolState) -> Self {
+        pool.backup_workers_live.fetch_add(1, Ordering::AcqRel);
+        Self { pool }
+    }
+}
+
+#[cfg(test)]
+impl Drop for BackupWorkerLiveGuard<'_> {
+    fn drop(&mut self) {
+        self.pool.backup_workers_live.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
 fn spawn_worker(receiver: Receiver<Job>, pool: ThreadPoolStatePtr) -> JoinHandle<()> {
     thread::spawn(move || {
         // SAFETY: each worker is joined before the boxed pool state is dropped.
         let pool = unsafe { pool.as_ref() };
         install_pool(pool, || {
-            for job in receiver {
-                job();
-            }
+            install_background_worker(|| {
+                for job in receiver {
+                    job();
+                }
+            });
         });
     })
 }

--- a/concurrency/src/threadpool/mod.rs
+++ b/concurrency/src/threadpool/mod.rs
@@ -2,11 +2,12 @@
 //!
 //! [`ThreadPool`] owns a fixed set of primary worker threads. Each worker
 //! receives boxed `'static` jobs from a shared channel and exits when the
-//! channel is closed. A primary worker that blocks waiting for scoped work
-//! temporarily starts a backup worker so the pool can continue draining queued
-//! jobs. [`Scope`] provides the safe scoped API on top of those `'static` jobs
-//! by erasing task lifetimes when work is sent to the channel, then waiting for
-//! all work in the scope before returning to the caller.
+//! channel is closed. A primary worker that blocks waiting for nested scoped
+//! work helps drain queued jobs until that nested scope completes, so the pool
+//! does not lose a worker while work it needs may still be queued. [`Scope`]
+//! provides the safe scoped API on top of those `'static` jobs by erasing task
+//! lifetimes when work is sent to the channel, then waiting for all work in the
+//! scope before returning to the caller.
 //!
 //! The root callback runs on the caller thread, and spawned callbacks run on
 //! worker threads. Spawned callbacks receive the same scope reference as the
@@ -111,10 +112,11 @@ use std::sync::atomic::AtomicUsize;
 
 use crossbeam::channel::{Receiver, Sender, bounded, select_biased, unbounded};
 
-use crate::Notification;
-
 const EXPECTED_SHIFT: u32 = 32;
 const COMPLETED_MASK: u64 = u32::MAX as u64;
+// Keep inline helping bounded so pathological nested scopes move onto a fresh
+// stack before exhausting the current worker stack.
+const MAX_INLINE_SCOPE_HELP_DEPTH: usize = 64;
 
 type Job = Box<dyn FnOnce() + Send + 'static>;
 type ScopedJob<'scope> = Box<dyn FnOnce() + Send + 'scope>;
@@ -123,6 +125,7 @@ type PanicPayload = Box<dyn Any + Send + 'static>;
 thread_local! {
     static CURRENT_POOL: Cell<*const ThreadPoolState> = const { Cell::new(ptr::null()) };
     static IS_BACKGROUND_WORKER: Cell<bool> = const { Cell::new(false) };
+    static INLINE_SCOPE_HELP_DEPTH: Cell<usize> = const { Cell::new(0) };
 }
 
 /// Return the number of threads in the currently installed thread pool.
@@ -194,9 +197,9 @@ where
 
 /// A thread pool using a single shared work queue.
 ///
-/// The pool owns a fixed number of primary workers. It may also create
-/// short-lived backup workers while a primary worker is blocked waiting for
-/// nested scoped work.
+/// The pool owns a fixed number of primary workers. A primary worker that
+/// blocks waiting for nested scoped work helps drain the shared queue until the
+/// nested scope completes.
 ///
 /// # Examples
 ///
@@ -413,14 +416,54 @@ impl ThreadPoolState {
         }
     }
 
-    fn wait_for_notification(&self, notification: &Notification) {
-        if !is_background_worker_thread() || notification.has_been_notified() {
-            notification.wait();
+    fn wait_for_scope_completion(&self, done: &Receiver<()>) {
+        if !is_background_worker_thread() {
+            receive_scope_completion(done);
             return;
         }
 
-        let _backup = BackupWorker::spawn(self);
-        notification.wait();
+        let Some(_guard) = InlineScopeHelpGuard::try_enter() else {
+            let _backup = BackupWorker::spawn(self);
+            receive_scope_completion(done);
+            return;
+        };
+
+        let receiver = self.receiver.clone();
+        loop {
+            match done.try_recv() {
+                Ok(()) => break,
+                Err(crossbeam::channel::TryRecvError::Empty) => {}
+                Err(crossbeam::channel::TryRecvError::Disconnected) => {
+                    panic!("scope completion sender dropped before the scope completed");
+                }
+            }
+
+            match receiver.try_recv() {
+                Ok(job) => {
+                    job();
+                    continue;
+                }
+                Err(crossbeam::channel::TryRecvError::Empty) => {}
+                Err(crossbeam::channel::TryRecvError::Disconnected) => {
+                    receive_scope_completion(done);
+                    break;
+                }
+            }
+
+            select_biased! {
+                recv(done) -> message => {
+                    expect_scope_completion(message);
+                    break;
+                }
+                recv(receiver) -> message => match message {
+                    Ok(job) => job(),
+                    Err(_) => {
+                        receive_scope_completion(done);
+                        break;
+                    }
+                },
+            }
+        }
     }
 
     #[cfg(test)]
@@ -513,6 +556,30 @@ impl Drop for BackgroundWorkerGuard<'_> {
 
 fn is_background_worker_thread() -> bool {
     IS_BACKGROUND_WORKER.with(Cell::get)
+}
+
+struct InlineScopeHelpGuard {
+    previous: usize,
+}
+
+impl InlineScopeHelpGuard {
+    fn try_enter() -> Option<Self> {
+        INLINE_SCOPE_HELP_DEPTH.with(|depth| {
+            let previous = depth.get();
+            if previous >= MAX_INLINE_SCOPE_HELP_DEPTH {
+                return None;
+            }
+
+            depth.set(previous + 1);
+            Some(Self { previous })
+        })
+    }
+}
+
+impl Drop for InlineScopeHelpGuard {
+    fn drop(&mut self) {
+        INLINE_SCOPE_HELP_DEPTH.with(|depth| depth.set(self.previous));
+    }
 }
 
 fn with_current_pool<F, R>(f: F) -> R
@@ -640,15 +707,18 @@ impl<'scope> Scope<'scope> {
 
 struct ScopeState {
     completion: AtomicCounts,
-    finished: Notification,
+    done_sender: Sender<()>,
+    done_receiver: Receiver<()>,
     panic: Mutex<Option<PanicPayload>>,
 }
 
 impl ScopeState {
     fn new() -> Self {
+        let (done_sender, done_receiver) = bounded(1);
         Self {
             completion: AtomicCounts::with_root_callback(),
-            finished: Notification::new(),
+            done_sender,
+            done_receiver,
             panic: Mutex::new(None),
         }
     }
@@ -664,7 +734,13 @@ impl ScopeState {
         debug_assert!(completed <= expected);
 
         if completed == expected {
-            self.finished.notify();
+            // Keep the channel alive while signaling completion. Once the
+            // message is visible, the waiting root may receive it and drop the
+            // `ScopeState` before `try_send` returns on this worker.
+            let done_sender = self.done_sender.clone();
+            done_sender
+                .try_send(())
+                .expect("scope completion should only be signaled once");
             true
         } else {
             false
@@ -672,7 +748,7 @@ impl ScopeState {
     }
 
     fn wait(&self, pool: &ThreadPoolState) {
-        pool.wait_for_notification(&self.finished);
+        pool.wait_for_scope_completion(&self.done_receiver);
     }
 
     fn record_panic(&self, payload: PanicPayload) {
@@ -752,20 +828,22 @@ unsafe fn erase_job_lifetime<'scope>(job: ScopedJob<'scope>) -> Job {
     unsafe { mem::transmute::<ScopedJob<'scope>, Job>(job) }
 }
 
-/// A short-lived queue consumer that replaces a blocked background worker.
+fn receive_scope_completion(done: &Receiver<()>) {
+    expect_scope_completion(done.recv());
+}
+
+fn expect_scope_completion(message: Result<(), crossbeam::channel::RecvError>) {
+    message.expect("scope completion sender dropped before the scope completed");
+}
+
+/// A short-lived queue consumer used once inline scope helping gets too deep.
 ///
-/// Scoped work may itself open a nested scope. If the worker running that outer
-/// job blocks waiting for the nested scope to finish, the pool has one fewer
-/// thread draining the shared job queue. With a one-thread pool, that would
-/// deadlock: the only primary worker would be asleep while the nested job it is
-/// waiting for is still queued. `BackupWorker` temporarily clones the pool's
-/// receiver, installs the same current-pool and background-worker thread-local
-/// state as a primary worker, and runs queued jobs until the blocked worker
-/// finishes waiting.
-///
-/// The guard owns a shutdown channel and joins the spawned thread on drop, so a
-/// backup worker is tied to exactly one blocking wait. It also exits if the pool
-/// work channel is closed.
+/// A worker that waits for nested scoped work usually helps by running queued
+/// jobs on the same stack. Deeply nested scopes can make that recursive
+/// execution chain large enough to overflow the worker stack. `BackupWorker`
+/// provides the same liveness escape hatch as the original implementation, but
+/// only after the waiting worker has already helped inline up to
+/// [`MAX_INLINE_SCOPE_HELP_DEPTH`].
 struct BackupWorker {
     shutdown: Sender<()>,
     worker: Option<JoinHandle<()>>,

--- a/concurrency/src/threadpool/mod.rs
+++ b/concurrency/src/threadpool/mod.rs
@@ -152,6 +152,33 @@ pub fn current_num_threads() -> usize {
     with_current_pool(|pool| pool.map_or(1, ThreadPoolState::thread_count))
 }
 
+/// Run `f` with no current thread pool installed on this thread.
+///
+/// This is useful for serial operations that must not inherit an ambient pool.
+/// The previous current pool, if any, is restored before this function returns
+/// or unwinds.
+///
+/// # Examples
+///
+/// ```
+/// use egglog_concurrency::{ThreadPool, current_num_threads, without_current_pool};
+///
+/// let pool = ThreadPool::new(2);
+/// pool.install(|| {
+///     assert_eq!(current_num_threads(), 2);
+///     without_current_pool(|| {
+///         assert_eq!(current_num_threads(), 1);
+///     });
+///     assert_eq!(current_num_threads(), 2);
+/// });
+/// ```
+pub fn without_current_pool<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    install_pool_ptr(ptr::null(), f)
+}
+
 /// Run `f` in a scope on the currently installed thread pool.
 ///
 /// This is the free-function counterpart to [`ThreadPool::scope`]. It keeps the

--- a/concurrency/src/threadpool/tests.rs
+++ b/concurrency/src/threadpool/tests.rs
@@ -10,7 +10,7 @@ use std::{
 
 use crate::{Notification, Scope, ThreadPool, current_num_threads, scope as threadpool_scope};
 
-use super::is_background_worker_thread;
+use super::{MAX_INLINE_SCOPE_HELP_DEPTH, is_background_worker_thread};
 
 #[test]
 fn scope_runs_spawned_work_and_waits() {
@@ -384,6 +384,9 @@ fn pool_scope_installs_pool_for_root_and_spawned_callbacks() {
             assert_eq!(current_num_threads(), 4);
         });
     });
+
+    assert_eq!(pool.state.backup_workers_spawned(), 0);
+    assert_eq!(pool.state.backup_workers_live(), 0);
 }
 
 #[test]
@@ -443,7 +446,7 @@ fn primary_workers_are_marked_as_background_workers() {
 }
 
 #[test]
-fn root_scope_wait_does_not_spawn_backup_worker() {
+fn root_scope_waits_for_spawned_work() {
     let pool = ThreadPool::new(1);
     let entered = Arc::new(Notification::new());
     let release = Arc::new(Notification::new());
@@ -463,15 +466,15 @@ fn root_scope_wait_does_not_spawn_backup_worker() {
 
         entered.wait();
         thread::sleep(Duration::from_millis(10));
-        assert_eq!(pool.state.backup_workers_spawned(), 0);
         release.notify();
     });
 
+    assert_eq!(pool.state.backup_workers_spawned(), 0);
     assert_eq!(pool.state.backup_workers_live(), 0);
 }
 
 #[test]
-fn backup_worker_avoids_single_worker_nested_scope_deadlock() {
+fn background_worker_helps_single_worker_nested_scope() {
     let pool = ThreadPool::new(1);
     let nested_completed = AtomicBool::new(false);
 
@@ -488,12 +491,12 @@ fn backup_worker_avoids_single_worker_nested_scope_deadlock() {
     });
 
     assert!(nested_completed.load(Ordering::Acquire));
-    assert!(pool.state.backup_workers_spawned() >= 1);
+    assert_eq!(pool.state.backup_workers_spawned(), 0);
     assert_eq!(pool.state.backup_workers_live(), 0);
 }
 
 #[test]
-fn backup_worker_exits_after_blocked_scope_finishes() {
+fn background_worker_wait_returns_after_nested_scope_finishes() {
     let pool = ThreadPool::new(1);
     let nested_started = Arc::new(Notification::new());
     let release_nested = Arc::new(Notification::new());
@@ -519,20 +522,18 @@ fn backup_worker_exits_after_blocked_scope_finishes() {
         });
 
         nested_started.wait();
-        while pool.state.backup_workers_live() == 0 {
-            thread::yield_now();
-        }
+        thread::sleep(Duration::from_millis(10));
         assert!(!scope_returned.load(Ordering::Acquire));
         release_nested.notify();
     });
 
     assert!(scope_returned.load(Ordering::Acquire));
+    assert_eq!(pool.state.backup_workers_spawned(), 0);
     assert_eq!(pool.state.backup_workers_live(), 0);
-    assert_eq!(pool.state.backup_workers_spawned(), 1);
 }
 
 #[test]
-fn backup_workers_can_replace_backup_workers_that_block() {
+fn nested_background_worker_waits_can_reenter_help_loop() {
     let pool = ThreadPool::new(1);
     let completed = AtomicUsize::new(0);
 
@@ -552,6 +553,33 @@ fn backup_workers_can_replace_backup_workers_that_block() {
     });
 
     assert_eq!(completed.load(Ordering::Acquire), 1);
-    assert!(pool.state.backup_workers_spawned() >= 2);
+    assert_eq!(pool.state.backup_workers_spawned(), 0);
+    assert_eq!(pool.state.backup_workers_live(), 0);
+}
+
+#[test]
+fn deeply_nested_background_waits_fall_back_to_backup_worker() {
+    fn recurse(depth: usize, completed: &AtomicUsize) {
+        if depth == 0 {
+            completed.fetch_add(1, Ordering::Release);
+            return;
+        }
+
+        threadpool_scope(|scope| {
+            scope.spawn(move |_| recurse(depth - 1, completed));
+        });
+    }
+
+    let pool = ThreadPool::new(1);
+    let completed = AtomicUsize::new(0);
+
+    pool.scope(|scope| {
+        scope.spawn(|_| {
+            recurse(MAX_INLINE_SCOPE_HELP_DEPTH + 8, &completed);
+        });
+    });
+
+    assert_eq!(completed.load(Ordering::Acquire), 1);
+    assert!(pool.state.backup_workers_spawned() >= 1);
     assert_eq!(pool.state.backup_workers_live(), 0);
 }

--- a/concurrency/src/threadpool/tests.rs
+++ b/concurrency/src/threadpool/tests.rs
@@ -1,0 +1,428 @@
+use std::{
+    panic,
+    sync::{
+        Arc, Barrier, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+use crate::{Notification, Scope, ThreadPool, current_num_threads, scope as threadpool_scope};
+
+#[test]
+fn scope_runs_spawned_work_and_waits() {
+    let pool = ThreadPool::new(4);
+    let counter = AtomicUsize::new(0);
+
+    pool.scope(|scope| {
+        for _ in 0..128 {
+            scope.spawn(|_| {
+                counter.fetch_add(1, Ordering::Relaxed);
+            });
+        }
+    });
+
+    assert_eq!(counter.load(Ordering::Relaxed), 128);
+}
+
+#[test]
+fn scope_allows_borrowing_stack_data() {
+    let pool = ThreadPool::new(2);
+    let values = [1usize, 3, 5, 7, 11];
+    let sum = AtomicUsize::new(0);
+
+    pool.scope(|scope| {
+        for value in &values {
+            scope.spawn(|_| {
+                sum.fetch_add(*value, Ordering::Relaxed);
+            });
+        }
+    });
+
+    assert_eq!(sum.load(Ordering::Relaxed), values.iter().sum());
+}
+
+#[test]
+fn scope_allows_one_task_to_mutate_stack_data() {
+    let pool = ThreadPool::new(1);
+    let mut value = 0;
+
+    pool.scope(|scope| {
+        scope.spawn(|_| {
+            value = 42;
+        });
+    });
+
+    assert_eq!(value, 42);
+}
+
+#[test]
+fn scope_handles_work_completed_before_expected_is_published() {
+    let pool = ThreadPool::new(4);
+    let counter = AtomicUsize::new(0);
+    const TASKS: usize = 64;
+
+    pool.scope(|scope| {
+        for _ in 0..TASKS {
+            scope.spawn(|_| {
+                counter.fetch_add(1, Ordering::Release);
+            });
+        }
+
+        while counter.load(Ordering::Acquire) != TASKS {
+            thread::yield_now();
+        }
+    });
+
+    assert_eq!(counter.load(Ordering::Acquire), TASKS);
+}
+
+#[test]
+fn scope_waits_for_last_work_after_expected_is_published() {
+    let pool = ThreadPool::new(2);
+    let release = Arc::new(Notification::new());
+    let entered = Arc::new(Notification::new());
+    let scope_returned = Arc::new(AtomicBool::new(false));
+
+    thread::scope(|thread_scope| {
+        let release_inner = release.clone();
+        let entered_inner = entered.clone();
+        let scope_returned_inner = scope_returned.clone();
+        let pool = &pool;
+        thread_scope.spawn(move || {
+            pool.scope(|scope| {
+                scope.spawn(move |_| {
+                    entered_inner.notify();
+                    release_inner.wait();
+                });
+            });
+            scope_returned_inner.store(true, Ordering::Release);
+        });
+
+        entered.wait();
+        thread::sleep(Duration::from_millis(10));
+        assert!(!scope_returned.load(Ordering::Acquire));
+        release.notify();
+    });
+
+    assert!(scope_returned.load(Ordering::Acquire));
+}
+
+#[test]
+fn many_scopes_cover_completion_races() {
+    let pool = ThreadPool::new(4);
+
+    for round in 0..512 {
+        let counter = AtomicUsize::new(0);
+        let tasks = round % 65;
+
+        pool.scope(|scope| {
+            for task in 0..tasks {
+                let counter = &counter;
+                scope.spawn(move |_| {
+                    if task % 3 == 0 {
+                        thread::yield_now();
+                    }
+                    counter.fetch_add(1, Ordering::AcqRel);
+                });
+            }
+
+            if round % 2 == 0 {
+                while counter.load(Ordering::Acquire) != tasks {
+                    thread::yield_now();
+                }
+            }
+        });
+
+        assert_eq!(counter.load(Ordering::Acquire), tasks);
+    }
+}
+
+#[test]
+fn blocked_tasks_complete_together() {
+    let pool = ThreadPool::new(8);
+    let barrier = Arc::new(Barrier::new(8));
+    let counter = AtomicUsize::new(0);
+
+    pool.scope(|scope| {
+        for _ in 0..8 {
+            let barrier = barrier.clone();
+            let counter = &counter;
+            scope.spawn(move |_| {
+                barrier.wait();
+                counter.fetch_add(1, Ordering::AcqRel);
+            });
+        }
+    });
+
+    assert_eq!(counter.load(Ordering::Acquire), 8);
+}
+
+#[test]
+fn nested_spawn_runs_to_completion() {
+    let pool = ThreadPool::new(4);
+    let counter = AtomicUsize::new(0);
+
+    pool.scope(|scope| {
+        for _ in 0..8 {
+            scope.spawn(|scope| {
+                counter.fetch_add(1, Ordering::AcqRel);
+                for _ in 0..8 {
+                    scope.spawn(|_| {
+                        counter.fetch_add(1, Ordering::AcqRel);
+                    });
+                }
+            });
+        }
+    });
+
+    assert_eq!(counter.load(Ordering::Acquire), 72);
+}
+
+#[test]
+fn nested_spawn_can_borrow_scope_data() {
+    let pool = ThreadPool::new(4);
+    let values = [2usize, 4, 8, 16];
+    let sum = AtomicUsize::new(0);
+
+    pool.scope(|scope| {
+        for value in &values {
+            let sum = &sum;
+            scope.spawn(move |scope| {
+                scope.spawn(move |_| {
+                    sum.fetch_add(*value, Ordering::AcqRel);
+                });
+            });
+        }
+    });
+
+    assert_eq!(sum.load(Ordering::Acquire), values.iter().sum());
+}
+
+#[test]
+fn nested_work_spawned_after_root_callback_returns_is_waited_for() {
+    let pool = ThreadPool::new(2);
+    let root_returned = Arc::new(Notification::new());
+    let release_nested_spawn = Arc::new(Notification::new());
+    let nested_ran = Arc::new(AtomicBool::new(false));
+    let scope_returned = Arc::new(AtomicBool::new(false));
+
+    thread::scope(|thread_scope| {
+        let root_returned_inner = root_returned.clone();
+        let release_nested_spawn_inner = release_nested_spawn.clone();
+        let nested_ran_inner = nested_ran.clone();
+        let scope_returned_inner = scope_returned.clone();
+        let pool = &pool;
+
+        thread_scope.spawn(move || {
+            pool.scope(|scope| {
+                scope.spawn(move |scope| {
+                    root_returned_inner.wait();
+                    release_nested_spawn_inner.wait();
+                    scope.spawn(move |_| {
+                        nested_ran_inner.store(true, Ordering::Release);
+                    });
+                });
+            });
+            scope_returned_inner.store(true, Ordering::Release);
+        });
+
+        root_returned.notify();
+        thread::sleep(Duration::from_millis(10));
+        assert!(!scope_returned.load(Ordering::Acquire));
+        release_nested_spawn.notify();
+    });
+
+    assert!(nested_ran.load(Ordering::Acquire));
+    assert!(scope_returned.load(Ordering::Acquire));
+}
+
+#[test]
+fn scope_root_callback_can_borrow_shorter_scheduling_data() {
+    fn increment<'slice, 'counter>(pool: &ThreadPool, counters: &'slice [&'counter AtomicUsize]) {
+        pool.scope(move |scope: &Scope<'counter>| {
+            for &counter in counters {
+                scope.spawn(move |_| {
+                    counter.fetch_add(1, Ordering::Relaxed);
+                });
+            }
+        });
+    }
+
+    let pool = ThreadPool::new(4);
+    let counter = AtomicUsize::new(0);
+    increment(&pool, &[&counter; 64]);
+
+    assert_eq!(counter.load(Ordering::Relaxed), 64);
+}
+
+#[test]
+fn static_scope_still_allows_local_scheduling_iterator() {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    let pool = ThreadPool::new(4);
+    let mut range = 0..32;
+    let expected = range.clone().sum();
+    let iter = &mut range;
+
+    COUNTER.store(0, Ordering::Relaxed);
+    pool.scope(|scope: &Scope<'static>| {
+        for value in iter {
+            scope.spawn(move |_| {
+                COUNTER.fetch_add(value, Ordering::Relaxed);
+            });
+        }
+    });
+
+    assert_eq!(COUNTER.load(Ordering::Relaxed), expected);
+}
+
+#[test]
+fn worker_panic_is_propagated_after_other_tasks_finish() {
+    let pool = ThreadPool::new(2);
+    let completed = Arc::new(AtomicUsize::new(0));
+
+    let result = {
+        let completed = completed.clone();
+        panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            pool.scope(|scope| {
+                scope.spawn(|_| panic!("worker panic"));
+                scope.spawn(move |_| {
+                    completed.fetch_add(1, Ordering::Release);
+                });
+            });
+        }))
+    };
+
+    assert!(result.is_err());
+    assert_eq!(completed.load(Ordering::Acquire), 1);
+}
+
+#[test]
+fn outer_panic_still_waits_for_spawned_work() {
+    let pool = ThreadPool::new(1);
+    let completed = AtomicBool::new(false);
+
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        pool.scope(|scope| {
+            scope.spawn(|_| {
+                completed.store(true, Ordering::Release);
+            });
+            panic!("outer panic");
+        });
+    }));
+
+    assert!(result.is_err());
+    assert!(completed.load(Ordering::Acquire));
+}
+
+#[test]
+fn parallel_for_each_processes_borrowed_items() {
+    let pool = ThreadPool::new(4);
+    let values = vec![1usize, 2, 3, 4, 5, 6];
+    let seen = Mutex::new(Vec::new());
+
+    pool.parallel_for_each(values.iter(), |value| {
+        seen.lock().unwrap().push(*value);
+    });
+
+    let mut seen = seen.into_inner().unwrap();
+    seen.sort_unstable();
+    assert_eq!(seen, values);
+}
+
+#[test]
+fn parallel_for_each_waits_for_all_work() {
+    let pool = ThreadPool::new(4);
+    let counter = AtomicUsize::new(0);
+
+    pool.parallel_for_each(0..256, |_| {
+        counter.fetch_add(1, Ordering::AcqRel);
+    });
+
+    assert_eq!(counter.load(Ordering::Acquire), 256);
+}
+
+#[test]
+fn dropping_pool_closes_workers() {
+    let pool = ThreadPool::new(4);
+    assert_eq!(pool.thread_count(), 4);
+    drop(pool);
+}
+
+#[test]
+fn current_num_threads_is_one_without_installed_pool() {
+    assert_eq!(current_num_threads(), 1);
+}
+
+#[test]
+fn install_sets_and_restores_current_pool() {
+    let outer = ThreadPool::new(2);
+    let inner = ThreadPool::new(3);
+
+    assert_eq!(current_num_threads(), 1);
+    outer.install(|| {
+        assert_eq!(current_num_threads(), 2);
+        inner.install(|| {
+            assert_eq!(current_num_threads(), 3);
+        });
+        assert_eq!(current_num_threads(), 2);
+    });
+    assert_eq!(current_num_threads(), 1);
+}
+
+#[test]
+fn pool_scope_installs_pool_for_root_and_spawned_callbacks() {
+    let pool = ThreadPool::new(4);
+
+    pool.scope(|scope| {
+        assert_eq!(current_num_threads(), 4);
+        scope.spawn(|_| {
+            assert_eq!(current_num_threads(), 4);
+        });
+    });
+}
+
+#[test]
+fn free_scope_uses_installed_pool() {
+    let pool = ThreadPool::new(4);
+    let counter = AtomicUsize::new(0);
+
+    pool.install(|| {
+        threadpool_scope(|scope| {
+            assert_eq!(current_num_threads(), 4);
+            scope.spawn(|_| {
+                assert_eq!(current_num_threads(), 4);
+                counter.fetch_add(1, Ordering::Relaxed);
+            });
+        });
+    });
+
+    assert_eq!(counter.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn free_scope_works_from_spawned_callback() {
+    let pool = ThreadPool::new(4);
+    let counter = AtomicUsize::new(0);
+
+    pool.scope(|scope| {
+        scope.spawn(|_| {
+            threadpool_scope(|scope| {
+                scope.spawn(|_| {
+                    assert_eq!(current_num_threads(), 4);
+                    counter.fetch_add(1, Ordering::Relaxed);
+                });
+            });
+        });
+    });
+
+    assert_eq!(counter.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+#[should_panic(expected = "no egglog thread pool is currently installed")]
+fn free_scope_panics_without_installed_pool() {
+    threadpool_scope(|_| {});
+}

--- a/concurrency/src/threadpool/tests.rs
+++ b/concurrency/src/threadpool/tests.rs
@@ -10,6 +10,8 @@ use std::{
 
 use crate::{Notification, Scope, ThreadPool, current_num_threads, scope as threadpool_scope};
 
+use super::is_background_worker_thread;
+
 #[test]
 fn scope_runs_spawned_work_and_waits() {
     let pool = ThreadPool::new(4);
@@ -425,4 +427,131 @@ fn free_scope_works_from_spawned_callback() {
 #[should_panic(expected = "no egglog thread pool is currently installed")]
 fn free_scope_panics_without_installed_pool() {
     threadpool_scope(|_| {});
+}
+
+#[test]
+fn primary_workers_are_marked_as_background_workers() {
+    let pool = ThreadPool::new(1);
+
+    assert!(!is_background_worker_thread());
+    pool.scope(|scope| {
+        assert!(!is_background_worker_thread());
+        scope.spawn(|_| {
+            assert!(is_background_worker_thread());
+        });
+    });
+}
+
+#[test]
+fn root_scope_wait_does_not_spawn_backup_worker() {
+    let pool = ThreadPool::new(1);
+    let entered = Arc::new(Notification::new());
+    let release = Arc::new(Notification::new());
+
+    thread::scope(|thread_scope| {
+        let entered_inner = entered.clone();
+        let release_inner = release.clone();
+        let pool = &pool;
+        thread_scope.spawn(move || {
+            pool.scope(|scope| {
+                scope.spawn(move |_| {
+                    entered_inner.notify();
+                    release_inner.wait();
+                });
+            });
+        });
+
+        entered.wait();
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(pool.state.backup_workers_spawned(), 0);
+        release.notify();
+    });
+
+    assert_eq!(pool.state.backup_workers_live(), 0);
+}
+
+#[test]
+fn backup_worker_avoids_single_worker_nested_scope_deadlock() {
+    let pool = ThreadPool::new(1);
+    let nested_completed = AtomicBool::new(false);
+
+    pool.scope(|scope| {
+        scope.spawn(|_| {
+            threadpool_scope(|nested| {
+                nested.spawn(|_| {
+                    assert!(is_background_worker_thread());
+                    assert_eq!(current_num_threads(), 1);
+                    nested_completed.store(true, Ordering::Release);
+                });
+            });
+        });
+    });
+
+    assert!(nested_completed.load(Ordering::Acquire));
+    assert!(pool.state.backup_workers_spawned() >= 1);
+    assert_eq!(pool.state.backup_workers_live(), 0);
+}
+
+#[test]
+fn backup_worker_exits_after_blocked_scope_finishes() {
+    let pool = ThreadPool::new(1);
+    let nested_started = Arc::new(Notification::new());
+    let release_nested = Arc::new(Notification::new());
+    let scope_returned = Arc::new(AtomicBool::new(false));
+
+    thread::scope(|thread_scope| {
+        let nested_started_inner = nested_started.clone();
+        let release_nested_inner = release_nested.clone();
+        let scope_returned_inner = scope_returned.clone();
+        let pool = &pool;
+        thread_scope.spawn(move || {
+            pool.scope(|scope| {
+                scope.spawn(move |_| {
+                    threadpool_scope(|nested| {
+                        nested.spawn(move |_| {
+                            nested_started_inner.notify();
+                            release_nested_inner.wait();
+                        });
+                    });
+                });
+            });
+            scope_returned_inner.store(true, Ordering::Release);
+        });
+
+        nested_started.wait();
+        while pool.state.backup_workers_live() == 0 {
+            thread::yield_now();
+        }
+        assert!(!scope_returned.load(Ordering::Acquire));
+        release_nested.notify();
+    });
+
+    assert!(scope_returned.load(Ordering::Acquire));
+    assert_eq!(pool.state.backup_workers_live(), 0);
+    assert_eq!(pool.state.backup_workers_spawned(), 1);
+}
+
+#[test]
+fn backup_workers_can_replace_backup_workers_that_block() {
+    let pool = ThreadPool::new(1);
+    let completed = AtomicUsize::new(0);
+
+    pool.scope(|scope| {
+        scope.spawn(|_| {
+            threadpool_scope(|scope| {
+                scope.spawn(|_| {
+                    threadpool_scope(|scope| {
+                        scope.spawn(|_| {
+                            assert!(is_background_worker_thread());
+                            completed.fetch_add(1, Ordering::Release);
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    assert_eq!(completed.load(Ordering::Acquire), 1);
+    assert!(pool.state.backup_workers_spawned() >= 2);
+    assert_eq!(pool.state.backup_workers_live(), 0);
 }

--- a/concurrency/src/threadpool/tests.rs
+++ b/concurrency/src/threadpool/tests.rs
@@ -8,7 +8,10 @@ use std::{
     time::Duration,
 };
 
-use crate::{Notification, Scope, ThreadPool, current_num_threads, scope as threadpool_scope};
+use crate::{
+    Notification, Scope, ThreadPool, current_num_threads, scope as threadpool_scope,
+    without_current_pool,
+};
 
 use super::{MAX_INLINE_SCOPE_HELP_DEPTH, is_background_worker_thread};
 
@@ -371,6 +374,21 @@ fn install_sets_and_restores_current_pool() {
         });
         assert_eq!(current_num_threads(), 2);
     });
+    assert_eq!(current_num_threads(), 1);
+}
+
+#[test]
+fn without_current_pool_clears_and_restores_current_pool() {
+    let pool = ThreadPool::new(2);
+
+    pool.install(|| {
+        assert_eq!(current_num_threads(), 2);
+        without_current_pool(|| {
+            assert_eq!(current_num_threads(), 1);
+        });
+        assert_eq!(current_num_threads(), 2);
+    });
+
     assert_eq!(current_num_threads(), 1);
 }
 

--- a/core-relations/Cargo.toml
+++ b/core-relations/Cargo.toml
@@ -28,7 +28,6 @@ crossbeam = { workspace = true }
 crossbeam-queue = { workspace = true }
 dashmap = { workspace = true, features = ["raw-api"] }
 web-time = { workspace = true }
-rayon = { workspace = true }
 rand = { workspace = true }
 dyn-clone = { workspace = true }
 num = { workspace = true }
@@ -37,6 +36,7 @@ once_cell = { workspace = true }
 [dev-dependencies]
 divan = { workspace = true }
 mimalloc = { workspace = true }
+rayon = { workspace = true }
 
 [[bench]]
 name = "writes"

--- a/core-relations/src/containers/mod.rs
+++ b/core-relations/src/containers/mod.rs
@@ -17,16 +17,13 @@ use std::{
 use crate::numeric_id::{DenseIdMap, IdVec, NumericId, define_id};
 use crossbeam_queue::SegQueue;
 use dashmap::SharedValue;
-use rayon::{
-    iter::{ParallelBridge, ParallelIterator},
-    prelude::*,
-};
 use rustc_hash::FxHasher;
 
 use crate::{
     ColumnId, CounterId, ExecutionState, Offset, SubsetRef, TableId, TaggedRowBuffer, Value,
     WrappedTable,
     common::{DashMap, IndexSet, SubsetTracker},
+    parallel,
     parallel_heuristics::{parallelize_inter_container_op, parallelize_intra_container_op},
     table_spec::{Rebuilder, ValueRebuilder},
 };
@@ -202,22 +199,20 @@ impl ContainerValues {
             self.subset_tracker.recent_updates(table_id, table)
         });
         let mut summary = if parallelize_inter_container_op(self.data.next_id().index()) {
-            self.data
-                .iter_mut()
-                .zip(std::iter::repeat_with(|| exec_state.clone()))
-                .par_bridge()
-                .map(|((_, env), mut exec_state)| {
-                    env.apply_rebuild(
-                        table,
-                        &*rebuilder,
-                        to_scan.as_ref().map(|x| x.as_ref()),
-                        &mut exec_state,
-                    )
-                })
-                .reduce(ContainerRebuildSummary::default, |mut acc, summary| {
-                    acc.extend(summary);
-                    acc
-                })
+            parallel::map_dense_id_map_mut(&mut self.data, |_, env| {
+                let mut exec_state = exec_state.clone();
+                env.apply_rebuild(
+                    table,
+                    &*rebuilder,
+                    to_scan.as_ref().map(|x| x.as_ref()),
+                    &mut exec_state,
+                )
+            })
+            .into_iter()
+            .fold(ContainerRebuildSummary::default(), |mut acc, summary| {
+                acc.extend(summary);
+                acc
+            })
         } else {
             let mut summary = ContainerRebuildSummary::default();
             for (_, env) in self.data.iter_mut() {
@@ -631,110 +626,104 @@ impl<C: ContainerValue> ContainerEnv<C> {
         to_reinsert.resize_with(self.to_id.shards().len(), Default::default);
 
         let shards = self.to_id.shards_mut();
-        let changed = shards
-            .par_iter_mut()
-            .map(|shard| {
-                let mut changed = false;
-                let shard = shard.get_mut();
-                // SAFETY: the iterator does not outlive `shard`.
-                for bucket in unsafe { shard.iter() } {
-                    // SAFETY: the bucket is valid; we just got it from the iterator.
-                    let (container, val) = unsafe { bucket.as_mut() };
-                    let old_val = *val.get();
-                    let new_val = rebuilder.rebuild_val(old_val);
-                    let container_changed = container.rebuild_contents(rebuilder);
-                    if !container_changed && new_val == old_val {
-                        // Nothing changed about this entry. Leave it in place.
-                        continue;
-                    }
-                    changed = true;
-                    if container_changed {
-                        // The container changed. Remove both map entries then reinsert.
-                        // SAFETY: This is a valid bucket. Furthermore, iterators remain valid if
-                        // buckets they have already yielded have been removed.
-                        let ((container, _), _) = unsafe { shard.remove(bucket) };
-                        self.to_container.remove(&old_val);
-                        // Spooky: we're using `to_container` to determine the shard for
-                        // `to_id`. We are assuming that the # shards determination is
-                        // deterministic here. There is a debug assertion in `get_or_insert`
-                        // that attempts to verify this.
-                        let shard = self
-                            .to_container
-                            .determine_shard(hash_container(&container) as usize);
-                        to_reinsert[shard].push((container, new_val, new_val == old_val));
-                    } else {
-                        // Just the value changed. Leave the container in place.
-                        *val.get_mut() = new_val;
-                        let prev = self.to_container.remove(&old_val).unwrap().1;
-                        self.to_container.insert(new_val, prev);
-                    }
+        let changed = parallel::map_mut(shards, |_, shard| {
+            let mut changed = false;
+            let shard = shard.get_mut();
+            // SAFETY: the iterator does not outlive `shard`.
+            for bucket in unsafe { shard.iter() } {
+                // SAFETY: the bucket is valid; we just got it from the iterator.
+                let (container, val) = unsafe { bucket.as_mut() };
+                let old_val = *val.get();
+                let new_val = rebuilder.rebuild_val(old_val);
+                let container_changed = container.rebuild_contents(rebuilder);
+                if !container_changed && new_val == old_val {
+                    // Nothing changed about this entry. Leave it in place.
+                    continue;
                 }
-                changed
-            })
-            .max()
-            .unwrap_or(false);
+                changed = true;
+                if container_changed {
+                    // The container changed. Remove both map entries then reinsert.
+                    // SAFETY: This is a valid bucket. Furthermore, iterators remain valid if
+                    // buckets they have already yielded have been removed.
+                    let ((container, _), _) = unsafe { shard.remove(bucket) };
+                    self.to_container.remove(&old_val);
+                    // Spooky: we're using `to_container` to determine the shard for
+                    // `to_id`. We are assuming that the # shards determination is
+                    // deterministic here. There is a debug assertion in `get_or_insert`
+                    // that attempts to verify this.
+                    let shard = self
+                        .to_container
+                        .determine_shard(hash_container(&container) as usize);
+                    to_reinsert[shard].push((container, new_val, new_val == old_val));
+                } else {
+                    // Just the value changed. Leave the container in place.
+                    *val.get_mut() = new_val;
+                    let prev = self.to_container.remove(&old_val).unwrap().1;
+                    self.to_container.insert(new_val, prev);
+                }
+            }
+            changed
+        })
+        .into_iter()
+        .any(|changed| changed);
 
         let dirty_ids = SegQueue::new();
-        shards
-            .iter_mut()
-            .enumerate()
-            .map(|(i, shard)| (i, shard, exec_state.clone()))
-            .par_bridge()
-            .for_each(|(shard_id, shard, mut exec_state)| {
-                // This bit is a real slog. Once Dashmap updates from RawTable to HashTable for
-                // the underlying shard, this will get a little better.
-                //
-                // NB: We are probably leaving some paralellism on the floor with these calls
-                // to `to_container` and `val_index`.
-                let shard = shard.get_mut();
-                let queue = &to_reinsert[shard_id];
-                while let Some((container, val, stable_id)) = queue.pop() {
-                    let hc = hash_container(&container);
-                    let target_map = self.to_container.determine_shard(hc as usize);
-                    match shard.find_or_find_insert_slot(
-                        hc,
-                        |(c, _)| c == &container,
-                        |(c, _)| hash_container(c),
-                    ) {
-                        Ok(bucket) => {
-                            // SAFETY: the bucket is valid; we just got it from the shard and
-                            // we have not done any operations that can invalidate the bucket.
-                            let (container, val_slot) = unsafe { bucket.as_mut() };
-                            let old_val = *val_slot.get();
-                            let result = (self.merge_fn)(&mut exec_state, old_val, val);
-                            if result != old_val {
-                                self.to_container.remove(&old_val);
-                                self.to_container.insert(result, (hc as usize, target_map));
-                                *val_slot.get_mut() = result;
-                                for val in container.iter() {
-                                    let mut index = self.val_index.entry(val).or_default();
-                                    index.swap_remove(&old_val);
-                                    index.insert(result);
-                                }
-                            }
-                            // As in the serial path, only same-id semantic
-                            // changes need an explicit parent-row refresh.
-                            if stable_id && result == val {
-                                dirty_ids.push(val);
+        parallel::for_each_mut(shards, |shard_id, shard| {
+            let mut exec_state = exec_state.clone();
+            // This bit is a real slog. Once Dashmap updates from RawTable to HashTable for
+            // the underlying shard, this will get a little better.
+            //
+            // NB: We are probably leaving some paralellism on the floor with these calls
+            // to `to_container` and `val_index`.
+            let shard = shard.get_mut();
+            let queue = &to_reinsert[shard_id];
+            while let Some((container, val, stable_id)) = queue.pop() {
+                let hc = hash_container(&container);
+                let target_map = self.to_container.determine_shard(hc as usize);
+                match shard.find_or_find_insert_slot(
+                    hc,
+                    |(c, _)| c == &container,
+                    |(c, _)| hash_container(c),
+                ) {
+                    Ok(bucket) => {
+                        // SAFETY: the bucket is valid; we just got it from the shard and
+                        // we have not done any operations that can invalidate the bucket.
+                        let (container, val_slot) = unsafe { bucket.as_mut() };
+                        let old_val = *val_slot.get();
+                        let result = (self.merge_fn)(&mut exec_state, old_val, val);
+                        if result != old_val {
+                            self.to_container.remove(&old_val);
+                            self.to_container.insert(result, (hc as usize, target_map));
+                            *val_slot.get_mut() = result;
+                            for val in container.iter() {
+                                let mut index = self.val_index.entry(val).or_default();
+                                index.swap_remove(&old_val);
+                                index.insert(result);
                             }
                         }
-                        Err(slot) => {
-                            self.to_container.insert(val, (hc as usize, target_map));
-                            for v in container.iter() {
-                                self.val_index.entry(v).or_default().insert(val);
-                            }
-                            // SAFETY: We just got this slot from `find_or_find_insert_slot`
-                            // and we have not mutated the map at all since then.
-                            unsafe {
-                                shard.insert_in_slot(hc, slot, (container, SharedValue::new(val)));
-                            }
-                            if stable_id {
-                                dirty_ids.push(val);
-                            }
+                        // As in the serial path, only same-id semantic
+                        // changes need an explicit parent-row refresh.
+                        if stable_id && result == val {
+                            dirty_ids.push(val);
+                        }
+                    }
+                    Err(slot) => {
+                        self.to_container.insert(val, (hc as usize, target_map));
+                        for v in container.iter() {
+                            self.val_index.entry(v).or_default().insert(val);
+                        }
+                        // SAFETY: We just got this slot from `find_or_find_insert_slot`
+                        // and we have not mutated the map at all since then.
+                        unsafe {
+                            shard.insert_in_slot(hc, slot, (container, SharedValue::new(val)));
+                        }
+                        if stable_id {
+                            dirty_ids.push(val);
                         }
                     }
                 }
-            });
+            }
+        });
         let mut summary = ContainerRebuildSummary::default();
         if changed {
             summary.note_change();

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -16,6 +16,7 @@ use crate::{
 use crossbeam::utils::CachePadded;
 use dashmap::mapref::entry::Entry;
 use dashmap::mapref::one::RefMut;
+use egglog_concurrency::Scope;
 use egglog_reports::{ReportLevel, RuleReport, RuleSetReport};
 use smallvec::SmallVec;
 use web_time::Instant;
@@ -30,7 +31,7 @@ use crate::{
     },
     hash_index::{ColumnIndex, IndexBase, TupleIndex},
     offsets::{Offsets, RowId, SortedOffsetSlice, SortedOffsetVector, Subset},
-    parallel_heuristics::parallelize_db_level_op,
+    parallel_heuristics::{action_batch_size, free_join_fork_depth, parallelize_db_level_op},
     pool::Pooled,
     query::RuleSet,
     row_buffer::TaggedRowBuffer,
@@ -359,7 +360,7 @@ impl Database {
             let dash_rule_reports: Arc<DashMap<Arc<str>, Vec<RuleReport>>> =
                 Arc::new(DashMap::default());
             let db: &Database = self;
-            rayon::in_place_scope(|scope| {
+            egglog_concurrency::scope(|scope| {
                 for (plan, desc, symbol_map) in rule_set.plans.values() {
                     // TODO: add stats
                     let report_plan = match report_level {
@@ -436,7 +437,7 @@ impl Database {
                                         plan.stages.blocks.iter().enumerate()
                                     {
                                         let mat_id = MatId::from_usize(mat_id);
-                                        rayon::in_place_scope(|stage_scope| {
+                                        egglog_concurrency::scope(|stage_scope| {
                                             let mut materializer = ScopedMaterializer {
                                                 scope: stage_scope,
                                                 specs: specs.clone(),
@@ -641,12 +642,12 @@ struct ActionState {
     bindings: Bindings,
 }
 
-impl Default for ActionState {
-    fn default() -> Self {
+impl ActionState {
+    fn new(batch_size: usize) -> Self {
         Self {
             n_runs: 0,
             len: 0,
-            bindings: Bindings::new(VAR_BATCH_SIZE),
+            bindings: Bindings::new(batch_size),
         }
     }
 }
@@ -986,7 +987,7 @@ impl<'a> JoinState<'a> {
                 }
                 // TODO: `supports_parallel_drain`` is a hack because currently
                 // `drain_updates_parallel!`` is a bit slower because of the additional ExecutionState clone.
-                if (cur == 0 || cur == 1) && action_buf.supports_parallel_drain() {
+                if cur < free_join_fork_depth() && action_buf.supports_parallel_drain() {
                     drain_updates_parallel!($updates)
                 } else {
                     $updates.drain(|update| match update {
@@ -1065,7 +1066,7 @@ impl<'a> JoinState<'a> {
                                 JoinState {
                                     db,
                                     exec_state: exec_state_for_work.clone(),
-                                    // Each rayon task uses its own thread-local pool.
+                                    // Each scoped task uses its own thread-local pool.
                                     // This makes drain_updates_parallel slightly more expensive
                                     // than drain_updates eevn when both are run in single thread
                                     pool: with_pool_set(|ps| ps.get_pool()),
@@ -1804,7 +1805,7 @@ impl<'a> JoinState<'a> {
     }
 }
 
-const VAR_BATCH_SIZE: usize = 128;
+const LOCAL_ACTION_BATCH_SIZE: usize = 128;
 
 /// A trait used to abstract over different ways of buffering actions together
 /// before running them.
@@ -1899,7 +1900,9 @@ impl<'a, 'outer: 'a> ActionBuffer<'a, ActionId> for InPlaceActionBuffer<'outer> 
         bindings: &DenseIdMap<Variable, Value>,
         mut to_exec_state: impl FnMut() -> ExecutionState<'a>,
     ) {
-        let action_state = self.batches.get_or_default(action);
+        let action_state = self
+            .batches
+            .get_or_insert(action, || ActionState::new(LOCAL_ACTION_BATCH_SIZE));
         action_state.n_runs += 1;
         action_state.len += 1;
         let action_info = &self.rule_set.actions[action];
@@ -1908,7 +1911,7 @@ impl<'a, 'outer: 'a> ActionBuffer<'a, ActionId> for InPlaceActionBuffer<'outer> 
         unsafe {
             action_state.bindings.push(bindings, &action_info.used_vars);
         }
-        if action_state.len >= VAR_BATCH_SIZE {
+        if action_state.len >= LOCAL_ACTION_BATCH_SIZE {
             let mut state = to_exec_state();
             let succeeded = state.run_instrs(&action_info.instrs, &mut action_state.bindings);
             action_state.bindings.clear();
@@ -1940,9 +1943,9 @@ impl<'a, 'outer: 'a> ActionBuffer<'a, ActionId> for InPlaceActionBuffer<'outer> 
     }
 }
 
-/// An Action buffer that hands off batches to of actions to rayon to execute.
+/// An action buffer that hands off batches of actions to scoped worker tasks.
 struct ScopedActionBuffer<'inner, 'scope> {
-    scope: &'inner rayon::Scope<'scope>,
+    scope: &'inner Scope<'scope>,
     rule_set: &'scope RuleSet,
     match_counter: Arc<MatchCounter>,
     batches: DenseIdMap<ActionId, ActionState>,
@@ -1951,7 +1954,7 @@ struct ScopedActionBuffer<'inner, 'scope> {
 
 impl<'inner, 'scope> ScopedActionBuffer<'inner, 'scope> {
     fn new(
-        scope: &'inner rayon::Scope<'scope>,
+        scope: &'inner Scope<'scope>,
         rule_set: &'scope RuleSet,
         match_counter: Arc<MatchCounter>,
     ) -> Self {
@@ -1977,7 +1980,10 @@ impl<'scope> ActionBuffer<'scope, ActionId> for ScopedActionBuffer<'_, 'scope> {
         mut to_exec_state: impl FnMut() -> ExecutionState<'scope>,
     ) {
         self.needs_flush = true;
-        let action_state = self.batches.get_or_default(action);
+        let batch_size = action_batch_size();
+        let action_state = self
+            .batches
+            .get_or_insert(action, || ActionState::new(batch_size));
         action_state.n_runs += 1;
         action_state.len += 1;
         let action_info = &self.rule_set.actions[action];
@@ -1986,10 +1992,9 @@ impl<'scope> ActionBuffer<'scope, ActionId> for ScopedActionBuffer<'_, 'scope> {
         unsafe {
             action_state.bindings.push(bindings, &action_info.used_vars);
         }
-        if action_state.len >= VAR_BATCH_SIZE {
+        if action_state.len >= batch_size {
             let mut state = to_exec_state();
-            let mut bindings =
-                mem::replace(&mut action_state.bindings, Bindings::new(VAR_BATCH_SIZE));
+            let mut bindings = mem::replace(&mut action_state.bindings, Bindings::new(batch_size));
             action_state.len = 0;
             let match_counter = self.match_counter.clone();
             self.scope.spawn(move |_| {
@@ -2171,7 +2176,7 @@ impl<'a> ActionBuffer<'a, MatId> for InPlaceMaterializer<'a> {
 }
 
 struct ScopedMaterializer<'inner, 'scope> {
-    scope: &'inner rayon::Scope<'scope>,
+    scope: &'inner Scope<'scope>,
     specs: Arc<DenseIdMap<MatId, MatSpec>>,
     materializations: Arc<DenseIdMap<MatId, Arc<DashMap<Vec<Value>, RowBuffer>>>>,
     scratch_key: Vec<Value>,

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -13,7 +13,6 @@ use crate::{
     numeric_id::{DenseIdMap, DenseIdMapWithReuse, NumericId, define_id},
 };
 use egglog_concurrency::{NotificationList, ResettableOnceLock};
-use rayon::prelude::*;
 use smallvec::SmallVec;
 
 use crate::{
@@ -25,6 +24,7 @@ use crate::{
     dependency_graph::DependencyGraph,
     hash_index::{ColumnIndex, Index, IndexBase},
     offsets::Subset,
+    parallel,
     parallel_heuristics::parallelize_db_level_op,
     pool::{Pool, Pooled, with_pool_set},
     query::{Query, RuleSetBuilder},
@@ -314,8 +314,8 @@ pub struct Database {
 impl Database {
     /// Create an empty Database.
     ///
-    /// Queries are executed using the current rayon thread pool, which defaults to the global
-    /// thread pool.
+    /// Queries use the currently installed egglog thread pool. If no pool is
+    /// installed, queries run single-threaded.
     pub fn new() -> Database {
         Database::default()
     }
@@ -420,7 +420,7 @@ impl Database {
                 tables.push((*id, self.tables.take(*id).unwrap()));
             }
             let view = self.read_only_view();
-            tables.par_iter_mut().for_each(|(id, info)| {
+            parallel::for_each_mut(&mut tables, |_, (id, info)| {
                 if run(*id, info, &view) {
                     self.notification_list.notify(*id);
                 }
@@ -560,14 +560,12 @@ impl Database {
                 }
                 let db = self.read_only_view();
                 changed |= if do_parallel {
-                    tables_merging
-                        .par_iter_mut()
-                        .map(|(_, (info, buffers))| {
-                            let mut es = ExecutionState::new(db, mem::take(buffers));
-                            info.as_mut().unwrap().table.merge(&mut es).added || es.changed
-                        })
-                        .max()
-                        .unwrap_or(false)
+                    parallel::map_dense_id_map_mut(&mut tables_merging, |_, (info, buffers)| {
+                        let mut es = ExecutionState::new(db, mem::take(buffers));
+                        info.as_mut().unwrap().table.merge(&mut es).added || es.changed
+                    })
+                    .into_iter()
+                    .any(|changed| changed)
                 } else {
                     tables_merging
                         .iter_mut()
@@ -834,11 +832,8 @@ impl Database {
 
 impl Drop for Database {
     fn drop(&mut self) {
-        // Clean up the ambient thread pool.
-        //
-        // Calling mem::forget on the egraph can result in much faster execution times.
+        // Clean up this thread's ambient memory pool.
         with_pool_set(PoolSet::clear);
-        rayon::broadcast(|_| with_pool_set(PoolSet::clear));
     }
 }
 

--- a/core-relations/src/hash_index/mod.rs
+++ b/core-relations/src/hash_index/mod.rs
@@ -3,24 +3,24 @@ use std::{
     cmp,
     hash::{Hash, Hasher},
     mem,
-    sync::{Arc, Mutex},
+    sync::Mutex,
 };
 
 use crate::{
     common::IndexMap,
     numeric_id::{IdVec, NumericId, define_id},
 };
-use egglog_concurrency::{Notification, ReadOptimizedLock};
+use egglog_concurrency::{ReadOptimizedLock, ThreadPool};
 use hashbrown::HashTable;
 use indexmap::map::Entry;
 use once_cell::sync::Lazy;
-use rayon::iter::ParallelIterator;
 use rustc_hash::FxHasher;
 
 use crate::{
     OffsetRange, Subset,
     common::{ShardData, ShardId, Value},
     offsets::{RowId, SortedOffsetSlice, SubsetRef},
+    parallel,
     parallel_heuristics::parallelize_index_construction,
     pool::{Pooled, with_pool_set},
     row_buffer::{RowBuffer, TaggedRowBuffer},
@@ -290,8 +290,8 @@ impl IndexBase for ColumnIndex {
             }
         };
 
-        run_in_thread_pool_and_block(&THREAD_POOL, || {
-            rayon::in_place_scope(|inner| {
+        run_in_index_thread_pool(|| {
+            egglog_concurrency::scope(|inner| {
                 let mut cur = Offset::new(0);
                 loop {
                     let mut buf = TaggedRowBuffer::new(cols.len());
@@ -307,7 +307,7 @@ impl IndexBase for ColumnIndex {
                 }
             });
 
-            self.shards.par_iter_mut().for_each(|(shard_id, shard)| {
+            parallel::for_each_id_vec_mut(&mut self.shards, |shard_id, shard| {
                 // Sort the vector by start row id to ensure we populate subsets in sorted order.
                 let mut vec = queues[shard_id].lock().unwrap();
                 vec.sort_by_key(|(start, _)| *start);
@@ -380,43 +380,6 @@ impl IndexBase for ColumnIndex {
             shard.table.insert(key, buffered);
         }
     }
-}
-
-/// This function is an alternative for [`rayon::ThreadPool::install`] that doesn't steal work from
-/// the callee's current thread pool while waiting for `f` to finish.
-///
-/// We do this to avoid deadlocks. The whole purpose of using a separate threadpool in this module
-/// is to allow for sufficient parallelism while holding a lock on the main threadpool. That means
-/// we are not worried about an outer lock tying up a thread in the main pool.
-///
-/// On the other hand, it _is_ a bad idea to steal work on a rayon thread pool with some locks
-/// held. In particular, if another task on the thread pool _itself_ attempts to aquire the same
-/// lock, this can cause a deadlock. We saw this in the tests for this crate. The relevant lock
-/// are those around individual indexes stored in the database-level index cache.
-fn run_in_thread_pool_and_block<'a>(pool: &rayon::ThreadPool, f: impl FnMut() + Send + 'a) {
-    // NB: We don't need the heap allocations here. But we are only calling this function if
-    // we are about to do a bunch of work, so clarify is probably going to be better than (even
-    // more) unsafe code.
-
-    // Alright, here we go: pretend `f` has `'static` lifetime because we are passing it to
-    // `spawn`.
-    trait LifetimeWork<'a>: FnMut() + Send + 'a {}
-
-    impl<'a, F: FnMut() + Send + 'a> LifetimeWork<'a> for F {}
-    let as_lifetime: Box<dyn LifetimeWork<'a>> = Box::new(f);
-    let mut casted_away = unsafe {
-        // SAFETY: `casted_away` will be dropped at the end of this method. The notification used
-        // below will ensure it does not escape.
-        mem::transmute::<Box<dyn LifetimeWork<'a>>, Box<dyn LifetimeWork<'static>>>(as_lifetime)
-    };
-    let n = Arc::new(Notification::new());
-    let inner = n.clone();
-    pool.spawn(move || {
-        casted_away();
-        mem::drop(casted_away);
-        inner.notify();
-    });
-    n.wait()
 }
 
 /// Adaptive LSB radix sort for (Value, RowId) pairs, sorting by the Value field.
@@ -669,8 +632,8 @@ impl IndexBase for TupleIndex {
                 queues[shard_id].lock().unwrap().push((first, buf));
             }
         };
-        run_in_thread_pool_and_block(&THREAD_POOL, || {
-            rayon::scope(|scope| {
+        run_in_index_thread_pool(|| {
+            egglog_concurrency::scope(|scope| {
                 let mut cur = Offset::new(0);
                 loop {
                     let mut buf = TaggedRowBuffer::new(cols.len());
@@ -685,7 +648,7 @@ impl IndexBase for TupleIndex {
                     }
                 }
             });
-            self.shards.par_iter_mut().for_each(|(shard_id, shard)| {
+            parallel::for_each_id_vec_mut(&mut self.shards, |shard_id, shard| {
                 use hashbrown::hash_table::Entry;
                 // Sort the vector by start row id to ensure we populate subsets in sorted order.
                 let mut vec = queues[shard_id].lock().unwrap();
@@ -973,23 +936,21 @@ impl BufferedSubset {
 }
 
 fn num_shards() -> usize {
-    let n_threads = rayon::current_num_threads();
+    let n_threads = parallel::current_num_threads();
     if n_threads == 1 { 1 } else { n_threads * 2 }
 }
 
 /// A thread pool specifically for parallel hash index construction.
 ///
-/// We use a separate thread pool here because callers can construct an index under a lock,
-/// and we do not want to take a long-running lock in the global thread pool without another
-/// way to get parallelism.
-///
-/// Earlier solutions using rayon::yield_now() were unreliable.
-static THREAD_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
-    rayon::ThreadPoolBuilder::new()
-        .num_threads(rayon::current_num_threads())
-        .build()
-        .unwrap()
-});
+/// Callers can construct indexes while holding database-level index locks. The
+/// separate pool preserves parallelism without tying up the caller's installed
+/// pool behind those locks.
+static INDEX_THREAD_POOL: Lazy<ThreadPool> =
+    Lazy::new(|| ThreadPool::new(parallel::current_num_threads().max(1)));
+
+fn run_in_index_thread_pool<R>(f: impl FnOnce() -> R) -> R {
+    INDEX_THREAD_POOL.install(f)
+}
 
 /// A simple free list used to reuse slots in a [`SubsetBuffer`].
 ///

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod dependency_graph;
 pub(crate) mod free_join;
 pub(crate) mod hash_index;
 pub(crate) mod offsets;
+pub(crate) mod parallel;
 pub(crate) mod parallel_heuristics;
 pub(crate) mod pool;
 pub(crate) mod query;

--- a/core-relations/src/parallel.rs
+++ b/core-relations/src/parallel.rs
@@ -1,0 +1,179 @@
+//! Small parallel helpers backed by the installed egglog thread pool.
+
+use std::sync::OnceLock;
+
+use crate::numeric_id::{DenseIdMap, IdVec, NumericId};
+
+const DEFAULT_TASKS_PER_THREAD: usize = 1;
+const TASKS_PER_THREAD_ENV: &str = "EGGLOG_PARALLEL_TASKS_PER_THREAD";
+
+static TASKS_PER_THREAD: OnceLock<usize> = OnceLock::new();
+
+pub(crate) fn current_num_threads() -> usize {
+    egglog_concurrency::current_num_threads()
+}
+
+pub(crate) fn enabled_for_len(len: usize) -> bool {
+    len > 1 && current_num_threads() > 1
+}
+
+fn chunk_len(len: usize) -> usize {
+    let tasks = current_num_threads()
+        .saturating_mul(tasks_per_thread())
+        .max(1);
+    len.div_ceil(tasks).max(1)
+}
+
+fn tasks_per_thread() -> usize {
+    *TASKS_PER_THREAD.get_or_init(|| {
+        read_usize_env(TASKS_PER_THREAD_ENV)
+            .unwrap_or(DEFAULT_TASKS_PER_THREAD)
+            .max(1)
+    })
+}
+
+fn read_usize_env(name: &str) -> Option<usize> {
+    std::env::var(name).ok()?.parse().ok()
+}
+
+fn default_vec<T: Default>(len: usize) -> Vec<T> {
+    vec_with(len, T::default)
+}
+
+fn vec_with<T>(len: usize, init: impl FnMut() -> T) -> Vec<T> {
+    let mut values = Vec::with_capacity(len);
+    values.resize_with(len, init);
+    values
+}
+
+pub(crate) fn for_each_mut<T, F>(items: &mut [T], f: F)
+where
+    T: Send,
+    F: Fn(usize, &mut T) + Sync,
+{
+    if !enabled_for_len(items.len()) {
+        for (index, item) in items.iter_mut().enumerate() {
+            f(index, item);
+        }
+        return;
+    }
+
+    let chunk_len = chunk_len(items.len());
+    egglog_concurrency::scope(|scope| {
+        let f = &f;
+        for (chunk_index, chunk) in items.chunks_mut(chunk_len).enumerate() {
+            let base = chunk_index * chunk_len;
+            scope.spawn(move |_| {
+                for (offset, item) in chunk.iter_mut().enumerate() {
+                    f(base + offset, item);
+                }
+            });
+        }
+    });
+}
+
+pub(crate) fn map_mut<T, R, F>(items: &mut [T], f: F) -> Vec<R>
+where
+    T: Send,
+    R: Default + Send,
+    F: Fn(usize, &mut T) -> R + Sync,
+{
+    map_mut_with(items, R::default, f)
+}
+
+pub(crate) fn map_mut_with<T, R, Init, F>(items: &mut [T], init: Init, f: F) -> Vec<R>
+where
+    T: Send,
+    R: Send,
+    Init: FnMut() -> R,
+    F: Fn(usize, &mut T) -> R + Sync,
+{
+    if !enabled_for_len(items.len()) {
+        return items
+            .iter_mut()
+            .enumerate()
+            .map(|(index, item)| f(index, item))
+            .collect();
+    }
+
+    let chunk_len = chunk_len(items.len());
+    let mut results = vec_with(items.len(), init);
+    egglog_concurrency::scope(|scope| {
+        let f = &f;
+        for (chunk_index, (chunk, out)) in items
+            .chunks_mut(chunk_len)
+            .zip(results.chunks_mut(chunk_len))
+            .enumerate()
+        {
+            let base = chunk_index * chunk_len;
+            scope.spawn(move |_| {
+                for (offset, item) in chunk.iter_mut().enumerate() {
+                    out[offset] = f(base + offset, item);
+                }
+            });
+        }
+    });
+
+    results
+}
+
+pub(crate) fn map_dense_id_map_mut<K, V, R, F>(map: &mut DenseIdMap<K, V>, f: F) -> Vec<R>
+where
+    K: NumericId,
+    V: Send,
+    R: Send,
+    F: Fn(K, &mut V) -> R + Sync,
+{
+    map_mut(map.raw_mut(), |index, slot| {
+        slot.as_mut().map(|value| f(K::from_usize(index), value))
+    })
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+pub(crate) fn for_each_id_vec_mut<K, V, F>(map: &mut IdVec<K, V>, f: F)
+where
+    K: NumericId,
+    V: Send,
+    F: Fn(K, &mut V) + Sync,
+{
+    for_each_mut(map.as_mut_slice(), |index, value| {
+        f(K::from_usize(index), value);
+    });
+}
+
+pub(crate) fn map<T, R, F>(items: &[T], f: F) -> Vec<R>
+where
+    T: Sync,
+    R: Default + Send,
+    F: Fn(usize, &T) -> R + Sync,
+{
+    if !enabled_for_len(items.len()) {
+        return items
+            .iter()
+            .enumerate()
+            .map(|(index, item)| f(index, item))
+            .collect();
+    }
+
+    let chunk_len = chunk_len(items.len());
+    let mut results = default_vec(items.len());
+    egglog_concurrency::scope(|scope| {
+        let f = &f;
+        for (chunk_index, (chunk, out)) in items
+            .chunks(chunk_len)
+            .zip(results.chunks_mut(chunk_len))
+            .enumerate()
+        {
+            let base = chunk_index * chunk_len;
+            scope.spawn(move |_| {
+                for (offset, item) in chunk.iter().enumerate() {
+                    out[offset] = f(base + offset, item);
+                }
+            });
+        }
+    });
+
+    results
+}

--- a/core-relations/src/parallel.rs
+++ b/core-relations/src/parallel.rs
@@ -36,14 +36,17 @@ fn read_usize_env(name: &str) -> Option<usize> {
     std::env::var(name).ok()?.parse().ok()
 }
 
-fn default_vec<T: Default>(len: usize) -> Vec<T> {
-    vec_with(len, T::default)
+fn empty_result_slots<T>(len: usize) -> Vec<Option<T>> {
+    let mut values = Vec::with_capacity(len);
+    values.resize_with(len, || None);
+    values
 }
 
-fn vec_with<T>(len: usize, init: impl FnMut() -> T) -> Vec<T> {
-    let mut values = Vec::with_capacity(len);
-    values.resize_with(len, init);
+fn collect_result_slots<T>(values: Vec<Option<T>>) -> Vec<T> {
     values
+        .into_iter()
+        .map(|value| value.expect("parallel map result slot should be initialized"))
+        .collect()
 }
 
 pub(crate) fn for_each_mut<T, F>(items: &mut [T], f: F)
@@ -75,17 +78,7 @@ where
 pub(crate) fn map_mut<T, R, F>(items: &mut [T], f: F) -> Vec<R>
 where
     T: Send,
-    R: Default + Send,
-    F: Fn(usize, &mut T) -> R + Sync,
-{
-    map_mut_with(items, R::default, f)
-}
-
-pub(crate) fn map_mut_with<T, R, Init, F>(items: &mut [T], init: Init, f: F) -> Vec<R>
-where
-    T: Send,
     R: Send,
-    Init: FnMut() -> R,
     F: Fn(usize, &mut T) -> R + Sync,
 {
     if !enabled_for_len(items.len()) {
@@ -97,7 +90,7 @@ where
     }
 
     let chunk_len = chunk_len(items.len());
-    let mut results = vec_with(items.len(), init);
+    let mut results = empty_result_slots(items.len());
     egglog_concurrency::scope(|scope| {
         let f = &f;
         for (chunk_index, (chunk, out)) in items
@@ -108,13 +101,13 @@ where
             let base = chunk_index * chunk_len;
             scope.spawn(move |_| {
                 for (offset, item) in chunk.iter_mut().enumerate() {
-                    out[offset] = f(base + offset, item);
+                    out[offset] = Some(f(base + offset, item));
                 }
             });
         }
     });
 
-    results
+    collect_result_slots(results)
 }
 
 pub(crate) fn map_dense_id_map_mut<K, V, R, F>(map: &mut DenseIdMap<K, V>, f: F) -> Vec<R>
@@ -146,7 +139,7 @@ where
 pub(crate) fn map<T, R, F>(items: &[T], f: F) -> Vec<R>
 where
     T: Sync,
-    R: Default + Send,
+    R: Send,
     F: Fn(usize, &T) -> R + Sync,
 {
     if !enabled_for_len(items.len()) {
@@ -158,7 +151,7 @@ where
     }
 
     let chunk_len = chunk_len(items.len());
-    let mut results = default_vec(items.len());
+    let mut results = empty_result_slots(items.len());
     egglog_concurrency::scope(|scope| {
         let f = &f;
         for (chunk_index, (chunk, out)) in items
@@ -169,11 +162,11 @@ where
             let base = chunk_index * chunk_len;
             scope.spawn(move |_| {
                 for (offset, item) in chunk.iter().enumerate() {
-                    out[offset] = f(base + offset, item);
+                    out[offset] = Some(f(base + offset, item));
                 }
             });
         }
     });
 
-    results
+    collect_result_slots(results)
 }

--- a/core-relations/src/parallel_heuristics.rs
+++ b/core-relations/src/parallel_heuristics.rs
@@ -1,37 +1,114 @@
-//! Basic heuristics for whether or not to use a parallel or serial verion of an algorithm.
+//! Basic heuristics for whether or not to use a parallel or serial version of an algorithm.
 //!
 //! The parallel implementations in this crate generally have a noticeable overhead when compared
 //! to the serial versions on small problem sizes.
+
+use std::sync::OnceLock;
+
+const DEFAULT_DB_LEVEL_OP_CUTOFF: usize = 10_000;
+const DEFAULT_INDEX_CONSTRUCTION_CUTOFF: usize = 400_000;
+const DEFAULT_REBUILD_CUTOFF: usize = 400_000;
+const DEFAULT_INTRA_CONTAINER_CUTOFF: usize = 10_000;
+const DEFAULT_INTER_CONTAINER_CUTOFF: usize = 8;
+const DEFAULT_TABLE_OP_CUTOFF: usize = 400_000;
+const DEFAULT_FREE_JOIN_FORK_DEPTH: usize = 2;
+const DEFAULT_ACTION_BATCH_SIZE: usize = 8 * 1024;
+
+static CUTOFFS: OnceLock<Cutoffs> = OnceLock::new();
+
+struct Cutoffs {
+    db_level_op: usize,
+    index_construction: usize,
+    rebuild: usize,
+    intra_container: usize,
+    inter_container: usize,
+    table_op: usize,
+    free_join_fork_depth: usize,
+    action_batch_size: usize,
+}
 
 /// These are operations that work on a per-table or per-rule level where the size of the workload
 /// is hard to gauge ahead of time. In this case, we gate parallel execution based on the number of
 /// threads available and whether the total size of the database exceeds a certain threshold.
 pub(crate) fn parallelize_db_level_op(db_size: usize) -> bool {
-    db_size > 10_000 && rayon::current_num_threads() > 1
+    should_parallelize(db_size, cutoffs().db_level_op)
 }
 
 /// Whether or not to use a parallel algorithm to construct a hash index.
 pub(crate) fn parallelize_index_construction(items_to_insert: usize) -> bool {
-    items_to_insert > 20_000 && rayon::current_num_threads() > 1
+    should_parallelize(items_to_insert, cutoffs().index_construction)
 }
 
 /// Whether or not to use a parallel algorithm to rebuild a [`crate::table::SortedWritesTable`].
 pub(crate) fn parallelize_rebuild(table_size: usize) -> bool {
-    table_size > 10_000 && rayon::current_num_threads() > 1
+    should_parallelize(table_size, cutoffs().rebuild)
 }
 
 /// Whether or not to perform an operation for a given container memo table.
 pub(crate) fn parallelize_intra_container_op(num_containers: usize) -> bool {
-    num_containers > 1_000 && rayon::current_num_threads() > 1
+    should_parallelize(num_containers, cutoffs().intra_container)
 }
 
 /// Whether or not to perform an operation in parallel across a set of different container memo
 /// tables.
 pub(crate) fn parallelize_inter_container_op(num_containers: usize) -> bool {
-    num_containers > 1 && rayon::current_num_threads() > 1
+    should_parallelize(num_containers, cutoffs().inter_container)
 }
 
 #[track_caller]
 pub(crate) fn parallelize_table_op(table_size: usize) -> bool {
-    table_size > 20_000 && rayon::current_num_threads() > 1
+    should_parallelize(table_size, cutoffs().table_op)
+}
+
+/// Number of top free-join frames that may fork recursive drain work.
+pub(crate) fn free_join_fork_depth() -> usize {
+    cutoffs().free_join_fork_depth
+}
+
+/// Number of action bindings to batch before dispatching a scoped worker task.
+pub(crate) fn action_batch_size() -> usize {
+    cutoffs().action_batch_size
+}
+
+fn should_parallelize(len: usize, cutoff: usize) -> bool {
+    len > cutoff && crate::parallel::current_num_threads() > 1
+}
+
+fn cutoffs() -> &'static Cutoffs {
+    CUTOFFS.get_or_init(|| Cutoffs {
+        db_level_op: cutoff(
+            "EGGLOG_PARALLEL_DB_LEVEL_OP_CUTOFF",
+            DEFAULT_DB_LEVEL_OP_CUTOFF,
+        ),
+        index_construction: cutoff(
+            "EGGLOG_PARALLEL_INDEX_CONSTRUCTION_CUTOFF",
+            DEFAULT_INDEX_CONSTRUCTION_CUTOFF,
+        ),
+        rebuild: cutoff("EGGLOG_PARALLEL_REBUILD_CUTOFF", DEFAULT_REBUILD_CUTOFF),
+        intra_container: cutoff(
+            "EGGLOG_PARALLEL_INTRA_CONTAINER_CUTOFF",
+            DEFAULT_INTRA_CONTAINER_CUTOFF,
+        ),
+        inter_container: cutoff(
+            "EGGLOG_PARALLEL_INTER_CONTAINER_CUTOFF",
+            DEFAULT_INTER_CONTAINER_CUTOFF,
+        ),
+        table_op: cutoff("EGGLOG_PARALLEL_TABLE_OP_CUTOFF", DEFAULT_TABLE_OP_CUTOFF),
+        free_join_fork_depth: cutoff(
+            "EGGLOG_PARALLEL_FREE_JOIN_FORK_DEPTH",
+            DEFAULT_FREE_JOIN_FORK_DEPTH,
+        ),
+        action_batch_size: cutoff(
+            "EGGLOG_PARALLEL_ACTION_BATCH_SIZE",
+            DEFAULT_ACTION_BATCH_SIZE,
+        )
+        .max(1),
+    })
+}
+
+fn cutoff(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
 }

--- a/core-relations/src/row_buffer/mod.rs
+++ b/core-relations/src/row_buffer/mod.rs
@@ -5,7 +5,6 @@ use std::{cell::Cell, mem, ops::Deref};
 
 use crate::numeric_id::NumericId;
 use egglog_concurrency::{ParallelVecWriter, parallel_writer::write_cell_slice};
-use rayon::iter::ParallelIterator;
 use smallvec::SmallVec;
 
 use crate::{
@@ -288,20 +287,6 @@ impl RowBuffer {
         self.total_rows = count;
     }
 
-    /// A parallel version of [`RowBuffer::iter`].
-    pub(crate) fn parallel_iter(&self) -> impl ParallelIterator<Item = &[Value]> {
-        use rayon::prelude::*;
-        // SAFETY: This kind of transmutation is safe so long as no one
-        // modifies any of the values behind the `Cell` while this value is
-        // borrowed.
-        //
-        // The only time we modify these values is in safe methods requiring
-        // a mutable reference (`set_stale`, `get_row_mut`), or in the
-        // unsafe `set_stale_shared` method whose safety requirements imply
-        // that no call will overlap with borrowing such a row.
-        unsafe { mem::transmute::<&[Cell<Value>], &[Value]>(&self.data) }.par_chunks(self.n_columns)
-    }
-
     /// Mark a row as stale in the buffer with shared access to it. Returns
     /// whether the row was already stale.
     ///
@@ -400,9 +385,11 @@ impl TaggedRowBuffer {
         }
     }
 
-    /// A parallel iterator over the contents of the buffer.
-    pub fn par_iter(&self) -> impl ParallelIterator<Item = (RowId, &[Value])> {
-        self.inner.parallel_iter().map(|row| self.unwrap_row(row))
+    /// Iterate over the contents of the buffer.
+    ///
+    /// This is a compatibility alias for [`TaggedRowBuffer::iter`].
+    pub fn par_iter(&self) -> impl Iterator<Item = (RowId, &[Value])> {
+        self.iter()
     }
 }
 

--- a/core-relations/src/row_buffer/mod.rs
+++ b/core-relations/src/row_buffer/mod.rs
@@ -384,13 +384,6 @@ impl TaggedRowBuffer {
             inner: RowBuffer::new(n_columns + 1),
         }
     }
-
-    /// Iterate over the contents of the buffer.
-    ///
-    /// This is a compatibility alias for [`TaggedRowBuffer::iter`].
-    pub fn par_iter(&self) -> impl Iterator<Item = (RowId, &[Value])> {
-        self.iter()
-    }
 }
 
 impl TaggedRowBuffer<SmallValueVec> {

--- a/core-relations/src/table/mod.rs
+++ b/core-relations/src/table/mod.rs
@@ -18,7 +18,6 @@ use std::{
 use crate::numeric_id::{DenseIdMap, NumericId};
 use crossbeam_queue::SegQueue;
 use hashbrown::HashTable;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use rustc_hash::FxHasher;
 use sharded_hash_table::ShardedHashTable;
 
@@ -28,6 +27,7 @@ use crate::{
     common::{HashMap, ShardData, ShardId, SubsetTracker, Value},
     hash_index::{ColumnIndex, Index},
     offsets::{OffsetRange, Offsets, RowId, Subset, SubsetRef},
+    parallel,
     parallel_heuristics::parallelize_table_op,
     pool::with_pool_set,
     row_buffer::{ParallelRowBufWriter, RowBuffer},
@@ -592,46 +592,40 @@ impl SortedWritesTable {
     /// Flush all pending removals, in parallel.
     fn parallel_delete(&mut self) -> bool {
         let shard_data = self.hash.shard_data();
-        let stale_delta: usize = self
-            .hash
-            .mut_shards()
-            .par_iter_mut()
-            .enumerate()
-            .filter_map(|(shard_id, shard)| {
-                let shard_id = ShardId::from_usize(shard_id);
-                if self.pending_state.pending_removals[shard_id].is_empty() {
-                    return None;
-                }
-                Some((shard_id, shard))
-            })
-            .map(|(shard_id, shard)| {
-                let queue = &self.pending_state.pending_removals[shard_id];
-                let mut marked_stale = 0;
-                while let Some(buf) = queue.pop() {
-                    buf.for_each(|to_remove| {
-                        let (actual_shard, hc) = hash_code(shard_data, to_remove, self.n_keys);
-                        assert_eq!(actual_shard, shard_id);
-                        if let Ok(entry) = shard.find_entry(hc, |entry| {
-                            entry.hashcode == (hc as _)
-                                && &self.data.get_row(entry.row).unwrap()[0..self.n_keys]
-                                    == to_remove
-                        }) {
-                            let (ent, _) = entry.remove();
-                            // SAFETY: The safety requirements of
-                            // `set_stale_shared` are that there are no
-                            // concurrent accesses to `row`. No other threads
-                            // can access this row within this method because
-                            // different `shards` partition the space
-                            // (guaranteed by the assertion above), and we
-                            // launch at most one thread per shard.
-                            marked_stale +=
-                                unsafe { !self.data.data.set_stale_shared(ent.row) } as usize;
-                        }
-                    });
-                }
-                marked_stale
-            })
-            .sum();
+        let pending_removals = &self.pending_state.pending_removals;
+        let data = &self.data.data;
+        let n_keys = self.n_keys;
+        let stale_delta: usize = parallel::map_mut(self.hash.mut_shards(), |shard_id, shard| {
+            let shard_id = ShardId::from_usize(shard_id);
+            if pending_removals[shard_id].is_empty() {
+                return 0;
+            }
+            let queue = &pending_removals[shard_id];
+            let mut marked_stale = 0;
+            while let Some(buf) = queue.pop() {
+                buf.for_each(|to_remove| {
+                    let (actual_shard, hc) = hash_code(shard_data, to_remove, n_keys);
+                    assert_eq!(actual_shard, shard_id);
+                    if let Ok(entry) = shard.find_entry(hc, |entry| {
+                        entry.hashcode == (hc as _)
+                            && &data.get_row(entry.row)[0..n_keys] == to_remove
+                    }) {
+                        let (ent, _) = entry.remove();
+                        // SAFETY: The safety requirements of
+                        // `set_stale_shared` are that there are no
+                        // concurrent accesses to `row`. No other threads
+                        // can access this row within this method because
+                        // different `shards` partition the space
+                        // (guaranteed by the assertion above), and we
+                        // launch at most one thread per shard.
+                        marked_stale += unsafe { !data.set_stale_shared(ent.row) } as usize;
+                    }
+                });
+            }
+            marked_stale
+        })
+        .into_iter()
+        .sum();
         // Update the stale count with the total marked stale.
         self.data.stale_rows += stale_delta;
         stale_delta > 0
@@ -829,17 +823,17 @@ impl SortedWritesTable {
         let n_cols = self.n_columns;
         let next_offset = RowId::from_usize(self.data.data.len());
         let row_writer = self.data.data.parallel_writer();
-        let pending_adds = self
-            .hash
-            .mut_shards()
-            .par_iter_mut()
-            .enumerate()
-            .map(|(shard_id, shard)| {
+        let pending_rows = &self.pending_state.pending_rows;
+        let merge = self.merge.clone();
+        let pending_adds = parallel::map_mut_with(
+            self.hash.mut_shards(),
+            || (checker.clone(), 0usize, false),
+            |shard_id, shard| {
                 let shard_id = ShardId::from_usize(shard_id);
                 let mut checker = checker.clone();
                 let mut exec_state = exec_state.clone();
                 let mut scratch = with_pool_set(|ps| ps.get::<Vec<Value>>());
-                let queue = &self.pending_state.pending_rows[shard_id];
+                let queue = &pending_rows[shard_id];
                 let mut marked_stale = 0usize;
                 let mut staged = StagedOutputs::new(n_keys, n_cols, BATCH_SIZE);
                 let mut changed = false;
@@ -899,7 +893,7 @@ impl SortedWritesTable {
                                     // concurrent accesses to `row`. We have
                                     // exclusive access to any row whose hash matches this
                                     // shard.
-                                    if (self.merge)(&mut exec_state, cur, row, &mut scratch) {
+                                    if (merge)(&mut exec_state, cur, row, &mut scratch) {
                                         unsafe {
                                             let _was_stale = read_handle.set_stale_shared(occ.get().row);
                                             debug_assert!(!_was_stale);
@@ -939,9 +933,7 @@ impl SortedWritesTable {
                     // too many threads if someone needs to resize the row
                     // writer.
                     for row in buf.non_stale() {
-                        staged.insert(row, |cur, new, out| {
-                            (self.merge)(&mut exec_state, cur, new, out)
-                        });
+                        staged.insert(row, |cur, new, out| (merge)(&mut exec_state, cur, new, out));
                         if staged.len() >= BATCH_SIZE {
                             flush_staged_outputs!();
                         }
@@ -949,28 +941,24 @@ impl SortedWritesTable {
                 }
                 flush_staged_outputs!();
                 (checker, marked_stale, changed)
-            })
-            .collect_vec_list();
+            },
+        );
         self.data.data = row_writer.finish();
         // Now we just need to reset our invariants.
 
         // Confirm none of the writes violated sort order and update the
         // `offsets` vector.
-        let checker = C::check_global(pending_adds.iter().flatten().map(|(checker, _, _)| checker));
+        let checker = C::check_global(pending_adds.iter().map(|(checker, _, _)| checker));
         checker.update_offsets(next_offset, &mut self.offsets);
 
         // Update the staleness counters.
         self.data.stale_rows += pending_adds
             .iter()
-            .flatten()
             .map(|(_, stale, _)| *stale)
             .sum::<usize>();
 
         // Register any changes.
-        pending_adds
-            .iter()
-            .flatten()
-            .any(|(_, _, changed)| *changed)
+        pending_adds.iter().any(|(_, _, changed)| *changed)
     }
 
     fn binary_search_sort_val(&self, val: Value) -> Result<(RowId, RowId), RowId> {
@@ -1045,7 +1033,6 @@ impl SortedWritesTable {
         }
     }
     fn parallel_rehash(&mut self) {
-        use rayon::prelude::*;
         // Parallel rehashes go "hash-first" rather than "rows-first".
         //
         // We iterate over each shard and then write out new contents to a fresh row, in parallel.
@@ -1076,7 +1063,16 @@ impl SortedWritesTable {
             }
         }
         let mut results = Vec::<TimestampStats>::with_capacity(self.offsets.len());
-        results.resize_with(self.offsets.len() - 1, Default::default);
+        let offset_windows = self
+            .offsets
+            .windows(2)
+            .map(|xs| {
+                let [(start_val, start_row), (_, end_row)] = xs else {
+                    unreachable!()
+                };
+                (*start_val, *start_row, *end_row)
+            })
+            .collect::<Vec<_>>();
         // Use a macro rather than a lambda to avoid borrow issues.
         macro_rules! compute_hist {
             ($start_val: expr, $start_row: expr, $end_row: expr) => {{
@@ -1099,34 +1095,19 @@ impl SortedWritesTable {
                 }
             }};
         }
-        let mut last: TimestampStats = Default::default();
-        rayon::join(
-            || {
-                // This closure handles computing all timestamps but the last one.
-                self.offsets
-                    .windows(2)
-                    .zip(results.iter_mut())
-                    .par_bridge()
-                    .for_each(|(xs, res)| {
-                        let [(start_val, start_row), (_, end_row)] = xs else {
-                            unreachable!()
-                        };
-                        *res = compute_hist!(*start_val, *start_row, *end_row);
-                    })
-            },
-            || {
-                // And here we handle the final one.
-                let (start_val, start_row) = self.offsets.last().unwrap();
-                let end_row = self.data.next_row();
-                last = compute_hist!(*start_val, *start_row, end_row);
-            },
-        );
+        results.extend(parallel::map(
+            &offset_windows,
+            |_, (start_val, start_row, end_row)| compute_hist!(*start_val, *start_row, *end_row),
+        ));
+        // And here we handle the final one.
+        let (start_val, start_row) = self.offsets.last().unwrap();
+        let end_row = self.data.next_row();
+        let last = compute_hist!(*start_val, *start_row, end_row);
         results.push(last);
         // Now we need to compute cumulative statistics on the row layouts here.
         // We do this serially a we currently don't have a ton of use for cases with thousands
         // of timestamps or more. There are well-known parallel algorithms for computing these
-        // cumulative statistics in parallel, but they aren't currently all that well-suited
-        // for rayon at the moment.
+        // cumulative statistics in parallel, but they are not currently a good fit here.
         let mut prev_count = 0;
         self.offsets.clear();
         for stats in results.iter_mut() {
@@ -1161,42 +1142,37 @@ impl SortedWritesTable {
 
         self.data.scratch.clear();
         self.data.scratch.reserve(prev_count);
-        self.hash
-            .mut_shards()
-            .par_iter_mut()
-            .with_max_len(1)
-            .enumerate()
-            .for_each(|(shard_id, shard)| {
-                let shard_id = ShardId::from_usize(shard_id);
-                let scratch_ptr = self.data.scratch.raw_rows();
-                let mut progress =
-                    HashMap::<Value /* timestamp */, RowId /* next row */>::default();
-                progress.reserve(results.len());
-                for stats in &results {
-                    let Some(start) = stats.histogram.get(shard_id) else {
-                        continue;
-                    };
-                    progress.insert(stats.value, RowId::from_usize(*start));
+        let scratch_ptr = self.data.scratch.raw_rows() as usize;
+        let data = &self.data.data;
+        let n_columns = self.n_columns;
+        parallel::for_each_mut(self.hash.mut_shards(), |shard_id, shard| {
+            let shard_id = ShardId::from_usize(shard_id);
+            let scratch_ptr = scratch_ptr as *const Value;
+            let mut progress = HashMap::<Value /* timestamp */, RowId /* next row */>::default();
+            progress.reserve(results.len());
+            for stats in &results {
+                let Some(start) = stats.histogram.get(shard_id) else {
+                    continue;
+                };
+                progress.insert(stats.value, RowId::from_usize(*start));
+            }
+            for TableEntry { row: row_id, .. } in shard.iter_mut() {
+                let row = data.get_row(*row_id);
+                debug_assert!(!row[0].is_stale(), "shard should not map to a stale value");
+                let val = row[sort_by.index()];
+                let next = progress[&val];
+                // SAFETY: see above longer comment.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        row.as_ptr(),
+                        scratch_ptr.add(next.index() * n_columns) as *mut Value,
+                        n_columns,
+                    )
                 }
-                for TableEntry { row: row_id, .. } in shard.iter_mut() {
-                    let row = self
-                        .data
-                        .get_row(*row_id)
-                        .expect("shard should not map to a stale value");
-                    let val = row[sort_by.index()];
-                    let next = progress[&val];
-                    // SAFETY: see above longer comment.
-                    unsafe {
-                        std::ptr::copy_nonoverlapping(
-                            row.as_ptr(),
-                            scratch_ptr.add(next.index() * self.n_columns) as *mut Value,
-                            self.n_columns,
-                        )
-                    }
-                    *row_id = next;
-                    progress.insert(val, next.inc());
-                }
-            });
+                *row_id = next;
+                progress.insert(val, next.inc());
+            }
+        });
         // SAFETY: see above longer comment.
         unsafe { self.data.scratch.set_len(prev_count) };
         mem::swap(&mut self.data.data, &mut self.data.scratch);

--- a/core-relations/src/table/mod.rs
+++ b/core-relations/src/table/mod.rs
@@ -825,21 +825,18 @@ impl SortedWritesTable {
         let row_writer = self.data.data.parallel_writer();
         let pending_rows = &self.pending_state.pending_rows;
         let merge = self.merge.clone();
-        let pending_adds = parallel::map_mut_with(
-            self.hash.mut_shards(),
-            || (checker.clone(), 0usize, false),
-            |shard_id, shard| {
-                let shard_id = ShardId::from_usize(shard_id);
-                let mut checker = checker.clone();
-                let mut exec_state = exec_state.clone();
-                let mut scratch = with_pool_set(|ps| ps.get::<Vec<Value>>());
-                let queue = &pending_rows[shard_id];
-                let mut marked_stale = 0usize;
-                let mut staged = StagedOutputs::new(n_keys, n_cols, BATCH_SIZE);
-                let mut changed = false;
-                // The core flush loop: We call once `staged` reaches `BATCH_SIZE` or
-                // when we're done.
-                macro_rules! flush_staged_outputs {
+        let pending_adds = parallel::map_mut(self.hash.mut_shards(), |shard_id, shard| {
+            let shard_id = ShardId::from_usize(shard_id);
+            let mut checker = checker.clone();
+            let mut exec_state = exec_state.clone();
+            let mut scratch = with_pool_set(|ps| ps.get::<Vec<Value>>());
+            let queue = &pending_rows[shard_id];
+            let mut marked_stale = 0usize;
+            let mut staged = StagedOutputs::new(n_keys, n_cols, BATCH_SIZE);
+            let mut changed = false;
+            // The core flush loop: We call once `staged` reaches `BATCH_SIZE` or
+            // when we're done.
+            macro_rules! flush_staged_outputs {
                     () => {{
                         // Phase 2: Write the staged rows to the row writer. This only
                         // works due to the `ParallelRowBufWriter` machinery.
@@ -924,25 +921,24 @@ impl SortedWritesTable {
                         staged.clear();
                     }};
                 }
-                // Phase 1: process all incoming updates:
-                // * Add new values to `staged`
-                // * Removing entries in `shard` and mark them as stale in
-                // `data` if they will be overwritten.
-                while let Some(buf) = queue.pop() {
-                    // We create a read_handle once per batch to avoid blocking
-                    // too many threads if someone needs to resize the row
-                    // writer.
-                    for row in buf.non_stale() {
-                        staged.insert(row, |cur, new, out| (merge)(&mut exec_state, cur, new, out));
-                        if staged.len() >= BATCH_SIZE {
-                            flush_staged_outputs!();
-                        }
+            // Phase 1: process all incoming updates:
+            // * Add new values to `staged`
+            // * Removing entries in `shard` and mark them as stale in
+            // `data` if they will be overwritten.
+            while let Some(buf) = queue.pop() {
+                // We create a read_handle once per batch to avoid blocking
+                // too many threads if someone needs to resize the row
+                // writer.
+                for row in buf.non_stale() {
+                    staged.insert(row, |cur, new, out| (merge)(&mut exec_state, cur, new, out));
+                    if staged.len() >= BATCH_SIZE {
+                        flush_staged_outputs!();
                     }
                 }
-                flush_staged_outputs!();
-                (checker, marked_stale, changed)
-            },
-        );
+            }
+            flush_staged_outputs!();
+            (checker, marked_stale, changed)
+        });
         self.data.data = row_writer.finish();
         // Now we just need to reset our invariants.
 

--- a/core-relations/src/table/rebuild.rs
+++ b/core-relations/src/table/rebuild.rs
@@ -3,7 +3,6 @@
 use std::{cmp, mem};
 
 use crate::numeric_id::NumericId;
-use rayon::prelude::*;
 
 use crate::{
     ColumnId, ExecutionState, Offset, RowId, Subset, Table, TableId, TaggedRowBuffer, Value,
@@ -11,6 +10,7 @@ use crate::{
     common::HashSet,
     hash_index::{ColumnIndex, Index},
     offsets::Offsets,
+    parallel,
     parallel_heuristics::parallelize_rebuild,
     table_spec::{Rebuilder, WrappedTableRef},
 };
@@ -139,35 +139,28 @@ impl SortedWritesTable {
 
         if parallelize_rebuild(to_scan.size()) {
             WrappedTableRef::with_wrapper(self, |wrapped| {
-                buf.par_iter()
-                    .fold(
-                        || (self.new_buffer(), exec_state.clone(), false),
-                        |(mut mutation_buf, mut exec_state, mut changed), (_, row)| {
-                            let Some(subset) = self.rebuild_index.get_subset(&row[0]) else {
-                                return (mutation_buf, exec_state, changed);
-                            };
-                            let mut scanned = TaggedRowBuffer::new(self.n_columns);
-                            rebuilder.rebuild_subset(
-                                wrapped,
-                                subset,
-                                &mut scanned,
-                                &mut exec_state,
-                            );
-                            for (row_id, row) in scanned.non_stale_mut() {
-                                let to_remove =
-                                    self.data.get_row(row_id).map(|x| &x[0..self.n_keys]);
-                                if let Some(key) = to_remove {
-                                    mutation_buf.stage_remove(key);
-                                }
-                                changed = true;
-                                insert_row!(self, mutation_buf, row, next_ts);
-                            }
-                            (mutation_buf, exec_state, changed)
-                        },
-                    )
-                    .map(|(_, _, changed)| changed)
-                    .max()
-                    .unwrap_or(false)
+                let ids = buf.iter().map(|(_, row)| row[0]).collect::<Vec<_>>();
+                parallel::map(&ids, |_, id| {
+                    let mut mutation_buf = self.new_buffer();
+                    let mut exec_state = exec_state.clone();
+                    let mut changed = false;
+                    let Some(subset) = self.rebuild_index.get_subset(id) else {
+                        return changed;
+                    };
+                    let mut scanned = TaggedRowBuffer::new(self.n_columns);
+                    rebuilder.rebuild_subset(wrapped, subset, &mut scanned, &mut exec_state);
+                    for (row_id, row) in scanned.non_stale_mut() {
+                        let to_remove = self.data.get_row(row_id).map(|x| &x[0..self.n_keys]);
+                        if let Some(key) = to_remove {
+                            mutation_buf.stage_remove(key);
+                        }
+                        changed = true;
+                        insert_row!(self, mutation_buf, row, next_ts);
+                    }
+                    changed
+                })
+                .into_iter()
+                .any(|changed| changed)
             })
         } else {
             let mut scratch = TaggedRowBuffer::new(self.n_columns);
@@ -202,44 +195,33 @@ impl SortedWritesTable {
     ) -> bool {
         const STEP_SIZE: usize = 2048;
         if parallelize_rebuild(self.data.next_row().index()) {
-            (0..self.data.next_row().index())
-                .into_par_iter()
-                .step_by(STEP_SIZE)
-                .fold(
-                    || {
-                        (
-                            self.new_buffer(),
-                            TaggedRowBuffer::new(self.n_columns),
-                            exec_state.clone(),
-                            false,
-                        )
-                    },
-                    |(mut mutation_buf, mut buf, mut exec_state, mut changed), start| {
-                        rebuilder.rebuild_buf(
-                            &self.data.data,
-                            RowId::from_usize(start),
-                            RowId::from_usize(cmp::min(
-                                start + STEP_SIZE,
-                                self.data.next_row().index(),
-                            )),
-                            &mut buf,
-                            &mut exec_state,
-                        );
-                        for (row_id, row) in buf.non_stale_mut() {
-                            let to_remove = self.data.get_row(row_id).map(|x| &x[0..self.n_keys]);
-                            changed = true;
-                            if let Some(key) = to_remove {
-                                mutation_buf.stage_remove(key);
-                            }
-                            insert_row!(self, mutation_buf, row, next_ts);
-                        }
-                        buf.clear();
-                        (mutation_buf, buf, exec_state, changed)
-                    },
-                )
-                .map(|(_, _, _, changed)| changed)
-                .max()
-                .unwrap_or(false)
+            let max_row = self.data.next_row().index();
+            let starts = (0..max_row).step_by(STEP_SIZE).collect::<Vec<_>>();
+            parallel::map(&starts, |_, start| {
+                let mut mutation_buf = self.new_buffer();
+                let mut buf = TaggedRowBuffer::new(self.n_columns);
+                let mut exec_state = exec_state.clone();
+                let mut changed = false;
+                rebuilder.rebuild_buf(
+                    &self.data.data,
+                    RowId::from_usize(*start),
+                    RowId::from_usize(cmp::min(*start + STEP_SIZE, max_row)),
+                    &mut buf,
+                    &mut exec_state,
+                );
+                for (row_id, row) in buf.non_stale_mut() {
+                    let to_remove = self.data.get_row(row_id).map(|x| &x[0..self.n_keys]);
+                    changed = true;
+                    if let Some(key) = to_remove {
+                        mutation_buf.stage_remove(key);
+                    }
+                    insert_row!(self, mutation_buf, row, next_ts);
+                }
+                buf.clear();
+                changed
+            })
+            .into_iter()
+            .any(|changed| changed)
         } else {
             let mut buf = TaggedRowBuffer::new(self.n_columns);
             let mut changed = false;

--- a/core-relations/src/table/sharded_hash_table.rs
+++ b/core-relations/src/table/sharded_hash_table.rs
@@ -13,7 +13,7 @@ pub(crate) struct ShardedHashTable<T> {
 
 impl<T> Default for ShardedHashTable<T> {
     fn default() -> Self {
-        let cur_threads = rayon::current_num_threads();
+        let cur_threads = crate::parallel::current_num_threads();
         if cur_threads == 1 {
             Self::with_shards(1)
         } else {

--- a/core-relations/src/tests.rs
+++ b/core-relations/src/tests.rs
@@ -29,11 +29,12 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 /// Run a test closure both single-threaded and with 4 threads.
 fn run_serial_and_parallel(f: impl Fn() + Send + Sync) {
     for num_threads in [1, 32] {
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(num_threads)
-            .build()
-            .unwrap();
-        pool.install(&f);
+        if num_threads == 1 {
+            f();
+        } else {
+            let pool = egglog_concurrency::ThreadPool::new(num_threads);
+            pool.install(&f);
+        }
     }
 }
 

--- a/egglog-bridge/Cargo.toml
+++ b/egglog-bridge/Cargo.toml
@@ -10,6 +10,7 @@ readme = { workspace = true }
 
 [dependencies]
 egglog-core-relations = { workspace = true }
+egglog-concurrency = { workspace = true }
 egglog-numeric-id = { workspace = true }
 egglog-union-find = { workspace = true }
 egglog-reports = { workspace = true }
@@ -21,7 +22,6 @@ num-rational = { workspace = true }
 log = { workspace = true }
 indexmap = { workspace = true }
 web-time = { workspace = true }
-rayon = { workspace = true }
 dyn-clone = { workspace = true }
 once_cell = { workspace = true }
 ordered-float = { workspace = true }

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -23,6 +23,7 @@ use crate::core_relations::{
     WrappedTable,
 };
 use crate::numeric_id::{DenseIdMap, DenseIdMapWithReuse, NumericId, define_id};
+use egglog_concurrency::ThreadPool;
 use egglog_core_relations as core_relations;
 use egglog_numeric_id as numeric_id;
 use egglog_reports::{IterationReport, ReportLevel, RuleSetReport};
@@ -133,12 +134,66 @@ pub struct EGraph {
     /// [`WriteState`] / [`FullState`] can resolve table actions at
     /// invoke time. Mutated in place from [`add_table`](EGraph::add_table).
     action_registry: Arc<std::sync::RwLock<ActionRegistry>>,
+    threads: usize,
+    thread_pool: Option<Arc<ThreadPool>>,
 }
 
 pub type Result<T> = std::result::Result<T, anyhow::Error>;
 
+fn normalize_thread_count(threads: usize) -> usize {
+    #[cfg(target_family = "wasm")]
+    {
+        if threads > 1 {
+            panic!("cannot use more than 1 thread on wasm");
+        }
+        1
+    }
+    #[cfg(not(target_family = "wasm"))]
+    {
+        if threads == 0 {
+            std::thread::available_parallelism()
+                .map(usize::from)
+                .unwrap_or(1)
+        } else {
+            threads
+        }
+    }
+}
+
+fn install_thread_pool<R>(thread_pool: Option<Arc<ThreadPool>>, f: impl FnOnce() -> R) -> R {
+    match thread_pool {
+        Some(thread_pool) => thread_pool.install(f),
+        None => f(),
+    }
+}
+
 impl Default for EGraph {
     fn default() -> Self {
+        Self::new(1)
+    }
+}
+
+/// Properties of a function added to an [`EGraph`].
+pub struct FunctionConfig {
+    /// The function's schema. The last column in the schema is the return type.
+    pub schema: Vec<ColumnTy>,
+    /// The behavior of the function when lookups are made on keys not currently present.
+    pub default: DefaultVal,
+    /// How to resolve FD conflicts for the function.
+    pub merge: MergeFn,
+    /// The function's name
+    pub name: String,
+    /// Whether or not subsumption is enabled for this function.
+    pub can_subsume: bool,
+}
+
+impl EGraph {
+    /// Create an e-graph configured to use `threads` worker threads.
+    ///
+    /// Passing `1` keeps execution serial and does not allocate a thread pool.
+    /// Passing `0` uses the host's available parallelism.
+    pub fn new(threads: usize) -> Self {
+        let threads = normalize_thread_count(threads);
         let mut db = Database::new();
         let uf_table = db.add_table_named(
             DisplacedTable::default(),
@@ -184,25 +239,35 @@ impl Default for EGraph {
             panic_funcs,
             report_level: Default::default(),
             action_registry,
+            threads,
+            thread_pool: (threads > 1).then(|| Arc::new(ThreadPool::new(threads))),
         }
     }
-}
 
-/// Properties of a function added to an [`EGraph`].
-pub struct FunctionConfig {
-    /// The function's schema. The last column in the schema is the return type.
-    pub schema: Vec<ColumnTy>,
-    /// The behavior of the function when lookups are made on keys not currently present.
-    pub default: DefaultVal,
-    /// How to resolve FD conflicts for the function.
-    pub merge: MergeFn,
-    /// The function's name
-    pub name: String,
-    /// Whether or not subsumption is enabled for this function.
-    pub can_subsume: bool,
-}
+    /// Return a copy of this e-graph configured with a different thread count.
+    pub fn with_num_threads(mut self, threads: usize) -> Self {
+        self.set_num_threads(threads);
+        self
+    }
 
-impl EGraph {
+    /// Set the number of worker threads used by this e-graph.
+    ///
+    /// Passing `1` disables the pool. Passing `0` uses available parallelism.
+    pub fn set_num_threads(&mut self, threads: usize) {
+        let threads = normalize_thread_count(threads);
+        self.threads = threads;
+        self.thread_pool = (threads > 1).then(|| Arc::new(ThreadPool::new(threads)));
+    }
+
+    /// Return the configured thread count.
+    pub fn num_threads(&self) -> usize {
+        self.threads
+    }
+
+    fn thread_pool(&self) -> Option<Arc<ThreadPool>> {
+        self.thread_pool.clone()
+    }
+
     fn next_ts(&self) -> Timestamp {
         Timestamp::from_usize(self.db.read_counter(self.timestamp_counter))
     }
@@ -585,7 +650,8 @@ impl EGraph {
     ///
     /// If the given rules are malformed, this method can return an error.
     pub fn run_rules(&mut self, rules: &[RuleId]) -> Result<IterationReport> {
-        self.run_rules_inner(rules)
+        let thread_pool = self.thread_pool();
+        install_thread_pool(thread_pool, || self.run_rules_inner(rules))
     }
 
     fn run_rules_inner(&mut self, rules: &[RuleId]) -> Result<IterationReport> {
@@ -624,7 +690,7 @@ impl EGraph {
     }
 
     fn rebuild(&mut self) -> Result<()> {
-        let do_parallel = rayon::current_num_threads() > 1;
+        let do_parallel = egglog_concurrency::current_num_threads() > 1;
         if self.db.get_table(self.uf_table).rebuilder(&[]).is_some() {
             // The UF implementation supports "native"  rebuilding.
             let mut tables = Vec::with_capacity(self.funcs.next_id().index());
@@ -941,7 +1007,8 @@ impl EGraph {
     /// manipulation from outside any rule, not for use inside
     /// primitive implementations.
     pub fn with_execution_state<R>(&self, f: impl FnOnce(&mut ExecutionState<'_>) -> R) -> R {
-        self.db.with_execution_state(f)
+        let thread_pool = self.thread_pool();
+        install_thread_pool(thread_pool, || self.db.with_execution_state(f))
     }
 
     /// Like [`EGraph::with_execution_state`], but also reports whether `f`
@@ -958,6 +1025,11 @@ impl EGraph {
     /// Flush the pending update buffers to the EGraph.
     /// Returns `true` if the database is updated.
     pub fn flush_updates(&mut self) -> bool {
+        let thread_pool = self.thread_pool();
+        install_thread_pool(thread_pool, || self.flush_updates_inner())
+    }
+
+    fn flush_updates_inner(&mut self) -> bool {
         let uf_size_before = self.db.get_table(self.uf_table).len();
         let updated = self.db.merge_all();
         self.inc_ts();

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -194,17 +194,22 @@ impl EGraph {
     /// Passing `0` uses the host's available parallelism.
     pub fn new(threads: usize) -> Self {
         let threads = normalize_thread_count(threads);
-        let mut db = Database::new();
-        let uf_table = db.add_table_named(
-            DisplacedTable::default(),
-            "$uf".into(),
-            iter::empty(),
-            iter::empty(),
-        );
-        let id_counter = db.add_counter();
-        let ts_counter = db.add_counter();
-        // Start the timestamp counter at 1.
-        db.inc_counter(ts_counter);
+        let thread_pool = (threads > 1).then(|| Arc::new(ThreadPool::new(threads)));
+        let (mut db, uf_table, id_counter, ts_counter) =
+            install_thread_pool(thread_pool.clone(), || {
+                let mut db = Database::new();
+                let uf_table = db.add_table_named(
+                    DisplacedTable::default(),
+                    "$uf".into(),
+                    iter::empty(),
+                    iter::empty(),
+                );
+                let id_counter = db.add_counter();
+                let ts_counter = db.add_counter();
+                // Start the timestamp counter at 1.
+                db.inc_counter(ts_counter);
+                (db, uf_table, id_counter, ts_counter)
+            });
 
         // Register a default panic external function so the typed
         // state wrappers' `panic()` method has an id to call. This
@@ -240,7 +245,7 @@ impl EGraph {
             report_level: Default::default(),
             action_registry,
             threads,
-            thread_pool: (threads > 1).then(|| Arc::new(ThreadPool::new(threads))),
+            thread_pool,
         }
     }
 
@@ -598,13 +603,15 @@ impl EGraph {
         let mut write_deps = IndexSet::<TableId>::new();
         merge.fill_deps(self, &mut read_deps, &mut write_deps);
         let merge_fn = merge.to_callback(schema_math, &name, self);
-        let table = SortedWritesTable::new(
-            n_args,
-            n_cols,
-            Some(ColumnId::from_usize(schema.len())),
-            to_rebuild,
-            merge_fn,
-        );
+        let table = install_thread_pool(self.thread_pool(), || {
+            SortedWritesTable::new(
+                n_args,
+                n_cols,
+                Some(ColumnId::from_usize(schema.len())),
+                to_rebuild,
+                merge_fn,
+            )
+        });
         let name: Arc<str> = name.into();
         let table_id = self.db.add_table_named(
             table,

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -163,7 +163,7 @@ fn normalize_thread_count(threads: usize) -> usize {
 fn install_thread_pool<R>(thread_pool: Option<Arc<ThreadPool>>, f: impl FnOnce() -> R) -> R {
     match thread_pool {
         Some(thread_pool) => thread_pool.install(f),
-        None => f(),
+        None => egglog_concurrency::without_current_pool(f),
     }
 }
 

--- a/numeric-id/Cargo.toml
+++ b/numeric-id/Cargo.toml
@@ -8,8 +8,5 @@ keywords = { workspace = true }
 license = { workspace = true }
 readme = { workspace = true }
 
-[dependencies]
-rayon = { workspace = true }
-
 [features]
 default = []

--- a/numeric-id/src/lib.rs
+++ b/numeric-id/src/lib.rs
@@ -160,6 +160,10 @@ impl<K: NumericId, V> DenseIdMap<K, V> {
         &self.data
     }
 
+    pub fn raw_mut(&mut self) -> &mut [Option<V>] {
+        &mut self.data
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = (K, &V)> {
         self.data
             .iter()
@@ -214,24 +218,6 @@ impl<K: NumericId, V> DenseIdMap<K, V> {
 
     pub fn is_empty(&self) -> bool {
         self.data.iter().all(|v| v.is_none())
-    }
-}
-
-impl<K: NumericId, V: Send + Sync> DenseIdMap<K, V> {
-    /// Get a parallel iterator over the entries in the table.
-    pub fn par_iter(&self) -> impl ParallelIterator<Item = (K, &V)> {
-        self.data
-            .par_iter()
-            .enumerate()
-            .filter_map(|(i, v)| Some((K::from_usize(i), v.as_ref()?)))
-    }
-
-    /// Get a parallel iterator over mutable references to the entries in the table.
-    pub fn par_iter_mut(&mut self) -> impl ParallelIterator<Item = (K, &mut V)> {
-        self.data
-            .par_iter_mut()
-            .enumerate()
-            .filter_map(|(i, v)| Some((K::from_usize(i), v.as_mut()?)))
     }
 }
 
@@ -415,15 +401,9 @@ impl<K: NumericId, V> IdVec<K, V> {
     pub fn get(&self, key: K) -> Option<&V> {
         self.data.get(key.index())
     }
-}
 
-impl<K: NumericId, V: Send + Sync> IdVec<K, V> {
-    pub fn par_iter_mut(&mut self) -> impl IndexedParallelIterator<Item = (K, &mut V)> {
-        self.data
-            .par_iter_mut()
-            .with_max_len(1)
-            .enumerate()
-            .map(|(i, v)| (K::from_usize(i), v))
+    pub fn as_mut_slice(&mut self) -> &mut [V] {
+        &mut self.data
     }
 }
 
@@ -440,10 +420,6 @@ impl<K: NumericId, V> ops::IndexMut<K> for IdVec<K, V> {
         &mut self.data[key.index()]
     }
 }
-
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
-};
 
 #[macro_export]
 #[doc(hidden)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,7 @@ use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
 use clap::Parser;
 use env_logger::Env;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 #[derive(Debug, Parser)]
 #[command(version = env!("FULL_VERSION"), about = env!("CARGO_PKG_DESCRIPTION"))]
@@ -90,6 +91,8 @@ pub fn cli(mut egraph: EGraph) {
 
     let args = Args::parse();
 
+    egraph.set_num_threads(args.threads);
+
     if args.term_encoding {
         egraph = egraph.with_term_encoding_enabled();
     }
@@ -103,7 +106,6 @@ pub fn cli(mut egraph: EGraph) {
         egraph = egraph.with_proof_testing();
     }
 
-    EGraph::set_num_threads(args.threads);
     egraph.fact_directory.clone_from(&args.fact_directory);
     egraph.seminaive = !args.naive;
     egraph.no_decomp = args.no_decomp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ use std::io::{Read as _, Write as _};
 use std::iter::once;
 use std::ops::Deref;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Arc;
 pub use termdag::{OrdTerm, Term, TermDag, TermId};
 use thiserror::Error;
@@ -498,6 +497,14 @@ struct ResolvedNCommandsWithOutput {
 pub struct NotFoundError(String);
 
 impl EGraph {
+    /// Create a new e-graph configured with `num_threads`.
+    ///
+    /// Passing `1` keeps execution serial. Passing `0` uses available
+    /// parallelism.
+    pub fn new(num_threads: usize) -> Self {
+        EGraph::default().with_num_threads(num_threads)
+    }
+
     /// Create a new e-graph with the term-encoding pipeline enabled.
     ///
     /// In term-encoding mode the e-graph eagerly instruments every constructor
@@ -522,6 +529,7 @@ impl EGraph {
     /// Enable the term-encoding pipeline on an existing `EGraph`.
     ///
     /// This method is to support the current CLI implementation with egglog-experimental (https://github.com/egraphs-good/egglog/issues/768)
+    #[cfg(feature = "bin")]
     pub(crate) fn with_term_encoding_enabled(mut self) -> Self {
         self.proof_state.original_typechecking = Some(Box::new(self.clone()));
         self
@@ -530,6 +538,7 @@ impl EGraph {
     /// Enable proof generation on this e-graph.
     /// TODO proofs should be turned on during creation of the e-graph, not afterwards.
     /// This method is to support the current CLI implementation with egglog-experimental (https://github.com/egraphs-good/egglog/issues/768)
+    #[cfg(feature = "bin")]
     pub(crate) fn with_proofs_enabled(mut self) -> Self {
         self = self.with_term_encoding_enabled();
         self.proof_state.proofs_enabled = true;
@@ -542,39 +551,26 @@ impl EGraph {
         self
     }
 
-    /// Set the number of threads used for parallel operations.
+    /// Return a copy of this e-graph configured with `num_threads`.
+    pub fn with_num_threads(mut self, num_threads: usize) -> Self {
+        self.set_num_threads(num_threads);
+        self
+    }
+
+    /// Set the number of threads used by this e-graph.
     ///
-    /// This is a helper that simply configures the global rayon thread pool. It can only be called
-    /// once per process; subsequent calls will be ignored.
-    ///
-    /// # Panics
-    ///
-    /// Panics on wasm if `num_threads > 1`.
-    pub fn set_num_threads(num_threads: usize) {
-        #[cfg(target_family = "wasm")]
-        if num_threads > 1 {
-            panic!("cannot use more than 1 thread on wasm");
-        }
-        #[cfg(not(target_family = "wasm"))]
-        {
-            // This will fail silently if the global pool has already been configured.
-            let err = rayon::ThreadPoolBuilder::new()
-                .num_threads(num_threads)
-                .build_global();
-            // print log if successful
-            if matches!(err, Ok(())) {
-                log::info!("Initialize global thread pool with  {num_threads} threads");
-            } else {
-                log::warn!(
-                    "Failed to initialize global thread pool with {num_threads} threads. This may be because the thread pool was already initialized with a different number of threads. Error: {err:?}"
-                );
-            }
+    /// Passing `1` keeps execution serial. Passing `0` uses available
+    /// parallelism.
+    pub fn set_num_threads(&mut self, num_threads: usize) {
+        self.backend.set_num_threads(num_threads);
+        if let Some(original) = &mut self.proof_state.original_typechecking {
+            original.set_num_threads(num_threads);
         }
     }
 
-    /// Return the number of threads in the rayon thread pool.
+    /// Return the number of threads configured for this e-graph.
     pub fn num_threads(&self) -> usize {
-        rayon::current_num_threads()
+        self.backend.num_threads()
     }
 
     /// Return extension-owned state stored on this e-graph.

--- a/tests/cykjson.egg
+++ b/tests/cykjson.egg
@@ -32,13 +32,13 @@
 (input End "./tests/cykjson_End.csv")
 
 ; small size 801
-;(input getString "./tests/cykjson_small_token.csv")
+(input getString "./tests/cykjson_small_token.csv")
 
 ; medium size 7821 but runs for 2 min.
-(input getString "./tests/cykjson_medium_token.csv")
+;(input getString "./tests/cykjson_medium_token.csv")
 
 (run 10000)
 
-; (let $test1 (B 801 1 "VAL"))
-; 
-; (check (P 801 1 "VAL"))
+(let $test1 (B 801 1 "VAL"))
+
+(check (P 801 1 "VAL"))

--- a/tests/cykjson.egg
+++ b/tests/cykjson.egg
@@ -32,13 +32,13 @@
 (input End "./tests/cykjson_End.csv")
 
 ; small size 801
-(input getString "./tests/cykjson_small_token.csv")
+;(input getString "./tests/cykjson_small_token.csv")
 
 ; medium size 7821 but runs for 2 min.
-;(input getString "./tests/cykjson_medium_token.csv")
+(input getString "./tests/cykjson_medium_token.csv")
 
 (run 10000)
 
-(let $test1 (B 801 1 "VAL"))
-
-(check (P 801 1 "VAL"))
+; (let $test1 (B 801 1 "VAL"))
+; 
+; (check (P 801 1 "VAL"))

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -101,7 +101,7 @@ impl Run {
     }
 
     fn egraph(&self) -> EGraph {
-        if self.proof_testing {
+        let egraph = if self.proof_testing {
             EGraph::new_with_proofs().with_proof_testing()
         } else if self.proofs {
             EGraph::new_with_proofs()
@@ -109,7 +109,8 @@ impl Run {
             EGraph::new_with_term_encoding()
         } else {
             EGraph::default()
-        }
+        };
+        egraph.with_num_threads(self.threads)
     }
 
     // Returns a string of the desugared program and a string for the desugared program without proofs
@@ -190,20 +191,7 @@ impl Run {
     fn into_trial(self) -> Trial {
         let name = self.name().to_string();
         Trial::test(name, move || {
-            // We use a local rayon pool here because `build_global()` can only
-            // be called once per process, but libtest-mimic runs many trials
-            // (with different thread counts) in the same process.
-            // The threads == 1 case also goes through pool.install so the trial
-            // doesn't fall through to the default global rayon pool (which uses
-            // num_cpus threads and would make "single-threaded" tests
-            // nondeterministic).
-            // TODO: when we move to per-EGraph local thread pools, replace this
-            // with `egraph.with_num_threads()` and remove the explicit pool.
-            let pool = rayon::ThreadPoolBuilder::new()
-                .num_threads(self.threads)
-                .build()
-                .expect("failed to build rayon thread pool");
-            pool.install(|| self.run());
+            self.run();
             Ok(())
         })
     }

--- a/tests/math-microbenchmark.egg
+++ b/tests/math-microbenchmark.egg
@@ -64,7 +64,7 @@
                             (Div (Sub (Const 1)
                                     (Sqrt (Var "five")))
                                 (Const 2))))
-(run 11)
+(run 12)
 (print-size Add)
 (print-size Mul)
 

--- a/tests/math-microbenchmark.egg
+++ b/tests/math-microbenchmark.egg
@@ -64,7 +64,7 @@
                             (Div (Sub (Const 1)
                                     (Sqrt (Var "five")))
                                 (Const 2))))
-(run 12)
+(run 11)
 (print-size Add)
 (print-size Mul)
 


### PR DESCRIPTION
Remove the reliance on the rayon global thread pool, while maintaining single and multi-threaded performance in the `math` and `cykjson` microbenchmarks.

This should make us a lot more resilient to issues where parallelism is enabled by accident.