### PR TITLE
[codex] Fix proof-mode macro type info

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2022,12 +2022,12 @@ impl EGraph {
                 .proof_state
                 .original_typechecking
                 .as_ref()
-                .map(|egraph| egraph.type_info.clone())
-                .unwrap_or_else(|| self.type_info.clone());
+                .map(|egraph| &egraph.type_info)
+                .unwrap_or(&self.type_info);
             let macro_expanded = self.command_macros.apply(
                 before_expanded_command,
                 &mut self.parser.symbol_gen,
-                &macro_type_info,
+                macro_type_info,
             )?;
 
             for command in macro_expanded {
@@ -2815,41 +2815,6 @@ mod tests {
                 (let b (vec-of 6 5 4 3 2 1))
                 (check (= (inner-product a b) 56))
             ",
-            )
-            .unwrap();
-    }
-
-    #[test]
-    fn proof_mode_allows_eq_sort_primitive_results_in_facts() {
-        let mut egraph = EGraph::default();
-        let validator =
-            |_: &mut TermDag, args: &[TermId]| -> Option<TermId> { args.first().copied() };
-        add_primitive_with_validator!(
-            &mut egraph,
-            "proof-id" = |x: #| -> # { x },
-            validator
-        );
-        let mut egraph = egraph.with_proofs_enabled();
-
-        egraph
-            .parse_and_run_program(
-                None,
-                r#"
-                (datatype Math
-                  (Done)
-                  (Num i64))
-                (relation Seed (Math))
-
-                (Seed (Num 1))
-
-                (rule ((Seed y)
-                       (= x (proof-id y)))
-                      ((Done))
-                      :name "use-proof-id")
-
-                (run 1)
-                (prove (Done))
-                "#,
             )
             .unwrap();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2018,10 +2018,16 @@ impl EGraph {
         for before_expanded_command in program {
             // First do user-provided macro expansion for this command,
             // which may rely on type information from previous commands.
+            let macro_type_info = self
+                .proof_state
+                .original_typechecking
+                .as_ref()
+                .map(|egraph| egraph.type_info.clone())
+                .unwrap_or_else(|| self.type_info.clone());
             let macro_expanded = self.command_macros.apply(
                 before_expanded_command,
                 &mut self.parser.symbol_gen,
-                &self.type_info,
+                &macro_type_info,
             )?;
 
             for command in macro_expanded {
@@ -2809,6 +2815,41 @@ mod tests {
                 (let b (vec-of 6 5 4 3 2 1))
                 (check (= (inner-product a b) 56))
             ",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn proof_mode_allows_eq_sort_primitive_results_in_facts() {
+        let mut egraph = EGraph::default();
+        let validator =
+            |_: &mut TermDag, args: &[TermId]| -> Option<TermId> { args.first().copied() };
+        add_primitive_with_validator!(
+            &mut egraph,
+            "proof-id" = |x: #| -> # { x },
+            validator
+        );
+        let mut egraph = egraph.with_proofs_enabled();
+
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+                (datatype Math
+                  (Done)
+                  (Num i64))
+                (relation Seed (Math))
+
+                (Seed (Num 1))
+
+                (rule ((Seed y)
+                       (= x (proof-id y)))
+                      ((Done))
+                      :name "use-proof-id")
+
+                (run 1)
+                (prove (Done))
+                "#,
             )
             .unwrap();
     }

--- a/src/proofs/proof_encoding.rs
+++ b/src/proofs/proof_encoding.rs
@@ -877,6 +877,11 @@ impl<'a> ProofInstrumentor<'a> {
                         (fv, proof)
                     }
                     ResolvedCall::Primitive(specialized_primitive) => {
+                        if specialized_primitive.output().is_eq_sort() {
+                            panic!(
+                                "Term encoding does not support eq-sort primitive expressions in facts"
+                            );
+                        }
                         let fv = self.fresh_var();
                         res.push(format!(
                             "(= {fv} ({} {}))",
@@ -884,15 +889,7 @@ impl<'a> ProofInstrumentor<'a> {
                             ListDisplay(new_args, " ")
                         ));
 
-                        let proof = if !self.proofs_enabled() {
-                            "()".to_string()
-                        } else if specialized_primitive.output().is_eq_sort() {
-                            let term_proof_name =
-                                self.term_proof_name(specialized_primitive.output().name());
-                            let fresh_proof = self.fresh_var();
-                            res.push(format!("(= {fresh_proof} ({term_proof_name} {fv}))"));
-                            fresh_proof
-                        } else {
+                        let proof = if self.proofs_enabled() {
                             let fiat_constructor = &self.proof_names().fiat_constructor;
                             let to_ast = self
                                 .proof_names()
@@ -900,6 +897,8 @@ impl<'a> ProofInstrumentor<'a> {
                                 .get(specialized_primitive.output().name())
                                 .unwrap();
                             format!("({fiat_constructor} ({to_ast} {fv}) ({to_ast} {fv}))")
+                        } else {
+                            "()".to_string()
                         };
 
                         (fv.clone(), proof)

--- a/src/proofs/proof_encoding.rs
+++ b/src/proofs/proof_encoding.rs
@@ -877,11 +877,6 @@ impl<'a> ProofInstrumentor<'a> {
                         (fv, proof)
                     }
                     ResolvedCall::Primitive(specialized_primitive) => {
-                        if specialized_primitive.output().is_eq_sort() {
-                            panic!(
-                                "Term encoding does not support eq-sort primitive expressions in facts"
-                            );
-                        }
                         let fv = self.fresh_var();
                         res.push(format!(
                             "(= {fv} ({} {}))",
@@ -889,7 +884,15 @@ impl<'a> ProofInstrumentor<'a> {
                             ListDisplay(new_args, " ")
                         ));
 
-                        let proof = if self.proofs_enabled() {
+                        let proof = if !self.proofs_enabled() {
+                            "()".to_string()
+                        } else if specialized_primitive.output().is_eq_sort() {
+                            let term_proof_name =
+                                self.term_proof_name(specialized_primitive.output().name());
+                            let fresh_proof = self.fresh_var();
+                            res.push(format!("(= {fresh_proof} ({term_proof_name} {fv}))"));
+                            fresh_proof
+                        } else {
                             let fiat_constructor = &self.proof_names().fiat_constructor;
                             let to_ast = self
                                 .proof_names()
@@ -897,8 +900,6 @@ impl<'a> ProofInstrumentor<'a> {
                                 .get(specialized_primitive.output().name())
                                 .unwrap();
                             format!("({fiat_constructor} ({to_ast} {fv}) ({to_ast} {fv}))")
-                        } else {
-                            "()".to_string()
                         };
 
                         (fv.clone(), proof)

--- a/tests/proof_mode_regression.rs
+++ b/tests/proof_mode_regression.rs
@@ -1,0 +1,48 @@
+use egglog::ast::Command;
+use egglog::util::SymbolGen;
+use egglog::*;
+use std::sync::{Arc, Mutex};
+
+struct RecordFunctionInputArity {
+    name: String,
+    seen: Arc<Mutex<Vec<usize>>>,
+}
+
+impl CommandMacro for RecordFunctionInputArity {
+    fn transform(
+        &self,
+        command: Command,
+        _symbol_gen: &mut SymbolGen,
+        type_info: &TypeInfo,
+    ) -> Result<Vec<Command>, Error> {
+        if let Some(func) = type_info.get_func_type(&self.name) {
+            self.seen.lock().unwrap().push(func.input.len());
+        }
+        Ok(vec![command])
+    }
+}
+
+#[test]
+fn proof_mode_command_macros_see_original_function_arities() {
+    let seen = Arc::new(Mutex::new(vec![]));
+    let mut egraph = EGraph::new_with_proofs();
+    egraph
+        .command_macros_mut()
+        .register(Arc::new(RecordFunctionInputArity {
+            name: "score".to_string(),
+            seen: seen.clone(),
+        }));
+
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+            (datatype Math (Num i64))
+            (function score (Math) i64 :merge old)
+            (let x (Num 1))
+            "#,
+        )
+        .unwrap();
+
+    assert_eq!(*seen.lock().unwrap(), vec![1]);
+}


### PR DESCRIPTION
## Summary

- make proof-mode command macro expansion read from the original pre-instrumentation type environment
- keep the type environment borrowed rather than cloning `TypeInfo` for every command
- add a regression test showing proof-mode macros see the original function arity

## Why

Proof mode rewrites functions during term/proof instrumentation. Command macros run before each command is processed and need the user-facing type information, not the instrumented proof helper arities.

The first implementation cloned `TypeInfo` for each command, and CodSpeed flagged broad slowdowns. This update keeps the same behavior but passes a borrowed `TypeInfo` reference.

## Validation

- cargo fmt --check
- cargo test --test proof_mode_regression --release
- cargo test -p egglog test_command_macros --release
- cargo test -p egglog proof_tests --release
- git diff --check
