### PR TITLE
run-schedule size limit

### DIFF
--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -3,7 +3,7 @@
 use std::{
     cmp, iter, mem,
     ops::Range,
-    sync::{Arc, OnceLock, RwLock, atomic::AtomicUsize},
+    sync::{Arc, OnceLock, RwLock, atomic::AtomicBool, atomic::AtomicUsize},
 };
 
 use crate::{
@@ -2100,12 +2100,24 @@ pub static SIZE_CAP: AtomicUsize = AtomicUsize::new(usize::MAX);
 /// the cap is armed and after every iteration's rebuild, and bumped by inserts
 /// (an upper bound) in between.
 pub static SIZE_ESTIMATE: AtomicUsize = AtomicUsize::new(0);
+/// Set once the estimate first crosses the cap. The schedule loops poll this
+/// (`size_cap_hit`) and terminate the whole run-schedule, rather than
+/// stopping a single iteration mid-way and continuing (which would silently
+/// drop the unapplied matches of that iteration).
+pub static SIZE_CAP_HIT: AtomicBool = AtomicBool::new(false);
 
 /// Set the cap on total e-graph size and reset the running estimate (seed it
 /// with the actual size via `sync_size_estimate`). Pass `usize::MAX` to disable.
 pub fn set_action_row_cap(cap: usize) {
     SIZE_CAP.store(cap, std::sync::atomic::Ordering::Relaxed);
     SIZE_ESTIMATE.store(0, std::sync::atomic::Ordering::Relaxed);
+    SIZE_CAP_HIT.store(false, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether the estimate has crossed the cap (so the schedule should stop). Stays
+/// set until the cap is re-armed via `set_action_row_cap`.
+pub fn size_cap_hit() -> bool {
+    SIZE_CAP_HIT.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Whether a size cap is currently active. Used by the backend to avoid
@@ -2177,7 +2189,11 @@ impl MatchCounter {
         self.matches[action].load(std::sync::atomic::Ordering::Acquire)
     }
     fn over_cap(&self) -> bool {
-        SIZE_ESTIMATE.load(std::sync::atomic::Ordering::Relaxed) >= self.cap
+        let over = SIZE_ESTIMATE.load(std::sync::atomic::Ordering::Relaxed) >= self.cap;
+        if over {
+            SIZE_CAP_HIT.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+        over
     }
 
     /// The batch size to flush at (size cap). With no cap this is

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -1764,8 +1764,6 @@ impl<'a, 'outer: 'a> ActionBuffer<'a, ActionId> for InPlaceActionBuffer<'outer> 
         bindings: &DenseIdMap<Variable, Value>,
         mut to_exec_state: impl FnMut() -> ExecutionState<'a>,
     ) {
-        // Size cap: once the cumulative cap is reached, stop the
-        // join and drop further matches instead of buffering/applying them.
         if self.match_counter.over_cap() {
             to_exec_state().trigger_early_stop();
             return;
@@ -1871,6 +1869,10 @@ impl<'scope> ActionBuffer<'scope, ActionId> for ScopedActionBuffer<'_, 'scope> {
             action_state.len = 0;
             let match_counter = self.match_counter.clone();
             self.scope.spawn(move |_| {
+                if match_counter.over_cap() {
+                    state.trigger_early_stop();
+                    return;
+                }
                 let succeeded = state.run_instrs(&action_info.instrs, &mut bindings);
                 match_counter.inc_matches(action, succeeded);
                 if match_counter.over_cap() {
@@ -1935,11 +1937,11 @@ fn flush_action_states(
     rule_set: &RuleSet,
     match_counter: &MatchCounter,
 ) {
-    if match_counter.over_cap() {
-        return;
-    }
     for (action, ActionState { bindings, len, .. }) in actions.iter_mut() {
         if *len > 0 {
+            if match_counter.over_cap() {
+                return;
+            }
             let succeeded = exec_state.run_instrs(&rule_set.actions[action].instrs, bindings);
             bindings.clear();
             match_counter.inc_matches(action, succeeded);

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -3,7 +3,10 @@
 use std::{
     cmp, iter, mem,
     ops::Range,
-    sync::{Arc, OnceLock, RwLock, atomic::AtomicBool, atomic::AtomicUsize},
+    sync::{
+        Arc, OnceLock, RwLock,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
 };
 
 use crate::{
@@ -349,7 +352,7 @@ impl Database {
         if rule_set.plans.is_empty() {
             return RuleSetReport::default();
         }
-        let match_counter = Arc::new(MatchCounter::new(rule_set));
+        let match_counter = Arc::new(MatchCounter::new(rule_set, self.size_cap.clone()));
 
         let search_and_apply_timer = Instant::now();
         // let mut rule_reports: HashMap<String, Vec<RuleReport>>;
@@ -2081,56 +2084,71 @@ impl<'scope> ActionBuffer<'scope, MatId> for ScopedMaterializer<'_, 'scope> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Size cap
-//
-// A *mid-iteration* bound on the total size of the e-graph. `run_rule_set`
-// applies all matches in batches; with a cap set, it stops applying (and halts
-// the join via `ExecutionState::trigger_early_stop`) once the running size
-// estimate reaches the cap.
-//
-// State is process-global so the single counter is contention-free (one atomic
-// add per batch, not per row). It persists across `run_rule_set` calls until
-// the cap is cleared via `set_action_row_cap(usize::MAX)`.
-// ---------------------------------------------------------------------------
-
-/// The cap on total e-graph size. `usize::MAX` disables the cap.
-pub static SIZE_CAP: AtomicUsize = AtomicUsize::new(usize::MAX);
-/// Running estimate of the total e-graph size: resynced to the actual size when
-/// the cap is armed and after every iteration's rebuild, and bumped by inserts
-/// (an upper bound) in between.
-pub static SIZE_ESTIMATE: AtomicUsize = AtomicUsize::new(0);
-/// Set once the estimate first crosses the cap. The schedule loops poll this
-/// (`size_cap_hit`) and terminate the whole run-schedule, rather than
-/// stopping a single iteration mid-way and continuing (which would silently
-/// drop the unapplied matches of that iteration).
-pub static SIZE_CAP_HIT: AtomicBool = AtomicBool::new(false);
-
-/// Set the cap on total e-graph size and reset the running estimate (seed it
-/// with the actual size via `sync_size_estimate`). Pass `usize::MAX` to disable.
-pub fn set_action_row_cap(cap: usize) {
-    SIZE_CAP.store(cap, std::sync::atomic::Ordering::Relaxed);
-    SIZE_ESTIMATE.store(0, std::sync::atomic::Ordering::Relaxed);
-    SIZE_CAP_HIT.store(false, std::sync::atomic::Ordering::Relaxed);
+/// Per-`Database` size-cap state, shared with the `MatchCounter` (and thus the
+/// parallel action buffers) via `Arc`.
+pub(crate) struct SizeCap {
+    /// The cap on total e-graph size. `usize::MAX` disables the cap.
+    cap: AtomicUsize,
+    /// Running estimate of total e-graph size: resynced to the actual size when
+    /// armed and after every iteration's rebuild, bumped by inserts (an upper
+    /// bound) in between.
+    estimate: AtomicUsize,
+    /// Set once the estimate first crosses the cap, so the schedule loops stop
+    /// the whole run-schedule.
+    hit: AtomicBool,
 }
 
-/// Whether the estimate has crossed the cap (so the schedule should stop). Stays
-/// set until the cap is re-armed via `set_action_row_cap`.
-pub fn size_cap_hit() -> bool {
-    SIZE_CAP_HIT.load(std::sync::atomic::Ordering::Relaxed)
+impl Default for SizeCap {
+    fn default() -> Self {
+        Self {
+            cap: AtomicUsize::new(usize::MAX),
+            estimate: AtomicUsize::new(0),
+            hit: AtomicBool::new(false),
+        }
+    }
 }
 
-/// Whether a size cap is currently active. Used by the backend to avoid
-/// computing the actual size when uncapped.
-pub fn size_cap_active() -> bool {
-    SIZE_CAP.load(std::sync::atomic::Ordering::Relaxed) != usize::MAX
-}
+impl SizeCap {
+    /// Set the cap on total e-graph size and reset the running estimate (seed it
+    /// with the actual size via [`SizeCap::sync`]). Pass `usize::MAX` to disable.
+    pub(crate) fn set(&self, cap: usize) {
+        self.cap.store(cap, Ordering::Relaxed);
+        self.estimate.store(0, Ordering::Relaxed);
+        self.hit.store(false, Ordering::Relaxed);
+    }
 
-/// Resync the running size estimate to the actual e-graph size (e.g. to seed it
-/// when the cap is armed). No-op if uncapped.
-pub fn sync_size_estimate(actual_size: usize) {
-    if size_cap_active() {
-        SIZE_ESTIMATE.store(actual_size, std::sync::atomic::Ordering::Relaxed);
+    /// Whether a size cap is currently active.
+    pub(crate) fn active(&self) -> bool {
+        self.cap.load(Ordering::Relaxed) != usize::MAX
+    }
+
+    /// Resync the running estimate to the actual e-graph size.
+    pub(crate) fn sync(&self, actual_size: usize) {
+        self.estimate.store(actual_size, Ordering::Relaxed);
+    }
+
+    /// Whether the estimate has crossed the cap (sticky until re-armed via
+    /// [`SizeCap::set`]).
+    pub(crate) fn hit(&self) -> bool {
+        self.hit.load(Ordering::Relaxed)
+    }
+
+    fn cap_val(&self) -> usize {
+        self.cap.load(Ordering::Relaxed)
+    }
+    fn estimate_val(&self) -> usize {
+        self.estimate.load(Ordering::Relaxed)
+    }
+    fn add(&self, n: usize) {
+        self.estimate.fetch_add(n, Ordering::Relaxed);
+    }
+    /// Whether the estimate is at/over the cap; records the sticky hit flag.
+    fn over(&self) -> bool {
+        let over = self.estimate_val() >= self.cap_val();
+        if over {
+            self.hit.store(true, Ordering::Relaxed);
+        }
+        over
     }
 }
 
@@ -2153,17 +2171,17 @@ fn action_enode_bound(instrs: &[Instr]) -> usize {
 struct MatchCounter {
     matches: IdVec<ActionId, CachePadded<AtomicUsize>>,
     enode_bounds: IdVec<ActionId, usize>,
-    cap: usize,
+    size_cap: Arc<SizeCap>,
 }
 
 impl MatchCounter {
-    fn new(rule_set: &RuleSet) -> Self {
+    fn new(rule_set: &RuleSet, size_cap: Arc<SizeCap>) -> Self {
         let n_ids = rule_set.actions.n_ids();
         let mut matches = IdVec::with_capacity(n_ids);
         matches.resize_with(n_ids, || CachePadded::new(AtomicUsize::new(0)));
-        let cap = SIZE_CAP.load(std::sync::atomic::Ordering::Relaxed);
-        let mut enode_bounds = IdVec::with_capacity(if cap == usize::MAX { 0 } else { n_ids });
-        if cap != usize::MAX {
+        let capped = size_cap.active();
+        let mut enode_bounds = IdVec::with_capacity(if capped { n_ids } else { 0 });
+        if capped {
             enode_bounds.resize_with(n_ids, || 0usize);
             for (action, info) in rule_set.actions.iter() {
                 enode_bounds[action] = action_enode_bound(&info.instrs);
@@ -2172,28 +2190,24 @@ impl MatchCounter {
         Self {
             matches,
             enode_bounds,
-            cap,
+            size_cap,
         }
     }
 
     fn inc_matches(&self, action: ActionId, by: usize) {
-        self.matches[action].fetch_add(by, std::sync::atomic::Ordering::Relaxed);
-        if self.cap != usize::MAX {
+        self.matches[action].fetch_add(by, Ordering::Relaxed);
+        if self.size_cap.active() {
             let added = by * self.enode_bounds[action];
             if added > 0 {
-                SIZE_ESTIMATE.fetch_add(added, std::sync::atomic::Ordering::Relaxed);
+                self.size_cap.add(added);
             }
         }
     }
     fn read_matches(&self, action: ActionId) -> usize {
-        self.matches[action].load(std::sync::atomic::Ordering::Acquire)
+        self.matches[action].load(Ordering::Acquire)
     }
     fn over_cap(&self) -> bool {
-        let over = SIZE_ESTIMATE.load(std::sync::atomic::Ordering::Relaxed) >= self.cap;
-        if over {
-            SIZE_CAP_HIT.store(true, std::sync::atomic::Ordering::Relaxed);
-        }
-        over
+        self.size_cap.over()
     }
 
     /// The batch size to flush at (size cap). With no cap this is
@@ -2202,11 +2216,13 @@ impl MatchCounter {
     /// can't collectively overshoot by much: bound total in-flight (~threads ×
     /// batch) to the remaining budget.
     fn batch_size(&self) -> usize {
-        if self.cap == usize::MAX {
+        if !self.size_cap.active() {
             return VAR_BATCH_SIZE;
         }
-        let total = SIZE_ESTIMATE.load(std::sync::atomic::Ordering::Relaxed);
-        let remaining = self.cap.saturating_sub(total);
+        let remaining = self
+            .size_cap
+            .cap_val()
+            .saturating_sub(self.size_cap.estimate_val());
         let threads = rayon::current_num_threads().max(1);
         (remaining / (threads * 2)).clamp(1, VAR_BATCH_SIZE)
     }

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -2084,32 +2084,41 @@ impl<'scope> ActionBuffer<'scope, MatId> for ScopedMaterializer<'_, 'scope> {
 // ---------------------------------------------------------------------------
 // Size cap
 //
-// A *mid-iteration* bound on how much an e-graph may grow. `run_rule_set`
+// A *mid-iteration* bound on the total size of the e-graph. `run_rule_set`
 // applies all matches in batches; with a cap set, it stops applying (and halts
-// the join via `ExecutionState::trigger_early_stop`) once the budget is spent.
-//
-// The budget is measured in *applied action rows* weighted by how many rows
-// each action inserts (`action_enode_bound`). True net e-node count is only
-// known at table-merge time (iteration boundary), too late to stop a single
-// exploding iteration, so we use applied rows as a per-batch proxy. Applied
-// rows over-count net nodes (duplicate terms, congruence).
+// the join via `ExecutionState::trigger_early_stop`) once the running size
+// estimate reaches the cap.
 //
 // State is process-global so the single counter is contention-free (one atomic
-// add per batch, not per row). The cap is cumulative across `run_rule_set`
-// calls (reset only by `set_action_row_cap`) so it bounds *total* growth over a
-// whole schedule, not per-iteration growth.
+// add per batch, not per row). It persists across `run_rule_set` calls until
+// the cap is cleared via `set_action_row_cap(usize::MAX)`.
 // ---------------------------------------------------------------------------
 
-/// The cumulative budget on applied action rows. `usize::MAX` disables the cap.
-pub static ACTION_ROW_CAP: AtomicUsize = AtomicUsize::new(usize::MAX);
-/// Rows applied since the cap was last set via [`set_action_row_cap`].
-pub static ACTION_ROWS_APPLIED: AtomicUsize = AtomicUsize::new(0);
+/// The cap on total e-graph size. `usize::MAX` disables the cap.
+pub static SIZE_CAP: AtomicUsize = AtomicUsize::new(usize::MAX);
+/// Running estimate of the total e-graph size: seeded with the actual size when
+/// the cap is armed, then bumped by inserts during application.
+pub static SIZE_ESTIMATE: AtomicUsize = AtomicUsize::new(0);
 
-/// Set the cumulative cap on applied action rows and reset the running total.
-/// Pass `usize::MAX` to disable.
+/// Set the cap on total e-graph size and reset the running estimate (seed it
+/// with the actual size via `sync_size_estimate`). Pass `usize::MAX` to disable.
 pub fn set_action_row_cap(cap: usize) {
-    ACTION_ROW_CAP.store(cap, std::sync::atomic::Ordering::Relaxed);
-    ACTION_ROWS_APPLIED.store(0, std::sync::atomic::Ordering::Relaxed);
+    SIZE_CAP.store(cap, std::sync::atomic::Ordering::Relaxed);
+    SIZE_ESTIMATE.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether a size cap is currently active. Used by the backend to avoid
+/// computing the actual size when uncapped.
+pub fn size_cap_active() -> bool {
+    SIZE_CAP.load(std::sync::atomic::Ordering::Relaxed) != usize::MAX
+}
+
+/// Resync the running size estimate to the actual e-graph size (e.g. to seed it
+/// when the cap is armed). No-op if uncapped.
+pub fn sync_size_estimate(actual_size: usize) {
+    if size_cap_active() {
+        SIZE_ESTIMATE.store(actual_size, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
 /// The number of row-inserting instructions in an action -- an upper bound on
@@ -2139,7 +2148,7 @@ impl MatchCounter {
         let n_ids = rule_set.actions.n_ids();
         let mut matches = IdVec::with_capacity(n_ids);
         matches.resize_with(n_ids, || CachePadded::new(AtomicUsize::new(0)));
-        let cap = ACTION_ROW_CAP.load(std::sync::atomic::Ordering::Relaxed);
+        let cap = SIZE_CAP.load(std::sync::atomic::Ordering::Relaxed);
         let mut enode_bounds = IdVec::with_capacity(if cap == usize::MAX { 0 } else { n_ids });
         if cap != usize::MAX {
             enode_bounds.resize_with(n_ids, || 0usize);
@@ -2159,7 +2168,7 @@ impl MatchCounter {
         if self.cap != usize::MAX {
             let added = by * self.enode_bounds[action];
             if added > 0 {
-                ACTION_ROWS_APPLIED.fetch_add(added, std::sync::atomic::Ordering::Relaxed);
+                SIZE_ESTIMATE.fetch_add(added, std::sync::atomic::Ordering::Relaxed);
             }
         }
     }
@@ -2167,7 +2176,7 @@ impl MatchCounter {
         self.matches[action].load(std::sync::atomic::Ordering::Acquire)
     }
     fn over_cap(&self) -> bool {
-        ACTION_ROWS_APPLIED.load(std::sync::atomic::Ordering::Relaxed) >= self.cap
+        SIZE_ESTIMATE.load(std::sync::atomic::Ordering::Relaxed) >= self.cap
     }
 
     /// The batch size to flush at (size cap). With no cap this is
@@ -2179,7 +2188,7 @@ impl MatchCounter {
         if self.cap == usize::MAX {
             return VAR_BATCH_SIZE;
         }
-        let total = ACTION_ROWS_APPLIED.load(std::sync::atomic::Ordering::Relaxed);
+        let total = SIZE_ESTIMATE.load(std::sync::atomic::Ordering::Relaxed);
         let remaining = self.cap.saturating_sub(total);
         let threads = rayon::current_num_threads().max(1);
         (remaining / (threads * 2)).clamp(1, VAR_BATCH_SIZE)

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -22,7 +22,7 @@ use web_time::Instant;
 
 use crate::{
     Constraint, OffsetRange, Pool, SubsetRef,
-    action::{Bindings, ExecutionState},
+    action::{Bindings, ExecutionState, Instr},
     common::{DashMap, Value},
     free_join::{
         frame_update::{FrameUpdates, UpdateInstr},
@@ -349,7 +349,7 @@ impl Database {
         if rule_set.plans.is_empty() {
             return RuleSetReport::default();
         }
-        let match_counter = Arc::new(MatchCounter::new(rule_set.actions.n_ids()));
+        let match_counter = Arc::new(MatchCounter::new(rule_set));
 
         let search_and_apply_timer = Instant::now();
         // let mut rule_reports: HashMap<String, Vec<RuleReport>>;
@@ -1761,6 +1761,12 @@ impl<'a, 'outer: 'a> ActionBuffer<'a, ActionId> for InPlaceActionBuffer<'outer> 
         bindings: &DenseIdMap<Variable, Value>,
         mut to_exec_state: impl FnMut() -> ExecutionState<'a>,
     ) {
+        // Size cap: once the cumulative cap is reached, stop the
+        // join and drop further matches instead of buffering/applying them.
+        if self.match_counter.over_cap() {
+            to_exec_state().trigger_early_stop();
+            return;
+        }
         let action_state = self.batches.get_or_default(action);
         action_state.n_runs += 1;
         action_state.len += 1;
@@ -1770,12 +1776,15 @@ impl<'a, 'outer: 'a> ActionBuffer<'a, ActionId> for InPlaceActionBuffer<'outer> 
         unsafe {
             action_state.bindings.push(bindings, &action_info.used_vars);
         }
-        if action_state.len >= VAR_BATCH_SIZE {
+        if action_state.len >= self.match_counter.batch_size() {
             let mut state = to_exec_state();
             let succeeded = state.run_instrs(&action_info.instrs, &mut action_state.bindings);
             action_state.bindings.clear();
             self.match_counter.inc_matches(action, succeeded);
             action_state.len = 0;
+            if self.match_counter.over_cap() {
+                state.trigger_early_stop();
+            }
         }
     }
 
@@ -1838,6 +1847,10 @@ impl<'scope> ActionBuffer<'scope, ActionId> for ScopedActionBuffer<'_, 'scope> {
         bindings: &DenseIdMap<Variable, Value>,
         mut to_exec_state: impl FnMut() -> ExecutionState<'scope>,
     ) {
+        if self.match_counter.over_cap() {
+            to_exec_state().trigger_early_stop();
+            return;
+        }
         self.needs_flush = true;
         let action_state = self.batches.get_or_default(action);
         action_state.n_runs += 1;
@@ -1848,7 +1861,7 @@ impl<'scope> ActionBuffer<'scope, ActionId> for ScopedActionBuffer<'_, 'scope> {
         unsafe {
             action_state.bindings.push(bindings, &action_info.used_vars);
         }
-        if action_state.len >= VAR_BATCH_SIZE {
+        if action_state.len >= self.match_counter.batch_size() {
             let mut state = to_exec_state();
             let mut bindings =
                 mem::replace(&mut action_state.bindings, Bindings::new(VAR_BATCH_SIZE));
@@ -1857,6 +1870,9 @@ impl<'scope> ActionBuffer<'scope, ActionId> for ScopedActionBuffer<'_, 'scope> {
             self.scope.spawn(move |_| {
                 let succeeded = state.run_instrs(&action_info.instrs, &mut bindings);
                 match_counter.inc_matches(action, succeeded);
+                if match_counter.over_cap() {
+                    state.trigger_early_stop();
+                }
             });
         }
     }
@@ -1916,6 +1932,9 @@ fn flush_action_states(
     rule_set: &RuleSet,
     match_counter: &MatchCounter,
 ) {
+    if match_counter.over_cap() {
+        return;
+    }
     for (action, ActionState { bindings, len, .. }) in actions.iter_mut() {
         if *len > 0 {
             let succeeded = exec_state.run_instrs(&rule_set.actions[action].instrs, bindings);
@@ -2062,22 +2081,108 @@ impl<'scope> ActionBuffer<'scope, MatId> for ScopedMaterializer<'_, 'scope> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Size cap
+//
+// A *mid-iteration* bound on how much an e-graph may grow. `run_rule_set`
+// applies all matches in batches; with a cap set, it stops applying (and halts
+// the join via `ExecutionState::trigger_early_stop`) once the budget is spent.
+//
+// The budget is measured in *applied action rows* weighted by how many rows
+// each action inserts (`action_enode_bound`). True net e-node count is only
+// known at table-merge time (iteration boundary), too late to stop a single
+// exploding iteration, so we use applied rows as a per-batch proxy. Applied
+// rows over-count net nodes (duplicate terms, congruence).
+//
+// State is process-global so the single counter is contention-free (one atomic
+// add per batch, not per row). The cap is cumulative across `run_rule_set`
+// calls (reset only by `set_action_row_cap`) so it bounds *total* growth over a
+// whole schedule, not per-iteration growth.
+// ---------------------------------------------------------------------------
+
+/// The cumulative budget on applied action rows. `usize::MAX` disables the cap.
+pub static ACTION_ROW_CAP: AtomicUsize = AtomicUsize::new(usize::MAX);
+/// Rows applied since the cap was last set via [`set_action_row_cap`].
+pub static ACTION_ROWS_APPLIED: AtomicUsize = AtomicUsize::new(0);
+
+/// Set the cumulative cap on applied action rows and reset the running total.
+/// Pass `usize::MAX` to disable.
+pub fn set_action_row_cap(cap: usize) {
+    ACTION_ROW_CAP.store(cap, std::sync::atomic::Ordering::Relaxed);
+    ACTION_ROWS_APPLIED.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The number of row-inserting instructions in an action -- an upper bound on
+/// the e-nodes one firing of that action adds.
+fn action_enode_bound(instrs: &[Instr]) -> usize {
+    instrs
+        .iter()
+        .filter(|i| {
+            matches!(
+                i,
+                Instr::Insert { .. }
+                    | Instr::InsertIfEq { .. }
+                    | Instr::LookupOrInsertDefault { .. }
+            )
+        })
+        .count()
+}
+
 struct MatchCounter {
     matches: IdVec<ActionId, CachePadded<AtomicUsize>>,
+    enode_bounds: IdVec<ActionId, usize>,
+    cap: usize,
 }
 
 impl MatchCounter {
-    fn new(n_ids: usize) -> Self {
+    fn new(rule_set: &RuleSet) -> Self {
+        let n_ids = rule_set.actions.n_ids();
         let mut matches = IdVec::with_capacity(n_ids);
         matches.resize_with(n_ids, || CachePadded::new(AtomicUsize::new(0)));
-        Self { matches }
+        let cap = ACTION_ROW_CAP.load(std::sync::atomic::Ordering::Relaxed);
+        let mut enode_bounds = IdVec::with_capacity(if cap == usize::MAX { 0 } else { n_ids });
+        if cap != usize::MAX {
+            enode_bounds.resize_with(n_ids, || 0usize);
+            for (action, info) in rule_set.actions.iter() {
+                enode_bounds[action] = action_enode_bound(&info.instrs);
+            }
+        }
+        Self {
+            matches,
+            enode_bounds,
+            cap,
+        }
     }
 
     fn inc_matches(&self, action: ActionId, by: usize) {
         self.matches[action].fetch_add(by, std::sync::atomic::Ordering::Relaxed);
+        if self.cap != usize::MAX {
+            let added = by * self.enode_bounds[action];
+            if added > 0 {
+                ACTION_ROWS_APPLIED.fetch_add(added, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
     }
     fn read_matches(&self, action: ActionId) -> usize {
         self.matches[action].load(std::sync::atomic::Ordering::Acquire)
+    }
+    fn over_cap(&self) -> bool {
+        ACTION_ROWS_APPLIED.load(std::sync::atomic::Ordering::Relaxed) >= self.cap
+    }
+
+    /// The batch size to flush at (size cap). With no cap this is
+    /// the constant `VAR_BATCH_SIZE` (max throughput). With a cap, shrink the
+    /// batch as we approach it so concurrent in-flight batches across threads
+    /// can't collectively overshoot by much: bound total in-flight (~threads ×
+    /// batch) to the remaining budget.
+    fn batch_size(&self) -> usize {
+        if self.cap == usize::MAX {
+            return VAR_BATCH_SIZE;
+        }
+        let total = ACTION_ROWS_APPLIED.load(std::sync::atomic::Ordering::Relaxed);
+        let remaining = self.cap.saturating_sub(total);
+        let threads = rayon::current_num_threads().max(1);
+        (remaining / (threads * 2)).clamp(1, VAR_BATCH_SIZE)
     }
 }
 

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -2096,8 +2096,9 @@ impl<'scope> ActionBuffer<'scope, MatId> for ScopedMaterializer<'_, 'scope> {
 
 /// The cap on total e-graph size. `usize::MAX` disables the cap.
 pub static SIZE_CAP: AtomicUsize = AtomicUsize::new(usize::MAX);
-/// Running estimate of the total e-graph size: seeded with the actual size when
-/// the cap is armed, then bumped by inserts during application.
+/// Running estimate of the total e-graph size: resynced to the actual size when
+/// the cap is armed and after every iteration's rebuild, and bumped by inserts
+/// (an upper bound) in between.
 pub static SIZE_ESTIMATE: AtomicUsize = AtomicUsize::new(0);
 
 /// Set the cap on total e-graph size and reset the running estimate (seed it

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -309,6 +309,9 @@ pub struct Database {
     /// This is primarily used to determine whether or not to attempt to do some operations in
     /// parallel.
     total_size_estimate: usize,
+    /// Per-database size-cap state (see [`execute::SizeCap`]). Shared via `Arc`
+    /// into the `MatchCounter` so the parallel action buffers can bump/poll it.
+    size_cap: Arc<execute::SizeCap>,
 }
 
 impl Database {
@@ -340,6 +343,22 @@ impl Database {
 
     pub fn base_values(&self) -> &BaseValues {
         &self.base_values
+    }
+
+    pub fn set_size_cap(&self, cap: usize) {
+        self.size_cap.set(cap);
+    }
+
+    pub fn sync_size_estimate(&self, actual_size: usize) {
+        self.size_cap.sync(actual_size);
+    }
+
+    pub fn size_cap_active(&self) -> bool {
+        self.size_cap.active()
+    }
+
+    pub fn size_cap_hit(&self) -> bool {
+        self.size_cap.hit()
     }
 
     pub fn base_values_mut(&mut self) -> &mut BaseValues {

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -28,7 +28,8 @@ pub use common::Value;
 pub use containers::{ContainerRebuildSummary, ContainerValue, ContainerValueId, ContainerValues};
 pub use free_join::{
     AtomId, CounterId, Database, ExternalFunction, ExternalFunctionId, TableId, Variable,
-    execute::set_action_row_cap, make_external_func, plan::PlanStrategy,
+    execute::{set_action_row_cap, size_cap_active, sync_size_estimate},
+    make_external_func, plan::PlanStrategy,
 };
 pub use hash_index::TupleIndex;
 pub use offsets::{OffsetRange, RowId, Subset, SubsetRef};

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -28,7 +28,7 @@ pub use common::Value;
 pub use containers::{ContainerRebuildSummary, ContainerValue, ContainerValueId, ContainerValues};
 pub use free_join::{
     AtomId, CounterId, Database, ExternalFunction, ExternalFunctionId, TableId, Variable,
-    make_external_func, plan::PlanStrategy,
+    execute::set_action_row_cap, make_external_func, plan::PlanStrategy,
 };
 pub use hash_index::TupleIndex;
 pub use offsets::{OffsetRange, RowId, Subset, SubsetRef};

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -28,7 +28,7 @@ pub use common::Value;
 pub use containers::{ContainerRebuildSummary, ContainerValue, ContainerValueId, ContainerValues};
 pub use free_join::{
     AtomId, CounterId, Database, ExternalFunction, ExternalFunctionId, TableId, Variable,
-    execute::{set_action_row_cap, size_cap_active, sync_size_estimate},
+    execute::{set_action_row_cap, size_cap_active, size_cap_hit, sync_size_estimate},
     make_external_func, plan::PlanStrategy,
 };
 pub use hash_index::TupleIndex;

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -28,7 +28,6 @@ pub use common::Value;
 pub use containers::{ContainerRebuildSummary, ContainerValue, ContainerValueId, ContainerValues};
 pub use free_join::{
     AtomId, CounterId, Database, ExternalFunction, ExternalFunctionId, TableId, Variable,
-    execute::{set_action_row_cap, size_cap_active, size_cap_hit, sync_size_estimate},
     make_external_func, plan::PlanStrategy,
 };
 pub use hash_index::TupleIndex;

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -571,6 +571,22 @@ impl EGraph {
         self.run_rules_inner(rules)
     }
 
+    pub fn set_size_cap(&self, cap: usize) {
+        self.db.set_size_cap(cap);
+    }
+
+    pub fn sync_size_estimate(&self, actual_size: usize) {
+        self.db.sync_size_estimate(actual_size);
+    }
+
+    pub fn size_cap_active(&self) -> bool {
+        self.db.size_cap_active()
+    }
+
+    pub fn size_cap_hit(&self) -> bool {
+        self.db.size_cap_hit()
+    }
+
     fn run_rules_inner(&mut self, rules: &[RuleId]) -> Result<IterationReport> {
         let ts = self.next_ts();
 

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -158,8 +158,8 @@ pub(crate) fn desugar_command(
             vec![NCommand::UnstableCombinedRuleset(span, name, subrulesets)]
         }
         Command::Action(action) => vec![NCommand::CoreAction(action)],
-        Command::RunSchedule(sched) => {
-            vec![NCommand::RunSchedule(sched.clone())]
+        Command::RunSchedule(sched, size_limit) => {
+            vec![NCommand::RunSchedule(sched.clone(), size_limit)]
         }
         Command::PrintOverallStatistics(span, file) => {
             vec![NCommand::PrintOverallStatistics(span, file.clone())]
@@ -263,13 +263,16 @@ fn desugar_prove(parser: &mut Parser, span: Span, query: Vec<Fact>) -> Vec<NComm
             },
         },
         // run the rule
-        NCommand::RunSchedule(GenericSchedule::Run(
-            span.clone(),
-            GenericRunConfig {
-                ruleset,
-                until: None,
-            },
-        )),
+        NCommand::RunSchedule(
+            GenericSchedule::Run(
+                span.clone(),
+                GenericRunConfig {
+                    ruleset,
+                    until: None,
+                },
+            ),
+            None,
+        ),
         // get a proof for the constructor
         NCommand::ProveExists(span, constructor_name),
     ]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -74,7 +74,7 @@ where
     },
     CoreAction(GenericAction<Head, Leaf>),
     Extract(Span, GenericExpr<Head, Leaf>, GenericExpr<Head, Leaf>),
-    RunSchedule(GenericSchedule<Head, Leaf>),
+    RunSchedule(GenericSchedule<Head, Leaf>, Option<usize>),
     PrintOverallStatistics(Span, Option<String>),
     Check(Span, Vec<GenericFact<Head, Leaf>>),
     PrintFunction(
@@ -153,7 +153,9 @@ where
                 GenericCommand::UnstableCombinedRuleset(span.clone(), name.clone(), others.clone())
             }
             GenericNCommand::NormRule { rule } => GenericCommand::Rule { rule: rule.clone() },
-            GenericNCommand::RunSchedule(schedule) => GenericCommand::RunSchedule(schedule.clone()),
+            GenericNCommand::RunSchedule(schedule, limit) => {
+                GenericCommand::RunSchedule(schedule.clone(), *limit)
+            }
             GenericNCommand::PrintOverallStatistics(span, file) => {
                 GenericCommand::PrintOverallStatistics(span.clone(), file.clone())
             }
@@ -205,8 +207,8 @@ where
                 rule.body = f(rule.body);
                 GenericNCommand::NormRule { rule }
             }
-            GenericNCommand::RunSchedule(schedule) => {
-                GenericNCommand::RunSchedule(schedule.visit_queries(f))
+            GenericNCommand::RunSchedule(schedule, limit) => {
+                GenericNCommand::RunSchedule(schedule.visit_queries(f), limit)
             }
             GenericNCommand::Fail(span, cmd) => {
                 GenericNCommand::Fail(span, Box::new(cmd.visit_queries(f)))
@@ -258,8 +260,8 @@ where
             GenericNCommand::NormRule { rule } => GenericNCommand::NormRule {
                 rule: rule.visit_exprs(f),
             },
-            GenericNCommand::RunSchedule(schedule) => {
-                GenericNCommand::RunSchedule(schedule.visit_exprs(f))
+            GenericNCommand::RunSchedule(schedule, limit) => {
+                GenericNCommand::RunSchedule(schedule.visit_exprs(f), limit)
             }
             GenericNCommand::PrintOverallStatistics(span, file) => {
                 GenericNCommand::PrintOverallStatistics(span, file)
@@ -847,7 +849,7 @@ where
     /// then runs `my-ruleset-2` four times.
     ///
     /// See [`Schedule`] for more details.
-    RunSchedule(GenericSchedule<Head, Leaf>),
+    RunSchedule(GenericSchedule<Head, Leaf>, Option<usize>),
     /// Print runtime statistics about rules
     /// and rulesets so far.
     PrintOverallStatistics(Span, Option<String>),
@@ -1049,7 +1051,10 @@ where
                 )
             }
             GenericCommand::Rule { rule } => rule.fmt(f),
-            GenericCommand::RunSchedule(sched) => write!(f, "(run-schedule {sched})"),
+            GenericCommand::RunSchedule(sched, limit) => match limit {
+                Some(n) => write!(f, "(run-schedule {sched} :size-limit {n})"),
+                None => write!(f, "(run-schedule {sched})"),
+            },
             GenericCommand::PrintOverallStatistics(_span, file) => match file {
                 Some(file) => write!(f, "(print-stats :file {file})"),
                 None => write!(f, "(print-stats)"),
@@ -1737,8 +1742,8 @@ where
             GenericCommand::Extract(span, expr, variants) => {
                 GenericCommand::Extract(span, expr, variants)
             }
-            GenericCommand::RunSchedule(schedule) => {
-                GenericCommand::RunSchedule(schedule.map_string_symbols(fun))
+            GenericCommand::RunSchedule(schedule, limit) => {
+                GenericCommand::RunSchedule(schedule.map_string_symbols(fun), limit)
             }
             GenericCommand::PrintOverallStatistics(span, file) => {
                 GenericCommand::PrintOverallStatistics(span, file)
@@ -1846,8 +1851,8 @@ where
                 file,
                 exprs: exprs.into_iter().map(|e| e.visit_exprs(f)).collect(),
             },
-            GenericCommand::RunSchedule(schedule) => {
-                GenericCommand::RunSchedule(schedule.visit_exprs(f))
+            GenericCommand::RunSchedule(schedule, limit) => {
+                GenericCommand::RunSchedule(schedule.visit_exprs(f), limit)
             }
             GenericCommand::Fail(span, cmd) => {
                 GenericCommand::Fail(span, Box::new(cmd.visit_exprs(f)))
@@ -1957,8 +1962,8 @@ where
                 expr.map_symbols(head, leaf),
                 variants.map_symbols(head, leaf),
             ),
-            GenericCommand::RunSchedule(schedule) => {
-                GenericCommand::RunSchedule(schedule.map_symbols(head, leaf))
+            GenericCommand::RunSchedule(schedule, limit) => {
+                GenericCommand::RunSchedule(schedule.map_symbols(head, leaf), limit)
             }
             GenericCommand::PrintOverallStatistics(span, file) => {
                 GenericCommand::PrintOverallStatistics(span, file)

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -600,16 +600,33 @@ impl Parser {
                     _ => return error!(span, "could not parse run options"),
                 };
 
-                vec![Command::RunSchedule(Schedule::Repeat(
-                    span.clone(),
-                    limit,
-                    Box::new(Schedule::Run(span, RunConfig { ruleset, until })),
-                ))]
+                vec![Command::RunSchedule(
+                    Schedule::Repeat(
+                        span.clone(),
+                        limit,
+                        Box::new(Schedule::Run(span, RunConfig { ruleset, until })),
+                    ),
+                    None,
+                )]
             }
-            "run-schedule" => vec![Command::RunSchedule(Schedule::Sequence(
-                span,
-                map_fallible(tail, self, Self::parse_schedule)?,
-            ))],
+            "run-schedule" => {
+                let split = tail
+                    .iter()
+                    .position(|s| matches!(s, Sexp::Atom(a, _) if a.starts_with(':')))
+                    .unwrap_or(tail.len());
+                let (scheds, opts) = tail.split_at(split);
+
+                let size_limit = match self.parse_options(opts)?.as_slice() {
+                    [] => None,
+                    [(":size-limit", [n])] => Some(n.expect_uint("size limit")?),
+                    _ => return error!(span, "could not parse run-schedule options"),
+                };
+
+                vec![Command::RunSchedule(
+                    Schedule::Sequence(span, map_fallible(scheds, self, Self::parse_schedule)?),
+                    size_limit,
+                )]
+            }
             "extract" => match tail {
                 [e] => vec![Command::Extract(
                     span.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ use core::CoreActionContext;
 use core::ResolvedAtomTerm;
 pub use core::{Atom, AtomTerm};
 pub use core::{ResolvedCall, SpecializedPrimitive};
-pub use core_relations::{BaseValue, ContainerValue, ExecutionState, Value};
+pub use core_relations::{BaseValue, ContainerValue, ExecutionState, Value, set_action_row_cap};
 use core_relations::{ExternalFunctionId, make_external_func};
 use csv::Writer;
 pub use egglog_add_primitive::add_literal_prim;
@@ -1275,8 +1275,15 @@ impl EGraph {
                 self.add_rule(rule)?;
                 log::info!("Declared rule {name}.")
             }
-            ResolvedNCommand::RunSchedule(sched) => {
-                let report = self.run_schedule(&sched)?;
+            ResolvedNCommand::RunSchedule(sched, size_limit) => {
+                if let Some(limit) = size_limit {
+                    set_action_row_cap(limit);
+                }
+                let result = self.run_schedule(&sched);
+                if size_limit.is_some() {
+                    set_action_row_cap(usize::MAX);
+                }
+                let report = result?;
                 log::info!("Ran schedule {sched}.");
                 log::info!("Report: {report}");
                 self.overall_run_report.union(report.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,9 @@ use core::CoreActionContext;
 use core::ResolvedAtomTerm;
 pub use core::{Atom, AtomTerm};
 pub use core::{ResolvedCall, SpecializedPrimitive};
-pub use core_relations::{BaseValue, ContainerValue, ExecutionState, Value, set_action_row_cap};
+pub use core_relations::{
+    BaseValue, ContainerValue, ExecutionState, Value, set_action_row_cap, sync_size_estimate,
+};
 use core_relations::{ExternalFunctionId, make_external_func};
 use csv::Writer;
 pub use egglog_add_primitive::add_literal_prim;
@@ -1278,6 +1280,7 @@ impl EGraph {
             ResolvedNCommand::RunSchedule(sched, size_limit) => {
                 if let Some(limit) = size_limit {
                     set_action_row_cap(limit);
+                    sync_size_estimate(self.num_tuples());
                 }
                 let result = self.run_schedule(&sched);
                 if size_limit.is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,10 +40,7 @@ use core::CoreActionContext;
 use core::ResolvedAtomTerm;
 pub use core::{Atom, AtomTerm};
 pub use core::{ResolvedCall, SpecializedPrimitive};
-pub use core_relations::{
-    BaseValue, ContainerValue, ExecutionState, Value, set_action_row_cap, size_cap_active,
-    size_cap_hit, sync_size_estimate,
-};
+pub use core_relations::{BaseValue, ContainerValue, ExecutionState, Value};
 use core_relations::{ExternalFunctionId, make_external_func};
 use csv::Writer;
 pub use egglog_add_primitive::add_literal_prim;
@@ -897,7 +894,7 @@ impl EGraph {
                     let rec = self.run_schedule(sched)?;
                     let can_stop = rec.can_stop;
                     report.union(rec);
-                    if can_stop || size_cap_hit() {
+                    if can_stop || self.size_cap_hit() {
                         break;
                     }
                 }
@@ -909,7 +906,7 @@ impl EGraph {
                     let rec = self.run_schedule(sched)?;
                     let updated = rec.updated;
                     report.union(rec);
-                    if !updated || size_cap_hit() {
+                    if !updated || self.size_cap_hit() {
                         break;
                     }
                 }
@@ -919,7 +916,7 @@ impl EGraph {
                 let mut report = RunReport::default();
                 for sched in scheds {
                     report.union(self.run_schedule(sched)?);
-                    if size_cap_hit() {
+                    if self.size_cap_hit() {
                         break;
                     }
                 }
@@ -988,8 +985,9 @@ impl EGraph {
             .run_rules(&rule_ids)
             .map_err(|e| Error::BackendError(e.to_string()))?;
 
-        if size_cap_active() {
-            sync_size_estimate(self.num_tuples());
+        if self.size_cap_active() {
+            let n = self.num_tuples();
+            self.sync_size_estimate(n);
         }
 
         Ok(RunReport::singleton(ruleset, iteration_report))
@@ -1287,12 +1285,13 @@ impl EGraph {
             }
             ResolvedNCommand::RunSchedule(sched, size_limit) => {
                 if let Some(limit) = size_limit {
-                    set_action_row_cap(limit);
-                    sync_size_estimate(self.num_tuples());
+                    self.set_size_cap(limit);
+                    let n = self.num_tuples();
+                    self.sync_size_estimate(n);
                 }
                 let result = self.run_schedule(&sched);
                 if size_limit.is_some() {
-                    set_action_row_cap(usize::MAX);
+                    self.set_size_cap(usize::MAX);
                 }
                 let report = result?;
                 log::info!("Ran schedule {sched}.");
@@ -1811,6 +1810,22 @@ impl EGraph {
             .values()
             .map(|f| self.backend.table_size(f.backend_id))
             .sum()
+    }
+
+    pub fn set_size_cap(&self, cap: usize) {
+        self.backend.set_size_cap(cap);
+    }
+
+    pub fn sync_size_estimate(&self, actual_size: usize) {
+        self.backend.sync_size_estimate(actual_size);
+    }
+
+    pub fn size_cap_active(&self) -> bool {
+        self.backend.size_cap_active()
+    }
+
+    pub fn size_cap_hit(&self) -> bool {
+        self.backend.size_cap_hit()
     }
 
     /// Returns a sort based on the type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,8 @@ use core::ResolvedAtomTerm;
 pub use core::{Atom, AtomTerm};
 pub use core::{ResolvedCall, SpecializedPrimitive};
 pub use core_relations::{
-    BaseValue, ContainerValue, ExecutionState, Value, set_action_row_cap, sync_size_estimate,
+    BaseValue, ContainerValue, ExecutionState, Value, set_action_row_cap, size_cap_active,
+    sync_size_estimate,
 };
 use core_relations::{ExternalFunctionId, make_external_func};
 use csv::Writer;
@@ -983,6 +984,10 @@ impl EGraph {
             .backend
             .run_rules(&rule_ids)
             .map_err(|e| Error::BackendError(e.to_string()))?;
+
+        if size_cap_active() {
+            sync_size_estimate(self.num_tuples());
+        }
 
         Ok(RunReport::singleton(ruleset, iteration_report))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub use core::{Atom, AtomTerm};
 pub use core::{ResolvedCall, SpecializedPrimitive};
 pub use core_relations::{
     BaseValue, ContainerValue, ExecutionState, Value, set_action_row_cap, size_cap_active,
-    sync_size_estimate,
+    size_cap_hit, sync_size_estimate,
 };
 use core_relations::{ExternalFunctionId, make_external_func};
 use csv::Writer;
@@ -897,7 +897,7 @@ impl EGraph {
                     let rec = self.run_schedule(sched)?;
                     let can_stop = rec.can_stop;
                     report.union(rec);
-                    if can_stop {
+                    if can_stop || size_cap_hit() {
                         break;
                     }
                 }
@@ -909,7 +909,7 @@ impl EGraph {
                     let rec = self.run_schedule(sched)?;
                     let updated = rec.updated;
                     report.union(rec);
-                    if !updated {
+                    if !updated || size_cap_hit() {
                         break;
                     }
                 }
@@ -919,6 +919,9 @@ impl EGraph {
                 let mut report = RunReport::default();
                 for sched in scheds {
                     report.union(self.run_schedule(sched)?);
+                    if size_cap_hit() {
+                        break;
+                    }
                 }
                 Ok(report)
             }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -153,13 +153,16 @@ pub fn add_ruleset(egraph: &mut EGraph, ruleset: &str) -> Result<Vec<CommandOutp
 
 /// Run one iteration of a ruleset.
 pub fn run_ruleset(egraph: &mut EGraph, ruleset: &str) -> Result<Vec<CommandOutput>, Error> {
-    egraph.run_program(vec![Command::RunSchedule(Schedule::Run(
-        span!(),
-        RunConfig {
-            ruleset: ruleset.to_owned(),
-            until: None,
-        },
-    ))])
+    egraph.run_program(vec![Command::RunSchedule(
+        Schedule::Run(
+            span!(),
+            RunConfig {
+                ruleset: ruleset.to_owned(),
+                until: None,
+            },
+        ),
+        None,
+    )])
 }
 
 #[macro_export]

--- a/src/proofs/proof_encoding.rs
+++ b/src/proofs/proof_encoding.rs
@@ -1196,8 +1196,11 @@ impl<'a> ProofInstrumentor<'a> {
                     self.parse_facts(&instrumented),
                 ));
             }
-            ResolvedNCommand::RunSchedule(schedule) => {
-                res.push(Command::RunSchedule(self.instrument_schedule(schedule)));
+            ResolvedNCommand::RunSchedule(schedule, size_limit) => {
+                res.push(Command::RunSchedule(
+                    self.instrument_schedule(schedule),
+                    *size_limit,
+                ));
             }
             ResolvedNCommand::Fail(span, cmd) => {
                 self.term_encode_command(cmd, res);
@@ -1217,7 +1220,7 @@ impl<'a> ProofInstrumentor<'a> {
                     res.extend(self.parse_program(&stmt));
                 }
                 // Rebuild before extract; we may have added new view rows that need canonicalization
-                res.push(Command::RunSchedule(self.rebuild()));
+                res.push(Command::RunSchedule(self.rebuild(), None));
                 res.push(Command::Extract(
                     span.clone(),
                     self.parse_expr(&instrumented_expr),
@@ -1281,7 +1284,7 @@ impl<'a> ProofInstrumentor<'a> {
             | ResolvedNCommand::Sort { .. } = &command
             {
             } else {
-                res.push(Command::RunSchedule(self.rebuild()));
+                res.push(Command::RunSchedule(self.rebuild(), None));
             }
         }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -457,10 +457,12 @@ mod test {
             );
 
             // Because of semi-naive, the exact rules that are run are more than just `test-rule`
-            assert!(report
-                .search_and_apply_time_per_rule
-                .keys()
-                .all(|k| k.starts_with("test-rule")));
+            assert!(
+                report
+                    .search_and_apply_time_per_rule
+                    .keys()
+                    .all(|k| k.starts_with("test-rule"))
+            );
             assert_eq!(
                 report.merge_time_per_ruleset.keys().collect::<Vec<_>>(),
                 [&"test".into()]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -252,6 +252,10 @@ impl EGraph {
             .run_rules(&action_rules)
             .map_err(|e| Error::BackendError(e.to_string()))?;
 
+        if crate::size_cap_active() {
+            crate::sync_size_estimate(self.num_tuples());
+        }
+
         // Step 5: combine the reports
         let mut query_report = RunReport::singleton(ruleset, query_iter_report);
         let mut action_report = RunReport::singleton(ruleset, action_iter_report);
@@ -452,12 +456,10 @@ mod test {
             );
 
             // Because of semi-naive, the exact rules that are run are more than just `test-rule`
-            assert!(
-                report
-                    .search_and_apply_time_per_rule
-                    .keys()
-                    .all(|k| k.starts_with("test-rule"))
-            );
+            assert!(report
+                .search_and_apply_time_per_rule
+                .keys()
+                .all(|k| k.starts_with("test-rule")));
             assert_eq!(
                 report.merge_time_per_ruleset.keys().collect::<Vec<_>>(),
                 [&"test".into()]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -252,8 +252,9 @@ impl EGraph {
             .run_rules(&action_rules)
             .map_err(|e| Error::BackendError(e.to_string()))?;
 
-        if crate::size_cap_active() {
-            crate::sync_size_estimate(self.num_tuples());
+        if self.size_cap_active() {
+            let n = self.num_tuples();
+            self.sync_size_estimate(n);
         }
 
         // Step 5: combine the reports

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -480,8 +480,9 @@ impl EGraph {
             NCommand::Fail(span, cmd) => {
                 ResolvedNCommand::Fail(span.clone(), Box::new(self.typecheck_command(cmd)?))
             }
-            NCommand::RunSchedule(schedule) => ResolvedNCommand::RunSchedule(
+            NCommand::RunSchedule(schedule, size_limit) => ResolvedNCommand::RunSchedule(
                 self.type_info.typecheck_schedule(symbol_gen, schedule)?,
+                *size_limit,
             ),
             NCommand::Pop(span, n) => ResolvedNCommand::Pop(span.clone(), *n),
             NCommand::Push(n) => ResolvedNCommand::Push(*n),

--- a/tests/size_cap.rs
+++ b/tests/size_cap.rs
@@ -1,0 +1,84 @@
+//! Tests for the e-graph size cap (`(run-schedule ... :size-limit N)`).
+//!
+//! The cap bounds *total* e-graph growth over a whole schedule. It is enforced
+//! against a running *estimate* of the size that is resynced to the true size
+//! after every iteration and bumped by an upper bound on inserted rows in
+//! between. Because the estimate is an upper bound, the true size can never run
+//! unboundedly past the cap; in the worst case it overshoots only by the rows
+//! already in flight across the parallel apply when the budget is spent.
+
+use egglog::*;
+
+/// The largest batch a single action buffer flushes at (`VAR_BATCH_SIZE` in
+/// `core-relations`). Batches near the cap are smaller, so this is an upper
+/// bound on the rows one in-flight batch can apply.
+const MAX_BATCH: usize = 128;
+
+/// An upper bound on how far the true size can overshoot the cap: at most one
+/// maximal batch per worker thread can be mid-apply when the cap trips, and each
+/// such row inserts at most `enodes_per_match` e-nodes. This is constant in the
+/// cap -- doubling the cap does not change it.
+fn overshoot_bound(enodes_per_match: usize) -> usize {
+    rayon::current_num_threads() * MAX_BATCH * enodes_per_match
+}
+
+/// Number of e-graph tuples after running a schedule that grows the relation `R`
+/// without bound, under the given size limit. `body` is the rule(s) that drive
+/// the growth.
+fn run_capped(cap: usize, body: &str) -> usize {
+    let mut egraph = EGraph::default();
+    let program = format!(
+        r#"
+        (relation R (i64))
+        (R 1)
+        (R 2)
+        (R 3)
+        (R 4)
+        (R 5)
+        {body}
+        (run-schedule (saturate (run)) :size-limit {cap})
+        "#
+    );
+    egraph.parse_and_run_program(None, &program).unwrap();
+    egraph.num_tuples()
+}
+
+/// Each match inserts two *distinct* new integers (a binary tree of values), so
+/// almost nothing the rule produces is a duplicate. Without a cap this relation
+/// grows without bound; the cap must stop it right around the limit.
+const FEW_DUPLICATES: &str = "(rule ((R x) (< x 1000000000)) ((R (* x 2)) (R (+ (* x 2) 1))))";
+
+/// Every pair of rows re-derives the single row `(R 0)`, so the rule fires a
+/// quadratic number of matches that almost all insert an already-present row.
+/// The second rule grows the relation slowly so the run never saturates. The
+/// estimate (applied rows) explodes while the true size grows slowly.
+const MANY_DUPLICATES: &str = r#"
+        (rule ((R x) (R y)) ((R 0)))
+        (rule ((R x) (< x 1000000000)) ((R (+ x 1))))
+        "#;
+
+#[test]
+fn few_duplicates_overshoot_is_constant_bounded() {
+    let bound = overshoot_bound(2);
+
+    for cap in [20_000usize, 100_000, 400_000] {
+        let size = run_capped(cap, FEW_DUPLICATES);
+        let overshoot = size - cap;
+        assert!(
+            overshoot <= bound,
+            "few-duplicates overshoot is not constant-bounded: size={size}, \
+             cap={cap}, overshoot={overshoot}, bound={bound}"
+        );
+    }
+}
+
+#[test]
+fn many_duplicates_stays_within_cap() {
+    for cap in [2_000usize, 20_000] {
+        let size = run_capped(cap, MANY_DUPLICATES);
+        assert!(
+            size <= cap,
+            "many-duplicates run exceeded the cap: size={size}, cap={cap}"
+        );
+    }
+}


### PR DESCRIPTION
- Add an optional `size-limit` tag to the `run-schedule` command.
- For the duration of the schedule, keeps track of an upper bound on how many enodes are added. When the estimated size reaches the limit, stops the schedule. Estimated size may be less than the actual egraph size after running the schedule, since matches may produce duplicate enodes.
- Updates the estimate after each iter to the actual size of the egraph after rebuild.
- Any matches found during the last iter but not applied will be lost and can't be recovered by seminaive.