### PR TITLE
Fix spurious `slice is not sorted` assert in `Subset::intersect` (#971)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - Report full source file paths in egglog span and error messages.
 - Fix seminaive matching after nested containers rebuild in place by propagating dirty container ids through parent containers.
 - Fix multi-column secondary index rebuilds so each value's rows come back sorted by row id, and make all rebuild paths (serial, parallel, and bulk) record a row once even when its value repeats across covered columns (#914).
-- Fix a spurious `slice is not sorted` debug assertion in `Subset::intersect` when galloping through a sparse subset that is being compacted in place, which panicked debug builds on some sparse/sparse intersections (#971).
 - Render nullary AST calls without a trailing space, e.g. (foo) instead of (foo ).
 - Escape `"` and `\` when displaying string literals so printed/serialized programs round-trip through the parser.
 - Add a BigRat to-i64 primitive for integral rationals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Report full source file paths in egglog span and error messages.
 - Fix seminaive matching after nested containers rebuild in place by propagating dirty container ids through parent containers.
 - Fix multi-column secondary index rebuilds so each value's rows come back sorted by row id, and make all rebuild paths (serial, parallel, and bulk) record a row once even when its value repeats across covered columns (#914).
+- Fix a spurious `slice is not sorted` debug assertion in `Subset::intersect` when galloping through a sparse subset that is being compacted in place, which panicked debug builds on some sparse/sparse intersections (#971).
 - Render nullary AST calls without a trailing space, e.g. (foo) instead of (foo ).
 - Escape `"` and `\` when displaying string literals so printed/serialized programs round-trip through the parser.
 - Add a BigRat to-i64 primitive for integral rationals.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,4 +18,4 @@ When you edit the files, make sure to respect the following:
 - When running tests, always use the `--release` mode. Alternatively, you can also run `make test`.
 - If your change is performance-critical, use `script/bench.py` as the ground truth to evaluate the performance impact.
 - Keep your documentation concise and avoid duplicate information. The `tidy-diff-docs` skill (`.claude/skills/tidy-diff-docs/`) cleans the doc and code comments in a diff down to the caller-facing contract.
-- Update CHANGELOG.md with a concise bullet when you make major changes (e.g., breaking changes or new features added) in the codebase.
+- Update CHANGELOG.md with a concise bullet when you make major changes (e.g., breaking changes or new features added) in the codebase. Don't update CHANGELOG.md if it's just a bug fix or if it's not a user-facing change. However, major performance improvements (e.g., using a new join algorithm or introducing a new sort of indices) should be documented.

--- a/core-relations/src/offsets/mod.rs
+++ b/core-relations/src/offsets/mod.rs
@@ -468,6 +468,12 @@ impl Subset {
                 } else if cur_len > other_len {
                     // other is much smaller: iterate other and gallop in cur.
                     // O(other_len * log(cur_len / other_len)) vs O(cur_len) for retain.
+                    // NB: the result is compacted into `cur` in place, so `cur` as a
+                    // whole is transiently unsorted while the loop runs. `write` only
+                    // ever advances to `ci` (a match at `found >= ci` writes to
+                    // `write <= found` and then sets `ci = found + 1`), so the
+                    // *suffix* `cur.0[ci..]` is always untouched, and searching it is
+                    // equivalent to searching all of `cur` from `ci`.
                     let mut write = 0usize;
                     let mut ci = 0usize;
                     #[allow(clippy::needless_range_loop)]
@@ -476,15 +482,19 @@ impl Subset {
                             break;
                         }
                         let target = other_inner[oi];
-                        let result = cur.slice().scan_for_offset(ci, target);
+                        debug_assert!(write <= ci);
+                        // SAFETY: `cur.0[ci..]` is an unmodified suffix of the
+                        // original sorted vector, per the note above.
+                        let suffix = unsafe { SortedOffsetSlice::new_unchecked(&cur.0[ci..]) };
+                        let result = suffix.scan_for_offset(0, target);
                         match result {
                             Ok(found) => {
                                 cur.0[write] = target;
                                 write += 1;
-                                ci = found + 1;
+                                ci += found + 1;
                             }
                             Err(next_ci) => {
-                                ci = next_ci;
+                                ci += next_ci;
                             }
                         }
                     }

--- a/core-relations/src/offsets/tests.rs
+++ b/core-relations/src/offsets/tests.rs
@@ -73,6 +73,10 @@ fn intersect() {
         Vec::from_iter(0..5),
         Vec::from_iter(0..100), // 20x skew → galloping path
         Vec::from_iter((0..100).filter(|x| x % 7 == 0)),
+        // Both sides Sparse (i.e. non-contiguous) with >4x skew: galloping in
+        // `cur` while compacting it in place.
+        Vec::from_iter((0..6).chain(11..22)),
+        vec![13, 20, 21],
     ];
     let all_elts: Vec<&Vec<usize>> = elts.iter().chain(skewed.iter()).collect();
 
@@ -132,4 +136,32 @@ fn iter_bounded() {
     );
     let expected = Vec::from_iter((2..12).map(|x| RowId::new(x * 2)));
     assert_eq!(got, expected);
+}
+
+#[test]
+fn intersect_sparse_sparse_skewed() {
+    // Regression test for #971. `cur` must be Sparse and >4x longer than
+    // `other` (which must also be Sparse) to reach the "gallop in cur" branch
+    // of `Subset::intersect`.
+    let cur_rows: Vec<usize> = (0..6).chain(11..22).collect();
+    let other_rows: Vec<usize> = vec![13, 20, 21];
+
+    let mut cur = Subset::empty();
+    for row in &cur_rows {
+        cur.add_row_sorted(o(*row));
+    }
+    let mut other = Subset::empty();
+    for row in &other_rows {
+        other.add_row_sorted(o(*row));
+    }
+    assert!(matches!(cur, Subset::Sparse(..)));
+    assert!(matches!(other, Subset::Sparse(..)));
+
+    cur.intersect(
+        other.as_ref(),
+        &with_pool_set(|pool_set| pool_set.get_pool()),
+    );
+    let mut got = Vec::new();
+    cur.offsets(|row| got.push(row.index()));
+    assert_eq!(got, other_rows);
 }


### PR DESCRIPTION
Fixes #971.

## Problem

`Subset::intersect`'s `(Sparse, Sparse)` "other is much smaller: iterate other and gallop in cur" branch compacts the intersection **into `cur` in place**, but re-derived a `SortedOffsetSlice` over the *whole* vector on every iteration:

```rust
let result = cur.slice().scan_for_offset(ci, target);   // asserts all of cur is sorted
match result {
    Ok(found) => { cur.0[write] = target; write += 1; ci = found + 1; }
```

Once the first match is written to `cur.0[write]`, the region between `write` and `ci` still holds stale originals, so `cur` as a whole is transiently unsorted and `slice()`'s `debug_assert!` fires on the *next* iteration.

That is exactly the panic in #971. `cur` was `[0,1,2,3,4,5,11..=21]` (17 rows) and the first match was `RowId(13)`, written over index 0:

```
[RowId(13), RowId(1), ..., RowId(5), RowId(11), RowId(12), RowId(13), ..., RowId(21)]
 ^^^^^^^^^ written result   ^^^^^^^^^^^^^^^^^^ untouched original tail
```

Despite the identical assertion message, this is a **different bug from #911/#914** — that one was in `hash_index`; this one is in `offsets`, reached via `Database::process_constraints`.

## This was only the assertion, not the results

`write <= ci` always holds (a match at `found >= ci` writes to `write <= found`, then sets `ci = found + 1`) and `scan_for_offset` never reads below its `start`, so every read already landed in the untouched suffix. Confirmed empirically: with the assertion compiled out, the pre-fix code produces correct intersections. So release builds were unaffected; debug builds panicked.

## Fix

Search `cur.0[ci..]` — the suffix that is guaranteed untouched — instead of all of `cur`, and make the returned offsets absolute again. `scan_for_offset`'s duplicate back-walk floors at `start`, which becomes suffix-relative `0`, so the semantics are unchanged. Same complexity, no extra work in the hot path.

## Testing

The existing `offsets::tests::intersect` corpus missed this because `add_row_sorted` collapses contiguous row sets to `Dense`, so its skewed pairs never put *two* `Sparse` subsets into this branch. Added:

- `offsets::tests::intersect_sparse_sparse_skewed`, a targeted regression test that reproduces #971's slice byte-for-byte in ~20 lines with no external dependencies.
- Two entries (a 17-row sparse subset and a 3-row sparse subset) to the exhaustive `intersect` corpus, so all-pairs coverage now reaches this branch.

Verified at `53b9721`:

- `cargo test --workspace`: **1132 passed, 0 failed** (including the 792-test integration suite).
- The reporter's reproducer in [ProteusLab/LIRA@egglog_repro](https://github.com/ProteusLab/LIRA/tree/egglog_repro) — `cd rust && cargo test -- repro` — passes against the patched egglog, as does the rest of that suite.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

I also audited the other `SortedOffsetVector::slice()` / `scan_for_offset` call sites; this was the only one whose receiver can be mid-mutation. One adjacent fragility, left alone as it is not a live bug: `binary_search_from`'s duplicate back-walk is bounded by `found > 0` rather than `found > start`, so it can return an index below `start`; at the sole `start != 0` call site the values make that unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
