### PR TITLE
Patch canonicalized rows in place in the rebuild output buffer

### DIFF
--- a/core-relations/src/hash_index/mod.rs
+++ b/core-relations/src/hash_index/mod.rs
@@ -435,7 +435,21 @@ pub(crate) fn radix_sort_slice_by_value(
         return;
     }
 
-    let max_val = data.iter().map(|&(v, _)| v.rep()).max().unwrap_or(0);
+    // One scan computes the pass count and detects already-sorted input (common
+    // when a column correlates with row order); a sorted block needs no work,
+    // since stability makes the result identical.
+    let mut max_val = 0u32;
+    let mut sorted = true;
+    let mut prev = 0u32;
+    for &(v, _) in data.iter() {
+        let rep = v.rep();
+        max_val = max_val.max(rep);
+        sorted &= prev <= rep;
+        prev = rep;
+    }
+    if sorted {
+        return;
+    }
     let n_passes = radix_passes_for(max_val);
 
     let mut src: &mut [(Value, RowId)] = data;

--- a/core-relations/src/row_buffer/mod.rs
+++ b/core-relations/src/row_buffer/mod.rs
@@ -444,6 +444,38 @@ impl<V: ValueVec> TaggedRowBuffer<V> {
         res
     }
 
+    /// Add the given row and RowId to the buffer, then let `patch` edit the
+    /// copied row in place. Equivalent to copying `row` into a scratch
+    /// buffer, editing it, and calling [`TaggedRowBuffer::add_row`], without
+    /// the intermediate copy.
+    #[inline]
+    pub fn add_row_with(
+        &mut self,
+        row_id: RowId,
+        row: &[Value],
+        patch: impl FnOnce(&mut [Value]),
+    ) -> RowId {
+        debug_assert_eq!(
+            row.len(),
+            self.base_arity(),
+            "attempting to add a row with mismatched arity to table"
+        );
+        if self.inner.total_rows == 0 {
+            self.inner.data.refresh();
+        }
+        let res = RowId::from_usize(self.inner.total_rows);
+        self.inner.data.extend_from_values(row);
+        self.inner.data.push(Cell::new(Value::new(row_id.rep())));
+        self.inner.total_rows += 1;
+        let vals = self.inner.data.as_values_mut();
+        let end = vals.len() - 1;
+        let dst = &mut vals[end - row.len()..end];
+        // SAFETY: see the comment in `RowBuffer::non_stale`; this is the same
+        // Cell-to-Value transmute used by `get_row_mut`.
+        patch(unsafe { mem::transmute::<&mut [Cell<Value>], &mut [Value]>(dst) });
+        res
+    }
+
     /// Get the row (and the id it was associated with at insertion time) at the
     /// offset associated with `row`.
     pub fn get_row(&self, row: RowId) -> (RowId, &[Value]) {

--- a/core-relations/src/uf/mod.rs
+++ b/core-relations/src/uf/mod.rs
@@ -8,6 +8,7 @@ use std::{
 
 use crate::numeric_id::{DenseIdMap, NumericId};
 use crossbeam_queue::SegQueue;
+use smallvec::SmallVec;
 
 use crate::{
     TableChange, TaggedRowBuffer,
@@ -88,7 +89,6 @@ impl Rebuilder for Canonicalizer<'_> {
         }
         assert!(end.index() <= buf.len());
         let mut cur = start;
-        let mut scratch = with_pool_set(|ps| ps.get::<Vec<Value>>());
         // SAFETY: `cur` is always in-bounds, guaranteed by the above assertion.
         // Special-case small columns: this gives us a modest speedup on rebuilding-heavy
         // workloads.
@@ -99,10 +99,7 @@ impl Rebuilder for Canonicalizer<'_> {
                     let to_canon = row[c.index()];
                     let canon = self.table.uf.find_naive(to_canon);
                     if canon != to_canon {
-                        scratch.extend_from_slice(row);
-                        scratch[c.index()] = canon;
-                        out.add_row(cur, &scratch);
-                        scratch.clear();
+                        out.add_row_with(cur, row, |dst| dst[c.index()] = canon);
                     }
                     cur = cur.inc();
                 }
@@ -115,11 +112,10 @@ impl Rebuilder for Canonicalizer<'_> {
                     let ca1 = self.table.uf.find_naive(v1);
                     let ca2 = self.table.uf.find_naive(v2);
                     if ca1 != v1 || ca2 != v2 {
-                        scratch.extend_from_slice(row);
-                        scratch[c1.index()] = ca1;
-                        scratch[c2.index()] = ca2;
-                        out.add_row(cur, &scratch);
-                        scratch.clear();
+                        out.add_row_with(cur, row, |dst| {
+                            dst[c1.index()] = ca1;
+                            dst[c2.index()] = ca2;
+                        });
                     }
                     cur = cur.inc();
                 }
@@ -134,30 +130,34 @@ impl Rebuilder for Canonicalizer<'_> {
                     let ca2 = self.table.uf.find_naive(v2);
                     let ca3 = self.table.uf.find_naive(v3);
                     if ca1 != v1 || ca2 != v2 || ca3 != v3 {
-                        scratch.extend_from_slice(row);
-                        scratch[c1.index()] = ca1;
-                        scratch[c2.index()] = ca2;
-                        scratch[c3.index()] = ca3;
-                        out.add_row(cur, &scratch);
-                        scratch.clear();
+                        out.add_row_with(cur, row, |dst| {
+                            dst[c1.index()] = ca1;
+                            dst[c2.index()] = ca2;
+                            dst[c3.index()] = ca3;
+                        });
                     }
                     cur = cur.inc();
                 }
             }
             cs => {
+                let mut canons: SmallVec<[Value; 8]> = SmallVec::with_capacity(cs.len());
                 while cur < end {
-                    scratch.extend_from_slice(unsafe { buf.get_row_unchecked(cur) });
+                    let row = unsafe { buf.get_row_unchecked(cur) };
+                    canons.clear();
                     let mut changed = false;
                     for c in cs {
-                        let to_canon = scratch[c.index()];
+                        let to_canon = row[c.index()];
                         let canon = self.table.uf.find_naive(to_canon);
-                        scratch[c.index()] = canon;
                         changed |= canon != to_canon;
+                        canons.push(canon);
                     }
                     if changed {
-                        out.add_row(cur, &scratch);
+                        out.add_row_with(cur, row, |dst| {
+                            for (c, canon) in cs.iter().zip(canons.iter()) {
+                                dst[c.index()] = *canon;
+                            }
+                        });
                     }
-                    scratch.clear();
                     cur = cur.inc();
                 }
             }


### PR DESCRIPTION
Canonicalizer::rebuild_buf copied every changed row into a pooled scratch vector, patched it there, and copied it again into the output TaggedRowBuffer. Add TaggedRowBuffer::add_row_with, which appends the original row and lets the caller patch the copy in place, and use it to drop the scratch buffer entirely (-4.7% instructions on eggcc-2mm).

Added another micro-optimization that doesn't radix sort an index if it's already sorted.