### PR TITLE
[codex] Simplify generated proof snapshots

### DIFF
--- a/src/proofs/proof_simplification.rs
+++ b/src/proofs/proof_simplification.rs
@@ -197,6 +197,7 @@ impl ProofStore {
                     justification: Justification::Sym(right_id),
                 };
                 let sym_right_id = self.add_proof(sym_right);
+                let sym_right_id = self.simplify(sym_right_id);
 
                 // Create Sym(p1): b = a
                 let sym_left = Proof {
@@ -204,6 +205,7 @@ impl ProofStore {
                     justification: Justification::Sym(left_id),
                 };
                 let sym_left_id = self.add_proof(sym_left);
+                let sym_left_id = self.simplify(sym_left_id);
 
                 // Create Trans(Sym(p2), Sym(p1)): c = a
                 let new_trans = Proof {

--- a/src/proofs/proof_simplification.rs
+++ b/src/proofs/proof_simplification.rs
@@ -79,6 +79,10 @@ impl ProofStore {
         let proof_id = self.map_child_proofs(proof_id, |store, pid| store.simplify(pid));
 
         // Apply local optimizations until fixed point
+        self.simplify_local(proof_id)
+    }
+
+    fn simplify_local(&mut self, proof_id: ProofId) -> ProofId {
         let mut current_id = proof_id;
         loop {
             let new_id = self.apply_local_optimizations(current_id);
@@ -197,7 +201,7 @@ impl ProofStore {
                     justification: Justification::Sym(right_id),
                 };
                 let sym_right_id = self.add_proof(sym_right);
-                let sym_right_id = self.simplify(sym_right_id);
+                let sym_right_id = self.simplify_local(sym_right_id);
 
                 // Create Sym(p1): b = a
                 let sym_left = Proof {
@@ -205,7 +209,7 @@ impl ProofStore {
                     justification: Justification::Sym(left_id),
                 };
                 let sym_left_id = self.add_proof(sym_left);
-                let sym_left_id = self.simplify(sym_left_id);
+                let sym_left_id = self.simplify_local(sym_left_id);
 
                 // Create Trans(Sym(p2), Sym(p1)): c = a
                 let new_trans = Proof {

--- a/tests/proofs/eqsat-basic-proof.egg
+++ b/tests/proofs/eqsat-basic-proof.egg
@@ -1,0 +1,24 @@
+(datatype Math
+  (Num i64)
+  (Var String)
+  (Add Math Math)
+  (Mul Math Math))
+
+;; expr1 = 2 * (x + 3)
+(let $expr1 (Mul (Num 2) (Add (Var "x") (Num 3))))
+;; expr2 = 6 + 2 * x
+(let $expr2 (Add (Num 6) (Mul (Num 2) (Var "x"))))
+
+;; (rule ((= __root (Add a b)))
+;;       ((union __root (Add b a)))
+(rewrite (Add a b)
+         (Add b a))
+(rewrite (Mul a (Add b c))
+         (Add (Mul a b) (Mul a c)))
+(rewrite (Add (Num a) (Num b))
+         (Num (+ a b)))
+(rewrite (Mul (Num a) (Num b))
+         (Num (* a b)))
+
+(run 10)
+(prove (= $expr1 $expr2))

--- a/tests/snapshots/files__shared_snapshot_eqsat_basic_proof.snap
+++ b/tests/snapshots/files__shared_snapshot_eqsat_basic_proof.snap
@@ -1,0 +1,59 @@
+---
+source: tests/files.rs
+expression: snapshot_content_across_treatments
+---
+(let t0 (Mul (Num 2) (Add (Var "x") (Num 3))))
+(let t1 (Mul (Num 2) (Var "x")))
+(let t2 (Add (Num 6) t1))
+(let t3 (Mul (Num 2) (Num 3)))
+(let t4 (Add t3 t1))
+(let prop0 (= t0 t4))
+(let prop1 (= t4 t0))
+(let t5 (Add t1 t3))
+(let t6 (premises (Fiat (= t0 t0))))
+(let t7
+  (substitution
+                    (@rewrite_var__1 t0)
+                    (a (Num 2))
+                    (b (Var "x"))
+                    (c (Num 3))))
+(let t8
+  (premises
+              (Sym
+                (= t0 t5)
+                (Rule
+                  (= t5 t0)
+                  (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
+                  t6
+                  t7))))
+(let t9 (substitution (a t1) (b t3) (@rewrite_var__ t0)))
+(let prop2 (= t4 t2))
+(Trans
+  (= t0 t2)
+  (Sym
+    prop0
+    (Sym
+      prop1
+      (Sym prop0 (Rule prop1 (name "(rewrite (Add a b) (Add b a))") t8 t9))))
+  (Sym
+    prop2
+    (Sym
+      (= t2 t4)
+      (Congr
+        prop2
+        (Rule (= t4 t4) (name "(rewrite (Add a b) (Add b a))") t8 t9)
+        (Rule
+          (= t3 (Num 6))
+          (name "(rewrite (Mul (Num a) (Num b)) (Num (* a b)))")
+          (premises
+            (Rule
+              (= t3 t3)
+              (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
+              t6
+              t7))
+          (substitution (a 2) (b 3) (@rewrite_var__3 t3)))
+        0))))
+((Add 4)
+ (Mul 3)
+ (Num 3)
+ (Var 1))

--- a/tests/snapshots/files__shared_snapshot_eqsat_basic_proof.snap
+++ b/tests/snapshots/files__shared_snapshot_eqsat_basic_proof.snap
@@ -7,52 +7,41 @@ expression: snapshot_content_across_treatments
 (let t2 (Add (Num 6) t1))
 (let t3 (Mul (Num 2) (Num 3)))
 (let t4 (Add t3 t1))
-(let prop0 (= t0 t4))
-(let prop1 (= t4 t0))
 (let t5 (Add t1 t3))
 (let t6 (premises (Fiat (= t0 t0))))
 (let t7
   (substitution
-                    (@rewrite_var__1 t0)
-                    (a (Num 2))
-                    (b (Var "x"))
-                    (c (Num 3))))
+                (@rewrite_var__1 t0)
+                (a (Num 2))
+                (b (Var "x"))
+                (c (Num 3))))
 (let t8
   (premises
-              (Sym
-                (= t0 t5)
-                (Rule
-                  (= t5 t0)
-                  (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
-                  t6
-                  t7))))
-(let t9 (substitution (a t1) (b t3) (@rewrite_var__ t0)))
-(let prop2 (= t4 t2))
-(Trans
-  (= t0 t2)
-  (Sym
-    prop0
-    (Sym
-      prop1
-      (Sym prop0 (Rule prop1 (name "(rewrite (Add a b) (Add b a))") t8 t9))))
-  (Sym
-    prop2
-    (Sym
-      (= t2 t4)
-      (Congr
-        prop2
-        (Rule (= t4 t4) (name "(rewrite (Add a b) (Add b a))") t8 t9)
-        (Rule
-          (= t3 (Num 6))
-          (name "(rewrite (Mul (Num a) (Num b)) (Num (* a b)))")
-          (premises
+          (Sym
+            (= t0 t5)
             (Rule
-              (= t3 t3)
+              (= t5 t0)
               (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
               t6
-              t7))
-          (substitution (a 2) (b 3) (@rewrite_var__3 t3)))
-        0))))
+              t7))))
+(let t9 (substitution (a t1) (b t3) (@rewrite_var__ t0)))
+(Trans
+  (= t0 t2)
+  (Sym (= t0 t4) (Rule (= t4 t0) (name "(rewrite (Add a b) (Add b a))") t8 t9))
+  (Congr
+    (= t4 t2)
+    (Rule (= t4 t4) (name "(rewrite (Add a b) (Add b a))") t8 t9)
+    (Rule
+      (= t3 (Num 6))
+      (name "(rewrite (Mul (Num a) (Num b)) (Num (* a b)))")
+      (premises
+        (Rule
+          (= t3 t3)
+          (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
+          t6
+          t7))
+      (substitution (a 2) (b 3) (@rewrite_var__3 t3)))
+    0))
 ((Add 4)
  (Mul 3)
  (Num 3)


### PR DESCRIPTION
## Summary

- Add a checked-in proof-mode fixture for `eqsat-basic` so the generated proof output has a stable snapshot to inspect.
- Simplify freshly-created `Sym` subproofs while rewriting `Sym(Trans(...))`, which removes redundant nested symmetry chains from generated proofs.
- Update the `eqsat-basic` proof snapshot to show the smaller proof shape produced by the simplifier.

## Rationale

Proof output is most useful when it is easy to look at and compare. The existing output for `eqsat-basic` was technically valid, but it included extra `Sym(Sym(...))` structure and proof let-bindings introduced by the simplifier itself. This change keeps the proof format low-level, but removes that avoidable noise so future proof changes are easier to review.

## Proof snapshot shrinkage

The simplifier commit is [`8ceaa013`](https://github.com/egraphs-good/egglog/pull/922/commits/8ceaa013b2463e571ac36f56a9860987fb11ef89). Its snapshot diff shows the proof getting smaller after redundant symmetry chains are simplified:

```diff
diff --git a/tests/snapshots/files__shared_snapshot_eqsat_basic_proof.snap b/tests/snapshots/files__shared_snapshot_eqsat_basic_proof.snap
index 26079be4..72d52cff 100644
--- a/tests/snapshots/files__shared_snapshot_eqsat_basic_proof.snap
+++ b/tests/snapshots/files__shared_snapshot_eqsat_basic_proof.snap
@@ -7,52 +7,41 @@ expression: snapshot_content_across_treatments
 (let t2 (Add (Num 6) t1))
 (let t3 (Mul (Num 2) (Num 3)))
 (let t4 (Add t3 t1))
-(let prop0 (= t0 t4))
-(let prop1 (= t4 t0))
 (let t5 (Add t1 t3))
 (let t6 (premises (Fiat (= t0 t0))))
 (let t7
   (substitution
-                    (@rewrite_var__1 t0)
-                    (a (Num 2))
-                    (b (Var "x"))
-                    (c (Num 3))))
+                (@rewrite_var__1 t0)
+                (a (Num 2))
+                (b (Var "x"))
+                (c (Num 3))))
 (let t8
   (premises
-              (Sym
-                (= t0 t5)
-                (Rule
-                  (= t5 t0)
-                  (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
-                  t6
-                  t7))))
+          (Sym
+            (= t0 t5)
+            (Rule
+              (= t5 t0)
+              (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
+              t6
+              t7))))
 (let t9 (substitution (a t1) (b t3) (@rewrite_var__ t0)))
-(let prop2 (= t4 t2))
 (Trans
   (= t0 t2)
-  (Sym
-    prop0
-    (Sym
-      prop1
-      (Sym prop0 (Rule prop1 (name "(rewrite (Add a b) (Add b a))") t8 t9))))
-  (Sym
-    prop2
-    (Sym
-      (= t2 t4)
-      (Congr
-        prop2
-        (Rule (= t4 t4) (name "(rewrite (Add a b) (Add b a))") t8 t9)
+  (Sym (= t0 t4) (Rule (= t4 t0) (name "(rewrite (Add a b) (Add b a))") t8 t9))
+  (Congr
+    (= t4 t2)
+    (Rule (= t4 t4) (name "(rewrite (Add a b) (Add b a))") t8 t9)
+    (Rule
+      (= t3 (Num 6))
+      (name "(rewrite (Mul (Num a) (Num b)) (Num (* a b)))")
+      (premises
         (Rule
-          (= t3 (Num 6))
-          (name "(rewrite (Mul (Num a) (Num b)) (Num (* a b)))")
-          (premises
-            (Rule
-              (= t3 t3)
-              (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
-              t6
-              t7))
-          (substitution (a 2) (b 3) (@rewrite_var__3 t3)))
-        0))))
+          (= t3 t3)
+          (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
+          t6
+          t7))
+      (substitution (a 2) (b 3) (@rewrite_var__3 t3)))
+    0))
 ((Add 4)
  (Mul 3)
  (Num 3)
```

## Validation

- `cargo insta test --test-runner nextest --release --workspace --unreferenced ignore --accept --`
- `cargo fmt --check`
- `git diff --check`


## Annotated eqsat-basic proofs

I also had the agent create an annotated output of the eqsat proofs based, which I found helpful to follow the format... It might be worth inculding something like this at some point in our docs:

```lisp
; Temporary tutorial copy of:
;   tests/snapshots/files__shared_snapshot_eqsat_basic_proof.snap
;
; This is documentation for the current proof output, not a standalone user
; program. The source program is tests/proofs/eqsat-basic-proof.egg.
; The proof constructors below are internal proof-mode output constructors.
;
; Goal of the example:
;   The source asks egglog to prove (= $expr1 $expr2), where:
;     $expr1 is 2 * (x + 3)
;     $expr2 is 6 + 2 * x
;
; How to read this file:
;   - The `t0`, `t1`, ... names are pretty-printer abbreviations for shared
;     terms. They are not source-level egglog variables.
;   - Every proof node begins with the equality it proves.
;   - `(Rule (= lhs rhs) (name "...") (premises ...) (substitution ...))`
;     means: apply a source rewrite/rule, using proofs for its premises and a
;     concrete substitution for its pattern variables.
;   - `(Sym (= lhs rhs) proof)` flips a proof of rhs = lhs into lhs = rhs.
;   - `(Trans (= lhs rhs) proof1 proof2)` composes two proofs through a
;     shared middle term. If `proof1` proves `(= lhs mid)` and `proof2` proves
;     `(= mid rhs)`, then `Trans` proves `(= lhs rhs)`. The middle term is not
;     an extra argument; it appears as the rhs of `proof1` and the lhs of
;     `proof2`.
;   - `(Congr (= lhs rhs) base-proof child-proof i)` rewrites child `i` of the
;     right side proved by `base-proof`, using `child-proof`.
;   - `(Fiat (= lhs rhs))` is trusted evidence that proof mode records for a
;     top-level inserted equality or primitive/reflexive fact. Proof mode does
;     not just assume every t = t for free.
;
; About `substitution`:
;   In this printed proof format, `substitution` is a helper record:
;
;     substitution : (VariableName, GroundTerm)* -> RuleInstantiation
;
;   It is not a normal egglog function from the source program. It records the
;   concrete terms used for a rule application. For example, `(a (Num 2))`
;   means the pattern variable `a` in the named rewrite was instantiated with
;   the term `(Num 2)`.
;
; About `@rewrite_var__...`:
;   These are internal fresh variables introduced by rewrite desugaring/proof
;   encoding. They are not written by the user. In this proof, they record the
;   concrete term/root being rewritten so the checker can connect a local rule
;   match back to the equality being justified.
;
; Follow the proof from the final `Trans`:
;   1. Prove t0 = t4: distribute 2 over (x + 3), then commute the Add.
;   2. Prove t4 = t2: evaluate the first Add child, (Mul 2 3), to 6.
;   3. Compose those with transitivity to prove t0 = t2.

; t0 is the starting expression: 2 * (x + 3).
(let t0 (Mul (Num 2) (Add (Var "x") (Num 3))))

; t1 is the reusable subterm 2 * x.
(let t1 (Mul (Num 2) (Var "x")))

; t2 is the target expression: 6 + (2 * x).
(let t2 (Add (Num 6) t1))

; t3 is the numeric multiplication subterm that will later reduce to 6.
(let t3 (Mul (Num 2) (Num 3)))

; t4 is the distributed expression in target order: (2 * 3) + (2 * x).
(let t4 (Add t3 t1))

; t5 is the same Add as t4 but with children swapped: (2 * x) + (2 * 3).
; The distributivity rewrite produces this order, and Add commutativity turns
; it into t4.
(let t5 (Add t1 t3))

; t6 is a premise list for the distributivity rule application below.
; The single premise proof says that the original root term t0 exists as t0 = t0.
(let t6 (premises (Fiat (= t0 t0))))

; t7 records the concrete substitution for distributivity:
;   (Mul a (Add b c)) -> (Add (Mul a b) (Mul a c))
;   a = 2, b = x, c = 3
; The internal @rewrite_var__1 binds the matched root term, t0.
(let t7
  (substitution
                (@rewrite_var__1 t0)
                (a (Num 2))
                (b (Var "x"))
                (c (Num 3))))

; t8 is a premise list used by the later Add-commutativity proof.
; Inside it, the Rule proves t5 = t0 by applying distributivity with t6/t7.
; The surrounding Sym flips that to t0 = t5, because the later rewrite wants
; evidence that the root expression can be seen as the Add term t5.
(let t8
  (premises
          (Sym
            (= t0 t5)
            (Rule
              (= t5 t0)
              (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
              t6
              t7))))

; t9 records the substitution for Add commutativity:
;   (Add a b) -> (Add b a)
;   a = t1, b = t3
; @rewrite_var__ is the internal root term being justified, again t0.
(let t9 (substitution (a t1) (b t3) (@rewrite_var__ t0)))

; The top-level proof is a transitivity chain for (= t0 t2).
; Read it as:
;   t0 = t4
;   t4 = t2
; Therefore:
;   t0 = t2
(Trans
  (= t0 t2)

  ; Left side of the Trans: prove t0 = t4.
  ; The Rule itself proves t4 = t0 by applying Add commutativity at the root
  ; after the distributivity premise t8. Sym flips that into t0 = t4.
  (Sym (= t0 t4) (Rule (= t4 t0) (name "(rewrite (Add a b) (Add b a))") t8 t9))

  ; Right side of the Trans: prove t4 = t2 with congruence.
  ; Base proof:
  ;   (Rule (= t4 t4) ...) proves the Add term t4 exists under the same
  ;   Add-commutativity rule context.
  ; Child proof:
  ;   The nested numeric Rule proves t3 = (Num 6), i.e. (Mul 2 3) = 6.
  ; Child index:
  ;   0 means "replace the first child of t4".
  ; Since t4 is (Add t3 t1), replacing child 0 with (Num 6) gives t2.
  (Congr
    (= t4 t2)
    (Rule (= t4 t4) (name "(rewrite (Add a b) (Add b a))") t8 t9)
    (Rule
      (= t3 (Num 6))
      (name "(rewrite (Mul (Num a) (Num b)) (Num (* a b)))")

      ; The numeric multiplication rewrite also needs a premise proof. Here it
      ; reuses the distributivity rule context to prove the subterm t3 exists.
      (premises
        (Rule
          (= t3 t3)
          (name "(rewrite (Mul a (Add b c)) (Add (Mul a b) (Mul a c)))")
          t6
          t7))

      ; Substitution for the numeric multiplication rewrite:
      ;   a = 2, b = 3
      ; @rewrite_var__3 is the internal root for this local rewrite, t3.
      (substitution (a 2) (b 3) (@rewrite_var__3 t3)))
    0))

; The test harness appends `(print-size)` to every file test. This final block
; is that ordinary size output, not part of the proof.
((Add 4)
 (Mul 3)
 (Num 3)
 (Var 1))
```