### PR TITLE
nightly: install deps into a venv (fix PEP 668 install failure)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ flamegraph.svg
 perf.data*
 profile.json
 nightly/output/
+nightly/.venv/
 /*.json
 /*.txt
 

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,13 @@ all: test nits docs
 
 # Build egglog and benchmark every tests/*.egg file with hyperfine, writing an
 # HTML dashboard to nightly/output/ (matching `report=` in nightly-conf).
-# Run nightly on nightly.cs.washington.edu.
+# Run nightly on nightly.cs.washington.edu. Dependencies install into a venv so
+# this works on PEP 668 externally-managed systems; eval_live must be importable
+# by the script's interpreter, so run it with the venv's python.
 nightly:
-	pip install -q -r scripts/requirements.txt
-	python3 scripts/nightly_bench.py
+	python3 -m venv nightly/.venv
+	nightly/.venv/bin/pip install -q -r scripts/requirements.txt
+	nightly/.venv/bin/python scripts/nightly_bench.py
 
 test: doctest
 	cargo insta test --test-runner nextest --release --workspace  --unreferenced reject


### PR DESCRIPTION
## Problem

The [nightly run failed to install](https://nightly.cs.washington.edu/logs/2026-06-25-165056-935288-egglog-nightly.log) after #935 was ported to render its report with [eval-live](https://github.com/oflatt/eval-live):

```
pip install -q -r scripts/requirements.txt
error: externally-managed-environment
× This environment is externally managed
```

The `make nightly` target ran `pip install` against the system interpreter, which Python 3.12 on the Debian-based nightly server rejects under [PEP 668](https://peps.python.org/pep-0668/).

## Fix

Install the dependency into a local virtualenv (`nightly/.venv`) and run `nightly_bench.py` with that venv's `python`. The script does `import eval_live` in-process, so it must run under the interpreter the dependency was installed into.

```make
nightly:
	python3 -m venv nightly/.venv
	nightly/.venv/bin/pip install -q -r scripts/requirements.txt
	nightly/.venv/bin/python scripts/nightly_bench.py
```

`nightly/.venv/` is gitignored.

## Verification

On Python 3.12 (same as the nightly server), `python3 -m venv` + `pip install -r scripts/requirements.txt` into the venv succeeds and `import eval_live` resolves from the venv. (The server needs the `python3-venv` package, which provides `ensurepip` — standard on these machines.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)