### PR TITLE
[codex] Add root-directed proof extraction

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -134,24 +134,6 @@ pub struct Extractor<C: Cost + Ord + Eq + Clone + Debug> {
     parent_edge: HashMap<String, HashMap<Value, (String, Vec<Value>)>>,
 }
 
-/// Options for configuring extraction behavior.
-struct ExtractionOptions<C: Cost> {
-    /// The cost model to use for extraction.
-    cost_model: Box<dyn CostModel<C>>,
-    /// Root sorts to extract from. If None, all extractable root sorts are used.
-    rootsorts: Option<Vec<ArcSort>>,
-    /// Whether to respect the unextractable flag on constructors.
-    /// When true, constructors marked as unextractable will not be used during extraction.
-    respect_unextractable: bool,
-    /// Whether to skip view tables (those with term_constructor annotations).
-    /// When true, view tables are skipped, which is useful for proof extraction
-    /// where we need to extract from the original term tables with their original names.
-    skip_view_tables: bool,
-    /// Whether to respect the hidden flag on constructors.
-    /// When true, constructors marked as hidden will not be used during extraction.
-    respect_hidden: bool,
-}
-
 impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
     /// Bulk of the computation happens at initialization time.
     /// The later extractions only reuses saved results.
@@ -164,40 +146,23 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
         egraph: &EGraph,
         cost_model: impl CostModel<C> + 'static,
     ) -> Self {
-        // For user extraction: respect unextractable and hidden, but use view tables (they have better names)
-        Self::compute_costs_from_rootsorts_internal(
-            egraph,
-            ExtractionOptions {
-                cost_model: Box::new(cost_model),
-                rootsorts,
-                respect_unextractable: true,
-                skip_view_tables: false,
-                respect_hidden: true,
-            },
-        )
-    }
-
-    fn compute_costs_from_rootsorts_internal(
-        egraph: &EGraph,
-        options: ExtractionOptions<C>,
-    ) -> Self {
         // We filter out tables unreachable from the root sorts
-        let extract_all_sorts = options.rootsorts.is_none();
+        let extract_all_sorts = rootsorts.is_none();
 
-        let mut rootsorts = options.rootsorts.unwrap_or_default();
+        let mut rootsorts = rootsorts.unwrap_or_default();
 
         // Built a reverse index from output sort to function head symbols
-        // Only include constructors (not regular functions) and respect unextractable flag
+        // Only include constructors (not regular functions), and respect the user-facing
+        // hidden and unextractable flags.
         let mut rev_index: HashMap<String, Vec<String>> = Default::default();
         for func in egraph.functions.iter() {
-            let unextractable = func.1.decl.unextractable && options.respect_unextractable;
-            let should_skip_view =
-                options.skip_view_tables && func.1.decl.term_constructor.is_some();
-            let hidden = func.1.decl.internal_hidden && options.respect_hidden;
+            let unextractable = func.1.decl.unextractable;
+            let hidden = func.1.decl.internal_hidden;
 
-            // only extract constructors (and functions with term_constructor), skip view tables when requested for proof extraction, and respect unextractable/hidden flag
+            // Only extract constructors and view tables, which reconstruct as their
+            // term_constructor. Proof extraction uses its own root-directed extractor
+            // and does not need alternate behavior here.
             if !unextractable
-                && !should_skip_view
                 && !hidden
                 && (func.1.decl.subtype == FunctionSubtype::Constructor
                     || func.1.decl.term_constructor.is_some())
@@ -277,7 +242,7 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
         let mut extractor = Extractor {
             rootsorts,
             funcs,
-            cost_model: options.cost_model,
+            cost_model: Box::new(cost_model),
             costs,
             topo_rnk_cnt: 0,
             topo_rnk,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -177,28 +177,6 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
         )
     }
 
-    /// Like `compute_costs_from_rootsorts`, but ignores the unextractable and hidden flags.
-    /// This is used for proof extraction where we need to extract proofs even
-    /// from terms that are marked unextractable (like global let bindings).
-    /// Also skips view tables (those with term_constructor) since proofs need
-    /// to extract from the original term tables with their original names.
-    pub(crate) fn compute_costs_from_rootsorts_allow_unextractable(
-        rootsorts: Option<Vec<ArcSort>>,
-        egraph: &EGraph,
-        cost_model: impl CostModel<C> + 'static,
-    ) -> Self {
-        Self::compute_costs_from_rootsorts_internal(
-            egraph,
-            ExtractionOptions {
-                cost_model: Box::new(cost_model),
-                rootsorts,
-                respect_unextractable: false,
-                skip_view_tables: true,
-                respect_hidden: false,
-            },
-        )
-    }
-
     fn compute_costs_from_rootsorts_internal(
         egraph: &EGraph,
         options: ExtractionOptions<C>,

--- a/src/proofs/mod.rs
+++ b/src/proofs/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod proof_checker;
 pub(crate) mod proof_encoding;
 pub(crate) mod proof_encoding_helpers;
 pub(crate) mod proof_extraction;
+pub(crate) mod proof_extractor;
 pub(crate) mod proof_format;
 pub(crate) mod proof_normal_form;
 pub(crate) mod proof_simplification;

--- a/src/proofs/proof_extraction.rs
+++ b/src/proofs/proof_extraction.rs
@@ -1,6 +1,6 @@
 use crate::ast::FunctionSubtype;
-use crate::extract::{Extractor, TreeAdditiveCostModel};
 use crate::proofs::proof_encoding::ProofInstrumentor;
+use crate::proofs::proof_extractor::extract_root;
 use crate::proofs::proof_format::{Justification, ProofId, ProofStore, proof_store_from_term};
 use crate::{RawValues, Read, ResolvedCall, TermDag};
 use thiserror::Error;
@@ -40,14 +40,6 @@ impl ProofInstrumentor<'_> {
 
         let backend_id = function.backend_id;
         let output_sort = function.schema.output.clone();
-
-        // Use the version that ignores unextractable flag since proof extraction
-        // needs to extract proofs from all terms including those marked unextractable
-        let extractor = Extractor::compute_costs_from_rootsorts_allow_unextractable(
-            None,
-            self.egraph,
-            TreeAdditiveCostModel::default(),
-        );
 
         let mut termdag = TermDag::default();
         let mut witness_value = None;
@@ -97,8 +89,7 @@ impl ProofInstrumentor<'_> {
             .unwrap()
             .unwrap_or_else(|| panic!("no proof recorded for constructor {}", func.name));
 
-        let (_, proof_term_id) = extractor
-            .extract_best_with_sort(self.egraph, &mut termdag, proof_value, proof_sort)
+        let proof_term_id = extract_root(self.egraph, &mut termdag, proof_value, proof_sort)
             .unwrap_or_else(|| {
                 panic!("failed to extract proof term for constructor {}", func.name)
             });

--- a/src/proofs/proof_extractor.rs
+++ b/src/proofs/proof_extractor.rs
@@ -1,0 +1,206 @@
+use crate::ast::FunctionSubtype;
+use crate::termdag::{TermDag, TermId};
+use crate::util::{HashMap, HashSet};
+use crate::{ArcSort, EGraph, Value};
+
+/// Root-directed extraction for proof terms.
+///
+/// Unlike the public extractor, this does not compute globally optimal costs
+/// for the whole e-graph. It searches for any reconstructable term for the
+/// requested root, ignoring `:unextractable` and hidden constructor flags, and
+/// skips view tables so proof terms use their original constructor names.
+struct RootExtractor {
+    cache: HashMap<(Value, String), Option<TermId>>,
+    active: HashSet<(Value, String)>,
+}
+
+impl RootExtractor {
+    fn new() -> Self {
+        Self {
+            cache: Default::default(),
+            active: Default::default(),
+        }
+    }
+
+    fn extract(
+        &mut self,
+        egraph: &EGraph,
+        termdag: &mut TermDag,
+        value: Value,
+        sort: &ArcSort,
+    ) -> Option<TermId> {
+        let key = (value, sort.name().to_owned());
+        if let Some(term) = self.cache.get(&key) {
+            return *term;
+        }
+        if !self.active.insert(key.clone()) {
+            return None;
+        }
+
+        let mut term = self.extract_exact(egraph, termdag, value, sort);
+        if term.is_none() {
+            let canonical = find_canonical(egraph, value, sort);
+            if canonical != value {
+                term = self.extract(egraph, termdag, canonical, sort);
+            }
+        }
+
+        self.active.remove(&key);
+        self.cache.insert(key, term);
+        term
+    }
+
+    fn extract_exact(
+        &mut self,
+        egraph: &EGraph,
+        termdag: &mut TermDag,
+        value: Value,
+        sort: &ArcSort,
+    ) -> Option<TermId> {
+        if sort.is_container_sort() {
+            self.extract_container(egraph, termdag, value, sort)
+        } else if sort.is_eq_sort() {
+            self.extract_eq(egraph, termdag, value, sort)
+        } else {
+            Some(sort.reconstruct_termdag_base(egraph.backend.base_values(), value, termdag))
+        }
+    }
+
+    fn extract_container(
+        &mut self,
+        egraph: &EGraph,
+        termdag: &mut TermDag,
+        value: Value,
+        sort: &ArcSort,
+    ) -> Option<TermId> {
+        let elements = sort.inner_values(egraph.backend.container_values(), value);
+        let mut ch_terms = Vec::with_capacity(elements.len());
+        for (sort, value) in elements {
+            ch_terms.push(self.extract(egraph, termdag, value, &sort)?);
+        }
+        Some(sort.reconstruct_termdag_container(
+            egraph.backend.container_values(),
+            value,
+            termdag,
+            ch_terms,
+        ))
+    }
+
+    fn extract_eq(
+        &mut self,
+        egraph: &EGraph,
+        termdag: &mut TermDag,
+        value: Value,
+        sort: &ArcSort,
+    ) -> Option<TermId> {
+        for func in egraph.functions.values() {
+            if func.decl.subtype != FunctionSubtype::Constructor
+                || func.extraction_output_sort().name() != sort.name()
+                || func.decl.term_constructor.is_some()
+            {
+                continue;
+            }
+
+            let output_idx = func.extraction_output_index();
+            let mut matching_rows = Vec::new();
+            egraph
+                .backend
+                .for_each(func.backend_id, |row: egglog_bridge::ScanEntry| {
+                    if !row.subsumed && row.vals[output_idx] == value {
+                        matching_rows.push(row.vals.to_vec());
+                    }
+                });
+
+            for row in matching_rows {
+                let num_children = func.extraction_num_children();
+                let mut ch_terms = Vec::with_capacity(num_children);
+                let mut valid = true;
+                for (value, sort) in row.iter().take(num_children).zip(func.schema.input.iter()) {
+                    match self.extract(egraph, termdag, *value, sort) {
+                        Some(term) => ch_terms.push(term),
+                        None => {
+                            valid = false;
+                            break;
+                        }
+                    }
+                }
+
+                if valid {
+                    return Some(termdag.app(func.extraction_term_name().to_string(), ch_terms));
+                }
+            }
+        }
+
+        None
+    }
+}
+
+pub(crate) fn extract_root(
+    egraph: &EGraph,
+    termdag: &mut TermDag,
+    value: Value,
+    sort: ArcSort,
+) -> Option<TermId> {
+    RootExtractor::new().extract(egraph, termdag, value, &sort)
+}
+
+fn find_canonical(egraph: &EGraph, value: Value, sort: &ArcSort) -> Value {
+    let Some(uf_name) = egraph.proof_state.uf_parent.get(sort.name()) else {
+        return value;
+    };
+
+    let Some(uf_func) = egraph.functions.get(uf_name) else {
+        return value;
+    };
+
+    let mut canonical = value;
+    egraph
+        .backend
+        .for_each(uf_func.backend_id, |row: egglog_bridge::ScanEntry| {
+            // UF table has (child, parent) as inputs.
+            if row.vals[0] == value {
+                canonical = row.vals[1];
+            }
+        });
+    canonical
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_direct_constructor_root() {
+        let mut egraph = EGraph::default();
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+                (sort Expr)
+                (constructor Target () Expr)
+                (Target)
+                "#,
+            )
+            .unwrap();
+
+        let target_func = egraph.functions.get("Target").unwrap();
+        let mut target_value = None;
+        egraph
+            .backend
+            .for_each_while(target_func.backend_id, |row| {
+                target_value = Some(row.vals[target_func.extraction_output_index()]);
+                false
+            });
+
+        let mut termdag = TermDag::default();
+        let term = extract_root(
+            &egraph,
+            &mut termdag,
+            target_value.unwrap(),
+            egraph.get_sort_by_name("Expr").unwrap().clone(),
+        )
+        .unwrap();
+
+        assert_eq!(termdag.to_string(term), "(Target)");
+    }
+}

--- a/src/proofs/proof_extractor.rs
+++ b/src/proofs/proof_extractor.rs
@@ -157,6 +157,9 @@ fn find_canonical(egraph: &EGraph, value: Value, sort: &ArcSort) -> Value {
     egraph
         .backend
         .for_each(uf_func.backend_id, |row: egglog_bridge::ScanEntry| {
+            // The generated UF parent table is a normal custom function with
+            // can_subsume=false, so there are no subsumed UF rows to filter.
+            // This matches the public extractor's one-hop canonical scan.
             // UF table has (child, parent) as inputs.
             if row.vals[0] == value {
                 canonical = row.vals[1];
@@ -168,6 +171,38 @@ fn find_canonical(egraph: &EGraph, value: Value, sort: &ArcSort) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn first_output(egraph: &EGraph, function_name: &str) -> Value {
+        let func = egraph.functions.get(function_name).unwrap();
+        let mut value = None;
+        egraph.backend.for_each_while(func.backend_id, |row| {
+            value = Some(row.vals[func.extraction_output_index()]);
+            false
+        });
+        value.unwrap()
+    }
+
+    fn first_input(egraph: &EGraph, function_name: &str, input: usize) -> Value {
+        let func = egraph.functions.get(function_name).unwrap();
+        let mut value = None;
+        egraph.backend.for_each_while(func.backend_id, |row| {
+            value = Some(row.vals[input]);
+            false
+        });
+        value.unwrap()
+    }
+
+    fn extract_to_string(egraph: &EGraph, value: Value, sort_name: &str) -> String {
+        let mut termdag = TermDag::default();
+        let term = extract_root(
+            egraph,
+            &mut termdag,
+            value,
+            egraph.get_sort_by_name(sort_name).unwrap().clone(),
+        )
+        .unwrap();
+        termdag.to_string(term)
+    }
 
     #[test]
     fn extracts_direct_constructor_root() {
@@ -183,24 +218,80 @@ mod tests {
             )
             .unwrap();
 
-        let target_func = egraph.functions.get("Target").unwrap();
-        let mut target_value = None;
+        assert_eq!(
+            extract_to_string(&egraph, first_output(&egraph, "Target"), "Expr"),
+            "(Target)"
+        );
+    }
+
+    #[test]
+    fn canonicalizes_when_exact_root_is_subsumed() {
+        let mut egraph = EGraph::default();
         egraph
-            .backend
-            .for_each_while(target_func.backend_id, |row| {
-                target_value = Some(row.vals[target_func.extraction_output_index()]);
-                false
-            });
+            .parse_and_run_program(
+                None,
+                r#"
+                (sort Expr :internal-uf UF_Expr)
+                (function UF_Expr (Expr Expr) Unit :merge old :internal-hidden)
+                (constructor Alias () Expr)
+                (constructor Target () Expr)
 
+                (let $alias (Alias))
+                (let $target (Target))
+                (set (UF_Expr $alias $target) ())
+                (subsume (Alias))
+                "#,
+            )
+            .unwrap();
+
+        assert_eq!(
+            extract_to_string(&egraph, first_output(&egraph, "Alias"), "Expr"),
+            "(Target)"
+        );
+    }
+
+    #[test]
+    fn extracts_container_root() {
+        let mut egraph = EGraph::default();
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+                (sort Expr)
+                (sort ExprPair (Pair Expr Expr))
+                (constructor Leaf () Expr)
+                (constructor Box (ExprPair) Expr)
+                (Box (pair (Leaf) (Leaf)))
+                "#,
+            )
+            .unwrap();
+
+        assert_eq!(
+            extract_to_string(&egraph, first_input(&egraph, "Box", 0), "ExprPair"),
+            "(pair (Leaf) (Leaf))"
+        );
+    }
+
+    #[test]
+    fn active_roots_break_cycles() {
+        let mut egraph = EGraph::default();
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+                (sort Expr)
+                (constructor Target () Expr)
+                (Target)
+                "#,
+            )
+            .unwrap();
+
+        let value = first_output(&egraph, "Target");
+        let sort = egraph.get_sort_by_name("Expr").unwrap().clone();
+        let mut extractor = RootExtractor::new();
         let mut termdag = TermDag::default();
-        let term = extract_root(
-            &egraph,
-            &mut termdag,
-            target_value.unwrap(),
-            egraph.get_sort_by_name("Expr").unwrap().clone(),
-        )
-        .unwrap();
+        extractor.active.insert((value, sort.name().to_owned()));
 
-        assert_eq!(termdag.to_string(term), "(Target)");
+        assert_eq!(extractor.extract(&egraph, &mut termdag, value, &sort), None);
     }
 }


### PR DESCRIPTION
## Summary

This changes proof-mode `prove_exists` to extract only the requested proof root instead of computing extraction costs for the whole e-graph. The new extractor is private to `src/proofs/` and returns any reconstructable proof term for the requested `(Value, Sort)` root.

The previous path used `Extractor::compute_costs_from_rootsorts_allow_unextractable(None, ...)`, which can spend time on unrelated proof terms before proof checking even starts. For proof existence checks we only need one proof term for the recorded proof value.

## Notes

- Moves the proof-specific extraction behavior into `src/proofs/proof_extractor.rs`.
- Removes the proof-only `compute_costs_from_rootsorts_allow_unextractable` helper from the public extraction module.
- Keeps the extractor private and adds only a minimal direct-constructor root test.

## Validation

```sh
cargo test --release --lib extracts_direct_constructor_root -- --nocapture
cargo test --release --lib proof_mode_allows -- --nocapture
cargo test --release --test files primitive_args -- --nocapture
cargo test --release --test files eqsat_basic_proof -- --nocapture
cargo fmt --check
git diff --check
```