### PR TITLE
Pass user-defined commands through term encoding instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased] - ReleaseDate
 
+- Pass user-defined commands through term encoding instead of panicking. Running plain term encoding (`--term-encoding`, proofs off) on a program containing a user-defined command no longer crashes; the command is forwarded to whatever registered it. Proof generation still rejects user-defined commands up front, so the pass-through only affects proofs-off term encoding.
 - Add typed `EGraph` extension state that clones with `EGraph` and is restored by `push`/`pop`.
 - Report full source file paths in egglog span and error messages.
 - Fix seminaive matching after nested containers rebuild in place by propagating dirty container ids through parent containers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1721,9 +1721,11 @@ impl EGraph {
             let typechecked = original_typechecking.typecheck_program(&desugared)?;
 
             for command in &typechecked {
-                if let Err(reason) =
-                    command_supports_proof_encoding(&command.to_command(), &self.type_info)
-                {
+                if let Err(reason) = command_supports_proof_encoding(
+                    &command.to_command(),
+                    &self.type_info,
+                    self.proof_state.proofs_enabled,
+                ) {
                     let command_text = format!("{}", command.to_command());
                     return Err(Error::UnsupportedProofCommand {
                         command: command_text,

--- a/src/proofs/proof_encoding.rs
+++ b/src/proofs/proof_encoding.rs
@@ -1252,7 +1252,14 @@ impl<'a> ProofInstrumentor<'a> {
                 res.push(command.to_command().make_unresolved());
             }
             ResolvedNCommand::UserDefined(..) => {
-                panic!("User defined commands unsupported in term encoding");
+                // Pass through unchanged: term encoding has nothing to
+                // instrument here — the user-defined command is dispatched
+                // later by whatever registered it (e.g. egglog-experimental's
+                // run-schedule / multi-extract). When proofs are actually being
+                // generated, `command_supports_proof_encoding` rejects this case
+                // up front (ProofEncodingUnsupportedReason::UserDefinedCommand),
+                // so this path is only hit in plain term encoding.
+                res.push(command.to_command().make_unresolved());
             }
         }
     }

--- a/src/proofs/proof_encoding_helpers.rs
+++ b/src/proofs/proof_encoding_helpers.rs
@@ -461,7 +461,11 @@ pub enum ProofEncodingUnsupportedReason {
 /// Checks whether a desugared program supports proof encoding.
 pub fn program_supports_proofs(commands: &[ResolvedCommand], type_info: &TypeInfo) -> bool {
     for command in commands {
-        if command_supports_proof_encoding(command, type_info).is_err() {
+        // This helper specifically asks whether the program is amenable
+        // to *proof* generation, so the full set of checks (validator,
+        // function-lookup-in-action, user-defined commands, etc.) applies
+        // — hence `proofs_enabled = true`.
+        if command_supports_proof_encoding(command, type_info, true).is_err() {
             return false;
         }
     }
@@ -501,34 +505,52 @@ fn action_has_function_lookup(action: &ResolvedAction, type_info: &TypeInfo) -> 
 
 /// Checks whether a resolved command supports proof encoding.
 /// Returns Ok(()) if supported, or Err with the reason if not.
+///
+/// `proofs_enabled` indicates whether the proof-tracking phase is
+/// actually going to run. Some checks below only matter when proofs
+/// are produced (e.g. the validator requirement: a validator is the
+/// hook that certifies a proof for a primitive call, so primitives
+/// without one can't produce a proof — but they're fine in plain
+/// term-encoding mode where no proofs are emitted). Callers pass
+/// `false` when term encoding is on but proofs are not, so the
+/// stricter proof-only checks are skipped.
 pub(crate) fn command_supports_proof_encoding(
     command: &ResolvedCommand,
     type_info: &TypeInfo,
+    proofs_enabled: bool,
 ) -> Result<(), ProofEncodingUnsupportedReason> {
-    // Check all expressions for primitives without validators
-    let mut all_primitives_have_validators = true;
-    command.clone().visit_exprs(&mut |expr| {
-        if !expr_primitives_have_validators(&expr) {
-            all_primitives_have_validators = false;
-        }
-        expr
-    });
+    // Check all expressions for primitives without validators —
+    // proof-mode only. Validators are how a primitive certifies its
+    // own result inside a generated proof; absent proofs, missing
+    // validators don't matter.
+    if proofs_enabled {
+        let mut all_primitives_have_validators = true;
+        command.clone().visit_exprs(&mut |expr| {
+            if !expr_primitives_have_validators(&expr) {
+                all_primitives_have_validators = false;
+            }
+            expr
+        });
 
-    if !all_primitives_have_validators {
-        return Err(ProofEncodingUnsupportedReason::PrimitiveWithoutValidator);
+        if !all_primitives_have_validators {
+            return Err(ProofEncodingUnsupportedReason::PrimitiveWithoutValidator);
+        }
     }
 
-    // Check actions (not queries) for function lookups
-    // Egglog supports lookups in actions at the global level, but not in proofs mode
-    // (global function calls are allowed - they get desugared to constructors)
-    let mut has_function_lookup_in_action = false;
-    command.clone().visit_actions(&mut |action| {
-        has_function_lookup_in_action |= action_has_function_lookup(&action, type_info);
-        action
-    });
+    // Check actions (not queries) for function lookups —
+    // proof-mode only. Global function calls (which get desugared to
+    // constructors) are fine; arbitrary lookups break proof
+    // generation but not plain term encoding.
+    if proofs_enabled {
+        let mut has_function_lookup_in_action = false;
+        command.clone().visit_actions(&mut |action| {
+            has_function_lookup_in_action |= action_has_function_lookup(&action, type_info);
+            action
+        });
 
-    if has_function_lookup_in_action {
-        return Err(ProofEncodingUnsupportedReason::FunctionLookupInAction);
+        if has_function_lookup_in_action {
+            return Err(ProofEncodingUnsupportedReason::FunctionLookupInAction);
+        }
     }
 
     // Now check command-specific constraints
@@ -544,8 +566,21 @@ pub(crate) fn command_supports_proof_encoding(
             proof_func: Some(_),
             ..
         } => Err(ProofEncodingUnsupportedReason::SortWithProofFuncAnnotation),
-        GenericCommand::UserDefined(..) => Err(ProofEncodingUnsupportedReason::UserDefinedCommand),
-        GenericCommand::Input { .. } => Err(ProofEncodingUnsupportedReason::InputCommand),
+        GenericCommand::UserDefined(..) if proofs_enabled => {
+            // Proof generation can't reason about user-defined
+            // commands (they're opaque to the term encoder). Plain
+            // term encoding is fine: the user-defined command runs
+            // through whatever the experimental extension installed
+            // (e.g. egglog-experimental's `run-schedule` rebinding,
+            // `multi-extract`), and term encoding doesn't need to
+            // rewrite it.
+            Err(ProofEncodingUnsupportedReason::UserDefinedCommand)
+        }
+        GenericCommand::UserDefined(..) => Ok(()),
+        GenericCommand::Input { .. } if proofs_enabled => {
+            Err(ProofEncodingUnsupportedReason::InputCommand)
+        }
+        GenericCommand::Input { .. } => Ok(()),
         // Extract commands can't have non-global function lookups
         // because instrument_action_expr doesn't support them
         // (global function calls are fine - they get desugared to constructors)
@@ -558,20 +593,21 @@ pub(crate) fn command_supports_proof_encoding(
                 Ok(())
             }
         }
-        // no-merge on a non-global function
+        // no-merge on a non-global function — proof-mode only.
+        // Term encoding without proofs is fine with this.
         // To add support: https://github.com/egraphs-good/egglog/issues/774
         GenericCommand::Function {
             merge: None, name, ..
-        } => {
+        } if proofs_enabled => {
             if type_info.is_global(name) {
                 Ok(())
             } else {
                 Err(ProofEncodingUnsupportedReason::NoMergeOnNonGlobalFunction)
             }
         }
-        // let binding with non-eq sort not supported by proof_global_desugar
-        ResolvedCommand::Action(ResolvedAction::Let(_, _, expr)) => {
-            // let binding with non-eq sort not supported by proof_global_desugar
+        // let binding with non-eq sort not supported by
+        // proof_global_desugar — proof-mode only.
+        ResolvedCommand::Action(ResolvedAction::Let(_, _, expr)) if proofs_enabled => {
             // we detect as setting something that is no-merge to a primitive not supported (global primitive binding)
             if expr.output_type().is_eq_sort() {
                 Ok(())
@@ -579,8 +615,10 @@ pub(crate) fn command_supports_proof_encoding(
                 Err(ProofEncodingUnsupportedReason::LetBindingWithNonEqSort)
             }
         }
-        // After global desugar it may look like this
-        ResolvedCommand::Action(ResolvedAction::Set(_span, head, _children, expr)) => {
+        // After global desugar it may look like this — proof-mode only.
+        ResolvedCommand::Action(ResolvedAction::Set(_span, head, _children, expr))
+            if proofs_enabled =>
+        {
             if !type_info.is_global(head.name()) || expr.output_type().is_eq_sort() {
                 Ok(())
             } else {

--- a/src/proofs/proof_tests.rs
+++ b/src/proofs/proof_tests.rs
@@ -47,4 +47,57 @@ mod tests {
 
         insta::assert_snapshot!("doc_example_add_function1", snapshot);
     }
+
+    /// A user-defined command must pass through term encoding (proofs off)
+    /// instead of panicking. The command here just runs a sub-program that
+    /// inserts a row, so we can observe that it actually executed.
+    #[test]
+    fn user_defined_command_passes_through_term_encoding() {
+        use crate::ast::{Expr, GenericCommand};
+        use crate::{CommandOutput, EGraph, Error, UserDefinedCommand};
+        use std::sync::Arc;
+
+        #[derive(Debug)]
+        struct InsertOne;
+
+        impl UserDefinedCommand for InsertOne {
+            fn update(
+                &self,
+                egraph: &mut EGraph,
+                _args: &[Expr],
+            ) -> Result<Vec<CommandOutput>, Error> {
+                egraph.parse_and_run_program(None, "(Add 1 2)")?;
+                Ok(vec![])
+            }
+        }
+
+        let mut egraph = EGraph::new_with_term_encoding();
+        egraph
+            .add_command("insert-one".to_string(), Arc::new(InsertOne))
+            .unwrap();
+
+        // This program contains a user-defined command. Before the fix this
+        // panicked in term-encoding instrumentation.
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+(sort Math)
+(constructor Add (i64 i64) Math)
+(insert-one)
+(check (Add 1 2))
+            "#,
+            )
+            .unwrap();
+
+        // Sanity check that resolve (the instrumentation path) also doesn't
+        // panic and forwards the user-defined command.
+        let resolved = egraph.resolve_program(None, "(insert-one)").unwrap();
+        assert!(
+            resolved
+                .iter()
+                .any(|c| matches!(c, GenericCommand::UserDefined(..))),
+            "user-defined command should be forwarded by term encoding, got: {resolved:?}"
+        );
+    }
 }


### PR DESCRIPTION
## The bug

Running plain term encoding (`--term-encoding`, proofs off) on a program that contains a user-defined command (e.g. one registered by egglog-experimental) panicked in the term-encoding instrumentation:

```rust
ResolvedNCommand::UserDefined(..) => {
    panic!("User defined commands unsupported in term encoding");
}
```

There is nothing for term encoding to instrument here — the user-defined command is dispatched later by whatever registered it (e.g. egglog-experimental's `run-schedule` rebinding or `multi-extract`).

## The fix

- Replace the panic with a pass-through that forwards the command unchanged, matching the adjacent `ResolvedNCommand` arms (`res.push(command.to_command().make_unresolved())`).
- Thread `proofs_enabled` through `command_supports_proof_encoding` so the proof-only checks (missing validators, function lookups in actions, user-defined commands, input commands, no-merge functions, non-eq `let`/`set` bindings) are skipped in proofs-off term encoding but still enforced when proofs are actually generated.

## Safety argument

The pass-through is only safe if proof generation still rejects user-defined commands. It does:

- `command_supports_proof_encoding` returns `Err(ProofEncodingUnsupportedReason::UserDefinedCommand)` for `GenericCommand::UserDefined` whenever `proofs_enabled == true`.
- This gate is enforced in `EGraph::resolve_command_before_proofs` (`src/lib.rs`), which runs **before** the term-encoding instrument path in `resolve_command`. When a user-defined command appears with proofs on, that function returns `Error::UnsupportedProofCommand` and the `UserDefined` instrument arm is never reached.

So the new pass-through is only reachable in plain term encoding (proofs off), where no proofs are emitted. Proof correctness is unaffected.

## Tests

- `cargo test --release --lib proof` — passes.
- `cargo test --release --test files proof_support_snapshot` — passes (`UserDefined` remains proof-unsupported).
- Added a unit test that registers a user-defined command and runs a program containing it under term encoding without proofs, confirming no panic and that the command is forwarded.
- `make fixnits` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)