### PR TITLE
nightly: prefer the rustup cargo shim over the system cargo

### DIFF
--- a/scripts/nightly_bench.py
+++ b/scripts/nightly_bench.py
@@ -265,6 +265,18 @@ def measure_cell(path: Path, threads: int, proof: bool,
 # ── main sweep ──────────────────────────────────────────────────────────────────
 
 
+def ensure_rustup_on_path() -> None:
+    """Put the rustup shim dir (~/.cargo/bin) first on PATH.
+
+    The nightly host has a system `cargo` ahead of the rustup shim; it is too
+    old for this crate's 2024 edition and ignores rust-toolchain.toml. The shim
+    reads rust-toolchain.toml and installs/uses the pinned toolchain on demand.
+    hyperfine and other cargo-installed tools live here too."""
+    cargo_bin = str(Path.home() / ".cargo" / "bin")
+    parts = [p for p in os.environ.get("PATH", "").split(os.pathsep) if p != cargo_bin]
+    os.environ["PATH"] = os.pathsep.join([cargo_bin, *parts])
+
+
 def build() -> None:
     log("Building egglog (release)...")
     subprocess.run(
@@ -426,6 +438,7 @@ def render_html(rows: list[dict], skipped: list[dict], meta: dict) -> str:
 
 
 def main() -> int:
+    ensure_rustup_on_path()
     if not shutil.which("hyperfine"):
         sys.exit("hyperfine not found — install with: cargo install hyperfine")
     # Fail fast: the report uses eval-live, but it is only needed at the very


### PR DESCRIPTION
Follow-up to #939. That PR fixed the `pip install` (PEP 668) failure, but its second commit — the toolchain fix — didn't make it into the squash-merge (the merge raced with the push), so the nightly still builds with the wrong cargo.

## Problem

The [next run](https://nightly.cs.washington.edu/logs/2026-06-29-103123-679783-egglog-nightly.log) failed at the build step:

```
cargo build --release --bin egglog --manifest-path .../Cargo.toml
error: feature `edition2024` is required ... not stabilized in this version of Cargo (1.75.0)
```

The crate is `edition = "2024"` and `rust-toolchain.toml` pins `1.91.0`, but the nightly host's `PATH` puts a system cargo (1.75.0, apt) ahead of the rustup shim. Toolchain-file overrides are a *rustup* feature — the system cargo ignores `rust-toolchain.toml` and tries to build with 1.75.0.

## Fix

Prepend `~/.cargo/bin` to `PATH` at the start of `nightly_bench.py` so the rustup shim wins. The shim reads `rust-toolchain.toml` and auto-installs/uses 1.91.0; `hyperfine` lives there too. This mirrors what [eggcc's nightly](https://github.com/egraphs-good/eggcc/blob/main/infra/nightly.py) does (it sets up `~/.cargo/bin` on `PATH` before any cargo/rustup call). The dir is always moved to the front, so it works even when it's already on `PATH` but after the system cargo — the server's situation.

## Verification

On a box with the same setup (system `PATH` lacks `~/.cargo/bin`): with the prepend, `cargo --version` in-repo resolves to `1.91.0` via the shim; without it, the system cargo wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)