### PR TITLE
Add sequence-backed container infrastructure

### DIFF
--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -19,8 +19,9 @@ use hashbrown::HashTable;
 use rustc_hash::FxHasher;
 
 use crate::{
-    BaseValues, ContainerValues, ExternalFunctionId, WrappedTable,
+    BaseValues, ContainerValueId, ContainerValues, ExternalFunctionId, WrappedTable,
     common::Value,
+    dependency_graph::MaintenanceId,
     free_join::{
         CounterId, CounterReservation, Counters, ExternalFunctions, TableId, TableInfo, Variable,
     },
@@ -291,38 +292,88 @@ pub(crate) struct ExtractedBinding {
     pub(crate) vals: Pooled<Vec<Value>>,
 }
 
+/// Namespace-qualified owner of a predicted row.
+///
+/// Tables and sequence-backed container types use independent dense `u32` id
+/// spaces. The high bit distinguishes them without widening [`PredictedEntry`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+struct PredictionOwner(u32);
+
+impl PredictionOwner {
+    const CONTAINER_TAG: u32 = 1 << 31;
+
+    fn table(table: TableId) -> Self {
+        Self::new(table.rep(), false)
+    }
+
+    fn container(container: ContainerValueId) -> Self {
+        Self::new(container.rep(), true)
+    }
+
+    fn new(rep: u32, is_container: bool) -> Self {
+        assert_eq!(
+            rep & Self::CONTAINER_TAG,
+            0,
+            "prediction owner id exceeds its 31-bit namespace"
+        );
+        Self(rep | if is_container { Self::CONTAINER_TAG } else { 0 })
+    }
+
+    fn rep(self) -> u32 {
+        self.0
+    }
+}
+
 #[derive(Clone, Copy)]
 struct PredictedEntry {
     hash: u64,
-    index: usize,
-    table: TableId,
+    index: u32,
+    row_end: u32,
+    owner: PredictionOwner,
     key_arity: u32,
+}
+
+#[derive(Clone, Copy)]
+struct PredictedValueEntry {
+    hash: u64,
+    index: u32,
+    row_end: u32,
+    owner: PredictionOwner,
 }
 
 #[derive(Default)]
 pub(crate) struct PredictedVals {
     index: HashTable<PredictedEntry>,
+    by_value: HashTable<PredictedValueEntry>,
     values: Vec<Value>,
 }
 
 impl Clear for PredictedVals {
     fn reuse(&self) -> bool {
-        self.index.capacity() > 0 || self.values.capacity() > 0
+        self.index.capacity() > 0 || self.by_value.capacity() > 0 || self.values.capacity() > 0
     }
     fn clear(&mut self) {
         self.index.clear();
+        self.by_value.clear();
         self.values.clear();
     }
     fn bytes(&self) -> usize {
         self.index.capacity() * std::mem::size_of::<PredictedEntry>()
+            + self.by_value.capacity() * std::mem::size_of::<PredictedValueEntry>()
             + self.values.capacity() * std::mem::size_of::<Value>()
     }
 }
 
 impl PredictedVals {
+    #[cfg(test)]
     fn hash(table: TableId, key: &[Value]) -> u64 {
+        Self::owner_hash(PredictionOwner::table(table), key)
+    }
+
+    fn owner_hash(owner: PredictionOwner, key: &[Value]) -> u64 {
         let mut hasher = FxHasher::default();
-        hasher.write_u32(table.rep());
+        hasher.write_u32(owner.rep());
         hasher.write_usize(key.len());
         for value in key {
             hasher.write_u32(value.rep());
@@ -330,15 +381,97 @@ impl PredictedVals {
         hasher.finish()
     }
 
-    fn row(&self, entry: PredictedEntry, row_arity: usize) -> &[Value] {
-        &self.values[entry.index..entry.index + row_arity]
+    fn value_hash(owner: PredictionOwner, value: Value) -> u64 {
+        let mut hasher = FxHasher::default();
+        hasher.write_u32(owner.rep());
+        hasher.write_u32(value.rep());
+        hasher.finish()
     }
 
-    fn matches(&self, entry: &PredictedEntry, hash: u64, table: TableId, key: &[Value]) -> bool {
-        if entry.hash != hash || entry.table != table || entry.key_arity as usize != key.len() {
+    fn row(&self, entry: PredictedEntry) -> &[Value] {
+        &self.values[entry.index as usize..entry.row_end as usize]
+    }
+
+    fn value_row(&self, entry: PredictedValueEntry) -> &[Value] {
+        &self.values[entry.index as usize..entry.row_end as usize]
+    }
+
+    fn matches(
+        &self,
+        entry: &PredictedEntry,
+        hash: u64,
+        owner: PredictionOwner,
+        key: &[Value],
+    ) -> bool {
+        if entry.hash != hash || entry.owner != owner || entry.key_arity as usize != key.len() {
             return false;
         }
-        self.values[entry.index..entry.index + key.len()] == *key
+        self.values[entry.index as usize..entry.index as usize + key.len()] == *key
+    }
+
+    fn matches_value(
+        &self,
+        entry: &PredictedValueEntry,
+        hash: u64,
+        owner: PredictionOwner,
+        value: Value,
+    ) -> bool {
+        entry.hash == hash
+            && entry.owner == owner
+            && self.values[entry.row_end as usize - 1] == value
+    }
+
+    /// Look up a locally predicted row by its final non-key value.
+    ///
+    /// Container tables conventionally store their externally visible identity
+    /// as the final non-key value. Recording that value here lets a container
+    /// produced by one action be read immediately by a nested action, before
+    /// staged table writes are merged. A value is required to identify exactly
+    /// one local row; attempts to reuse it for different contents are rejected.
+    pub(crate) fn get_container_by_value(
+        &self,
+        container: ContainerValueId,
+        value: Value,
+    ) -> Option<&[Value]> {
+        let owner = PredictionOwner::container(container);
+        let hash = Self::value_hash(owner, value);
+        let entry = self
+            .by_value
+            .find(hash, |entry| self.matches_value(entry, hash, owner, value))
+            .copied()?;
+        Some(self.value_row(entry))
+    }
+
+    fn index_container_value(&mut self, entry: PredictedEntry) {
+        let row_arity = entry.row_end - entry.index;
+        assert_eq!(
+            row_arity,
+            entry.key_arity + 1,
+            "reverse-indexed predictions must have exactly one non-key value"
+        );
+        let row_end = entry.row_end as usize;
+        let row_start = entry.index as usize;
+        let value = self.values[row_end - 1];
+        let hash = Self::value_hash(entry.owner, value);
+        if let Some(existing) = self.by_value.find(hash, |candidate| {
+            self.matches_value(candidate, hash, entry.owner, value)
+        }) {
+            assert_eq!(
+                self.value_row(*existing),
+                &self.values[row_start..row_end],
+                "one locally predicted value cannot identify two different rows"
+            );
+            return;
+        }
+
+        let value_entry = PredictedValueEntry {
+            hash,
+            index: entry.index,
+            row_end: entry.row_end,
+            owner: entry.owner,
+        };
+        self.by_value
+            .insert_unique(hash, value_entry, |entry| entry.hash);
     }
 
     pub(crate) fn get_or_insert_with(
@@ -348,21 +481,65 @@ impl PredictedVals {
         row_arity: usize,
         default: impl FnOnce(&mut Vec<Value>, usize),
     ) -> (&[Value], bool) {
-        let hash = Self::hash(table, key);
+        self.get_or_insert_impl(
+            PredictionOwner::table(table),
+            key,
+            row_arity,
+            false,
+            default,
+        )
+    }
+
+    /// Predict a row with exactly one non-key value and index it in both
+    /// directions.
+    ///
+    /// The one-value restriction matches an interned sequence row: its
+    /// variable-length key is the serialized value and its sole non-key value
+    /// is the externally visible identity returned to actions.
+    pub(crate) fn get_or_insert_container_with(
+        &mut self,
+        container: ContainerValueId,
+        key: &[Value],
+        default: impl FnOnce(&mut Vec<Value>, usize),
+    ) -> (&[Value], bool) {
+        let row_arity = key
+            .len()
+            .checked_add(1)
+            .expect("predicted container row arity overflow");
+        self.get_or_insert_impl(
+            PredictionOwner::container(container),
+            key,
+            row_arity,
+            true,
+            default,
+        )
+    }
+
+    fn get_or_insert_impl(
+        &mut self,
+        owner: PredictionOwner,
+        key: &[Value],
+        row_arity: usize,
+        index_value: bool,
+        default: impl FnOnce(&mut Vec<Value>, usize),
+    ) -> (&[Value], bool) {
+        let hash = Self::owner_hash(owner, key);
         if let Some(entry) = self
             .index
-            .find(hash, |entry| self.matches(entry, hash, table, key))
+            .find(hash, |entry| self.matches(entry, hash, owner, key))
             .copied()
         {
-            return (self.row(entry, row_arity), false);
+            assert_eq!(
+                entry.row_end as usize - entry.index as usize,
+                row_arity,
+                "predicted row arity changed for an existing key"
+            );
+            if index_value {
+                self.index_container_value(entry);
+            }
+            return (self.row(entry), false);
         }
 
-        let entry = PredictedEntry {
-            hash,
-            index: self.values.len(),
-            table,
-            key_arity: u32::try_from(key.len()).expect("predicted key arity must fit in u32"),
-        };
         self.values.reserve(row_arity);
         let row_start = self.values.len();
         self.values.extend_from_slice(key);
@@ -372,8 +549,20 @@ impl PredictedVals {
             row_arity,
             "predicted row builder produced the wrong arity"
         );
+        let entry = PredictedEntry {
+            hash,
+            index: u32::try_from(row_start).expect("predicted row offset must fit in u32"),
+            row_end: u32::try_from(self.values.len()).expect("predicted row end must fit in u32"),
+            owner,
+            key_arity: u32::try_from(key.len()).expect("predicted key arity must fit in u32"),
+        };
         self.index.insert_unique(hash, entry, |entry| entry.hash);
-        (self.row(entry, row_arity), true)
+
+        if index_value {
+            self.index_container_value(entry);
+        }
+
+        (self.row(entry), true)
     }
 }
 
@@ -384,7 +573,9 @@ pub(crate) struct DbView<'a> {
     pub(crate) external_funcs: &'a ExternalFunctions,
     pub(crate) bases: &'a BaseValues,
     pub(crate) containers: &'a ContainerValues,
-    pub(crate) notification_list: &'a NotificationList<TableId>,
+    pub(crate) notification_list: &'a NotificationList<MaintenanceId>,
+    pub(crate) table_maintenance: &'a DenseIdMap<TableId, MaintenanceId>,
+    pub(crate) container_maintenance: &'a DenseIdMap<ContainerValueId, MaintenanceId>,
 }
 
 /// A handle on a database that may be in the process of running a rule.
@@ -407,16 +598,19 @@ pub(crate) struct DbView<'a> {
 /// the next call to `merge` on the underlying table.
 ///
 /// ## Predicted Values
-/// ExecutionStates provide a means of synchronizing the results of a pending write across
-/// different executions of a rule. This is particularly important in the case where the result of
-/// an operation (such as "lookup or insert new id" operatiosn) is a fresh id. A common
-/// ExecutionState ensures that future lookups will see the same id (even across calls to
-/// [`ExecutionState::clone`]).
+/// Each execution locally remembers the results of its pending writes. This is
+/// particularly important when an operation such as "lookup or insert a new
+/// id" returns a fresh value that a later action in the same execution must be
+/// able to consume before table merge. Cloning an `ExecutionState` deliberately
+/// starts a fresh prediction cache; independently predicted values are
+/// reconciled by the table's merge function and the subsequent congruence-
+/// closure rebuild.
 pub struct ExecutionState<'a> {
     pub(crate) predicted: PredictedVals,
     pub(crate) db: DbView<'a>,
     counter_reservations: CounterReservations,
     buffers: MutationBuffers<'a>,
+    container_buffers: DenseIdMap<ContainerValueId, Box<dyn MutationBuffer>>,
     /// Whether any mutations have been staged via this ExecutionState.
     pub(crate) changed: bool,
     /// Atomic flag for early stopping of rule execution.
@@ -452,7 +646,12 @@ impl<'db> ExecutionStateSeed<'db, '_> {
             predicted: Default::default(),
             db: self.db,
             counter_reservations: Default::default(),
-            buffers: MutationBuffers::new(self.db.notification_list, Default::default()),
+            buffers: MutationBuffers::new(
+                self.db.notification_list,
+                self.db.table_maintenance,
+                Default::default(),
+            ),
+            container_buffers: Default::default(),
             changed: false,
             stop_match: Arc::clone(self.stop_match),
         }
@@ -466,13 +665,15 @@ impl<'db> ExecutionStateSeed<'db, '_> {
 /// A basic wrapper around an map from table id to a mutation buffer for that table that also
 /// tracks if a table has been modified.
 struct MutationBuffers<'a> {
-    notify_list: &'a NotificationList<TableId>,
+    notify_list: &'a NotificationList<MaintenanceId>,
+    table_maintenance: &'a DenseIdMap<TableId, MaintenanceId>,
     buffers: DenseIdMap<TableId, Box<dyn MutationBuffer>>,
 }
 
 impl Clone for MutationBuffers<'_> {
     fn clone(&self) -> Self {
-        let mut res = MutationBuffers::new(self.notify_list, Default::default());
+        let mut res =
+            MutationBuffers::new(self.notify_list, self.table_maintenance, Default::default());
         for (id, buf) in self.buffers.iter() {
             res.buffers.insert(id, buf.fresh_handle());
         }
@@ -480,13 +681,25 @@ impl Clone for MutationBuffers<'_> {
     }
 }
 
+fn fresh_container_buffers(
+    buffers: &DenseIdMap<ContainerValueId, Box<dyn MutationBuffer>>,
+) -> DenseIdMap<ContainerValueId, Box<dyn MutationBuffer>> {
+    let mut result = DenseIdMap::new();
+    for (id, buffer) in buffers.iter() {
+        result.insert(id, buffer.fresh_handle());
+    }
+    result
+}
+
 impl<'a> MutationBuffers<'a> {
     fn new(
-        notify_list: &'a NotificationList<TableId>,
+        notify_list: &'a NotificationList<MaintenanceId>,
+        table_maintenance: &'a DenseIdMap<TableId, MaintenanceId>,
         buffers: DenseIdMap<TableId, Box<dyn MutationBuffer>>,
     ) -> MutationBuffers<'a> {
         MutationBuffers {
             notify_list,
+            table_maintenance,
             buffers,
         }
     }
@@ -495,12 +708,12 @@ impl<'a> MutationBuffers<'a> {
     }
     fn stage_insert(&mut self, table_id: TableId, row: &[Value]) {
         self.buffers[table_id].stage_insert(row);
-        self.notify_list.notify(table_id);
+        self.notify_list.notify(self.table_maintenance[table_id]);
     }
 
     fn stage_remove(&mut self, table_id: TableId, key: &[Value]) {
         self.buffers[table_id].stage_remove(key);
-        self.notify_list.notify(table_id);
+        self.notify_list.notify(self.table_maintenance[table_id]);
     }
 }
 
@@ -511,6 +724,7 @@ impl Clone for ExecutionState<'_> {
             db: self.db,
             counter_reservations: Default::default(),
             buffers: self.buffers.clone(),
+            container_buffers: fresh_container_buffers(&self.container_buffers),
             changed: false,
             stop_match: Arc::clone(&self.stop_match),
         }
@@ -526,7 +740,8 @@ impl<'a> ExecutionState<'a> {
             predicted: Default::default(),
             db,
             counter_reservations: Default::default(),
-            buffers: MutationBuffers::new(db.notification_list, buffers),
+            buffers: MutationBuffers::new(db.notification_list, db.table_maintenance, buffers),
+            container_buffers: Default::default(),
             changed: false,
             stop_match: Arc::new(AtomicBool::new(false)),
         }
@@ -602,6 +817,52 @@ impl<'a> ExecutionState<'a> {
 
     pub fn container_values(&self) -> &'a ContainerValues {
         self.db.containers
+    }
+
+    /// Predict and stage a sequence-backed container row.
+    ///
+    /// The row is `key` followed by one fresh identity allocated from
+    /// `counter`. Repeated keys within this execution reuse the first identity
+    /// and are staged only once. The buffer cache is separate from ordinary
+    /// table buffers because its namespace is [`ContainerValueId`].
+    pub(crate) fn predict_container_value(
+        &mut self,
+        container: ContainerValueId,
+        key: &[Value],
+        counter: CounterId,
+        new_buffer: impl FnOnce() -> Box<dyn MutationBuffer>,
+    ) -> Value {
+        let counters = self.db.counters;
+        let counter_reservations = &mut self.counter_reservations;
+        let (row, inserted) =
+            self.predicted
+                .get_or_insert_container_with(container, key, |values, _| {
+                    values.push(Value::from_usize(
+                        counter_reservations.next(counters, counter),
+                    ));
+                });
+        let identity = row[row.len() - 1];
+        if inserted {
+            self.container_buffers
+                .get_or_insert(container, new_buffer)
+                .stage_insert(row);
+            // Standalone SequenceContainerEnv tests do not register a
+            // database scheduler target; database-owned environments do.
+            if let Some(maintenance) = self.db.container_maintenance.get(container) {
+                self.db.notification_list.notify(*maintenance);
+            }
+            self.changed = true;
+        }
+        identity
+    }
+
+    /// Return a sequence-backed container row predicted by this execution.
+    pub(crate) fn predicted_container_row(
+        &self,
+        container: ContainerValueId,
+        value: Value,
+    ) -> Option<&[Value]> {
+        self.predicted.get_container_by_value(container, value)
     }
 
     /// Get the _current_ value for a given key in `table`, or otherwise insert

--- a/core-relations/src/action/tests.rs
+++ b/core-relations/src/action/tests.rs
@@ -1,5 +1,10 @@
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+
 use crate::{
-    TableId, Value,
+    ContainerValueId, Database, MutationBuffer, TableId, Value,
     action::mask::{IterResult, ValueSource},
     numeric_id::NumericId,
     pool::Clear,
@@ -7,9 +12,49 @@ use crate::{
 };
 
 use super::{
-    PredictedEntry, PredictedVals,
+    PredictedEntry, PredictedVals, PredictedValueEntry, PredictionOwner,
     mask::{Mask, MaskIter},
 };
+
+#[derive(Clone)]
+struct RecordingMutationBuffer {
+    rows: Arc<Mutex<Vec<Vec<Value>>>>,
+    fresh_calls: Arc<AtomicUsize>,
+}
+
+impl MutationBuffer for RecordingMutationBuffer {
+    fn stage_insert(&mut self, row: &[Value]) {
+        self.rows.lock().unwrap().push(row.to_vec());
+    }
+
+    fn stage_remove(&mut self, _key: &[Value]) {
+        unreachable!("container prediction tests only stage inserts")
+    }
+
+    fn fresh_handle(&self) -> Box<dyn MutationBuffer> {
+        self.fresh_calls.fetch_add(1, Ordering::Relaxed);
+        Box::new(self.clone())
+    }
+}
+
+fn recording_buffer(
+    rows: &Arc<Mutex<Vec<Vec<Value>>>>,
+    creates: &Arc<AtomicUsize>,
+    fresh_calls: &Arc<AtomicUsize>,
+) -> impl FnOnce() -> Box<dyn MutationBuffer> + 'static {
+    let rows = Arc::clone(rows);
+    let creates = Arc::clone(creates);
+    let fresh_calls = Arc::clone(fresh_calls);
+    move || {
+        creates.fetch_add(1, Ordering::Relaxed);
+        Box::new(RecordingMutationBuffer { rows, fresh_calls })
+    }
+}
+
+#[test]
+fn predicted_entry_keeps_its_original_layout_size() {
+    assert_eq!(std::mem::size_of::<PredictedEntry>(), 24);
+}
 
 #[test]
 fn predicted_vals_store_rows_contiguously() {
@@ -31,6 +76,7 @@ fn predicted_vals_store_rows_contiguously() {
     });
     assert_eq!(got, row);
     assert!(inserted);
+    assert!(predicted.by_value.is_empty());
 
     let (got, inserted) = predicted.get_or_insert_with(table, &key, row.len(), |_, _| {
         default_calls += 1;
@@ -52,6 +98,7 @@ fn predicted_vals_store_rows_contiguously() {
 
     predicted.clear();
     assert!(predicted.index.is_empty());
+    assert!(predicted.by_value.is_empty());
     assert!(predicted.values.is_empty());
 }
 
@@ -71,7 +118,8 @@ fn predicted_vals_resolve_hash_collisions_with_the_backing_rows() {
         PredictedEntry {
             hash,
             index: 0,
-            table,
+            row_end: collision_row.len() as u32,
+            owner: PredictionOwner::table(table),
             key_arity: collision_key.len() as u32,
         },
         |entry| entry.hash,
@@ -88,6 +136,253 @@ fn predicted_vals_resolve_hash_collisions_with_the_backing_rows() {
     });
     assert_eq!(got, row);
     assert!(!inserted);
+}
+
+#[test]
+fn predicted_vals_reverse_lookup_supports_variable_rows_and_nested_use() {
+    let mut predicted = PredictedVals::default();
+    let inner_container = ContainerValueId::from_usize(3);
+    let outer_container = ContainerValueId::from_usize(4);
+    let inner_key = [Value::from_usize(10), Value::from_usize(11)];
+    let inner_id = Value::from_usize(90);
+    let inner_row = [inner_key[0], inner_key[1], inner_id];
+
+    let (row, inserted) =
+        predicted.get_or_insert_container_with(inner_container, &inner_key, |values, _| {
+            values.push(inner_id);
+        });
+    assert!(inserted);
+    assert_eq!(row, inner_row);
+
+    // The inner identity is available before any staged write is merged, so it
+    // can immediately be embedded in another variable-length predicted row.
+    let inner = predicted
+        .get_container_by_value(inner_container, inner_id)
+        .unwrap();
+    let outer_key = [inner[2], Value::from_usize(20), Value::from_usize(21)];
+    let outer_id = Value::from_usize(91);
+    let outer_row = [outer_key[0], outer_key[1], outer_key[2], outer_id];
+    let (row, inserted) =
+        predicted.get_or_insert_container_with(outer_container, &outer_key, |values, _| {
+            values.push(outer_id);
+        });
+    assert!(inserted);
+    assert_eq!(row, outer_row);
+    assert_eq!(
+        predicted.get_container_by_value(outer_container, outer_id),
+        Some(outer_row.as_slice())
+    );
+    assert_eq!(
+        predicted.get_container_by_value(inner_container, outer_id),
+        None
+    );
+}
+
+#[test]
+#[should_panic(expected = "one locally predicted value cannot identify two different rows")]
+fn predicted_vals_reverse_lookup_rejects_a_conflicting_identity() {
+    let mut predicted = PredictedVals::default();
+    let container = ContainerValueId::from_usize(3);
+    let identity = Value::from_usize(90);
+    let first_key = [Value::from_usize(10)];
+    let second_key = [Value::from_usize(11), Value::from_usize(12)];
+
+    predicted.get_or_insert_container_with(container, &first_key, |values, _| {
+        values.push(identity);
+    });
+    predicted.get_or_insert_container_with(container, &second_key, |values, _| {
+        values.push(identity);
+    });
+}
+
+#[test]
+fn predicted_vals_keep_table_and_container_namespaces_distinct() {
+    let mut predicted = PredictedVals::default();
+    let table = TableId::from_usize(3);
+    let container = ContainerValueId::from_usize(3);
+    let key = [Value::from_usize(10)];
+    let table_row = [key[0], Value::from_usize(80)];
+    let container_row = [key[0], Value::from_usize(90)];
+
+    let (row, inserted) =
+        predicted.get_or_insert_with(table, &key, table_row.len(), |values, _| {
+            values.push(table_row[1]);
+        });
+    assert!(inserted);
+    assert_eq!(row, table_row);
+
+    let (row, inserted) = predicted.get_or_insert_container_with(container, &key, |values, _| {
+        values.push(container_row[1]);
+    });
+    assert!(inserted);
+    assert_eq!(row, container_row);
+    assert_eq!(predicted.index.len(), 2);
+    assert_eq!(
+        predicted.get_container_by_value(container, container_row[1]),
+        Some(container_row.as_slice())
+    );
+
+    let (row, inserted) = predicted.get_or_insert_with(table, &key, table_row.len(), |_, _| {
+        unreachable!("the table prediction should remain independently addressable")
+    });
+    assert!(!inserted);
+    assert_eq!(row, table_row);
+}
+
+#[test]
+#[should_panic(expected = "predicted row builder produced the wrong arity")]
+fn predicted_container_rows_require_exactly_one_identity_value() {
+    let mut predicted = PredictedVals::default();
+    let container = ContainerValueId::from_usize(3);
+    let key = [Value::from_usize(10)];
+    predicted.get_or_insert_container_with(container, &key, |values, _| {
+        values.extend_from_slice(&[Value::from_usize(11), Value::from_usize(90)]);
+    });
+}
+
+#[test]
+fn predicted_vals_reverse_lookup_resolves_raw_hash_collisions() {
+    let mut predicted = PredictedVals::default();
+    let container = ContainerValueId::from_usize(3);
+    let owner = PredictionOwner::container(container);
+    let collision_row = [Value::from_usize(10), Value::from_usize(80)];
+    let key = [Value::from_usize(20), Value::from_usize(21)];
+    let identity = Value::from_usize(90);
+    let row = [key[0], key[1], identity];
+    let hash = PredictedVals::value_hash(owner, identity);
+
+    predicted.values.extend_from_slice(&collision_row);
+    predicted.by_value.insert_unique(
+        hash,
+        PredictedValueEntry {
+            hash,
+            index: 0,
+            row_end: collision_row.len() as u32,
+            owner,
+        },
+        |entry| entry.hash,
+    );
+
+    let (got, inserted) = predicted.get_or_insert_container_with(container, &key, |values, _| {
+        values.push(identity);
+    });
+    assert_eq!(got, row);
+    assert!(inserted);
+    assert_eq!(
+        predicted.get_container_by_value(container, identity),
+        Some(row.as_slice())
+    );
+    assert_eq!(predicted.by_value.len(), 2);
+    assert!(
+        predicted
+            .by_value
+            .find(hash, |entry| predicted.value_row(*entry) == collision_row)
+            .is_some()
+    );
+}
+
+#[test]
+fn predicted_vals_are_execution_local_across_clones() {
+    empty_execution_state!(state);
+    let container = ContainerValueId::from_usize(3);
+    let key = [Value::from_usize(10)];
+    let identity = Value::from_usize(90);
+    state
+        .predicted
+        .get_or_insert_container_with(container, &key, |values, _| values.push(identity));
+
+    let cloned = state.clone();
+    assert_eq!(
+        state.predicted.get_container_by_value(container, identity),
+        Some([key[0], identity].as_slice())
+    );
+    assert_eq!(
+        cloned.predicted.get_container_by_value(container, identity),
+        None
+    );
+}
+
+#[test]
+fn execution_state_predicts_and_stages_each_local_container_key_once() {
+    let mut db = Database::default();
+    let counter = db.add_reservable_counter(8);
+    let mut state = super::ExecutionState::new(db.read_only_view(), Default::default());
+    let container = ContainerValueId::from_usize(3);
+    let rows = Arc::new(Mutex::new(Vec::<Vec<Value>>::new()));
+    let creates = Arc::new(AtomicUsize::new(0));
+    let fresh_calls = Arc::new(AtomicUsize::new(0));
+    let key = [Value::from_usize(10), Value::from_usize(11)];
+
+    let first = state.predict_container_value(
+        container,
+        &key,
+        counter,
+        recording_buffer(&rows, &creates, &fresh_calls),
+    );
+    let repeated = state.predict_container_value(
+        container,
+        &key,
+        counter,
+        recording_buffer(&rows, &creates, &fresh_calls),
+    );
+    assert_eq!(first, repeated);
+    assert!(state.changed);
+    assert_eq!(creates.load(Ordering::Relaxed), 1);
+    assert_eq!(fresh_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(
+        state.predicted_container_row(container, first),
+        Some([key[0], key[1], first].as_slice())
+    );
+    assert_eq!(*rows.lock().unwrap(), vec![vec![key[0], key[1], first]]);
+
+    let other_key = [Value::from_usize(20)];
+    let second = state.predict_container_value(
+        container,
+        &other_key,
+        counter,
+        recording_buffer(&rows, &creates, &fresh_calls),
+    );
+    assert_ne!(first, second);
+    assert_eq!(second.index(), first.index() + 1);
+    assert_eq!(creates.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        *rows.lock().unwrap(),
+        vec![vec![key[0], key[1], first], vec![other_key[0], second]]
+    );
+}
+
+#[test]
+fn execution_state_clone_uses_fresh_container_buffer_handles() {
+    let mut db = Database::default();
+    let counter = db.add_reservable_counter(8);
+    let mut state = super::ExecutionState::new(db.read_only_view(), Default::default());
+    let container = ContainerValueId::from_usize(3);
+    let rows = Arc::new(Mutex::new(Vec::<Vec<Value>>::new()));
+    let creates = Arc::new(AtomicUsize::new(0));
+    let fresh_calls = Arc::new(AtomicUsize::new(0));
+    let key = [Value::from_usize(10)];
+    let original = state.predict_container_value(
+        container,
+        &key,
+        counter,
+        recording_buffer(&rows, &creates, &fresh_calls),
+    );
+
+    let mut cloned = state.clone();
+    assert_eq!(fresh_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(cloned.predicted_container_row(container, original), None);
+
+    let cloned_key = [Value::from_usize(20)];
+    let cloned_value = cloned.predict_container_value(container, &cloned_key, counter, || {
+        unreachable!("the cloned state should already have a fresh container buffer")
+    });
+    assert_ne!(original, cloned_value);
+    assert!(cloned.changed);
+    assert_eq!(creates.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        *rows.lock().unwrap(),
+        vec![vec![key[0], original], vec![cloned_key[0], cloned_value]]
+    );
 }
 
 #[test]

--- a/core-relations/src/containers/mod.rs
+++ b/core-relations/src/containers/mod.rs
@@ -20,16 +20,24 @@ use dashmap::SharedValue;
 use rustc_hash::FxHasher;
 
 use crate::{
-    ColumnId, CounterId, ExecutionState, Offset, SubsetRef, TableId, TaggedRowBuffer, Value,
-    WrappedTable,
+    ColumnId, CounterId, ExecutionState, Offset, Subset, SubsetRef, TableId, TaggedRowBuffer,
+    Value, WrappedTable,
     common::{DashMap, IndexSet, SubsetTracker},
     parallel,
-    parallel_heuristics::{parallelize_inter_container_op, parallelize_intra_container_op},
+    parallel_heuristics::{
+        parallelize_db_level_op, parallelize_inter_container_op, parallelize_intra_container_op,
+        parallelize_rebuild,
+    },
     table_spec::{Rebuilder, ValueRebuilder},
 };
 
+mod sequence;
+
 #[cfg(test)]
 mod tests;
+
+use sequence::SequenceContainerEnv;
+pub use sequence::SequenceContainerValue;
 
 define_id!(pub ContainerValueId, u32, "an identifier for containers");
 
@@ -68,6 +76,32 @@ pub struct ContainerValues {
     subset_tracker: SubsetTracker,
     container_ids: ContainerIds,
     data: DenseIdMap<ContainerValueId, Box<dyn DynamicContainerEnv + Send + Sync>>,
+}
+
+enum ContainerValueRefInner<'a, C> {
+    Legacy(Box<dyn Deref<Target = C> + 'a>),
+    Sequence(C),
+}
+
+/// A borrowed legacy container or an owned value decoded from a sequence.
+///
+/// Sequence-backed lookups deliberately reconstruct the Rust container: this
+/// is the slow compatibility path. Performance-sensitive primitives should
+/// use [`ExecutionState::container_sequence`] and operate on the serialized
+/// values directly.
+struct ContainerValueRef<'a, C> {
+    inner: ContainerValueRefInner<'a, C>,
+}
+
+impl<C> Deref for ContainerValueRef<'_, C> {
+    type Target = C;
+
+    fn deref(&self) -> &Self::Target {
+        match &self.inner {
+            ContainerValueRefInner::Legacy(value) => value,
+            ContainerValueRefInner::Sequence(value) => value,
+        }
+    }
 }
 
 /// Summary returned by container rebuild.
@@ -118,24 +152,78 @@ impl ContainerRebuildSummary {
     }
 }
 
+/// The storage implementation behind a type-erased container environment.
+///
+/// Sequence environments are eligible to become independently scheduled
+/// database maintenance targets. Legacy environments remain in the registry's
+/// compatibility rebuild pass.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ContainerBackend {
+    Legacy,
+    Sequence,
+}
+
+/// The shared union-find rebuild inputs for one container rebuild cycle.
+///
+/// Preparing this once is important for incremental rebuilds: consulting the
+/// subset tracker separately for the sequence and legacy passes would advance
+/// its watermark twice and make the second pass miss the relevant UF delta.
+struct ContainerRebuildContext<'a> {
+    table: &'a WrappedTable,
+    rebuilder: Box<dyn Rebuilder + 'a>,
+    to_scan: Option<Subset>,
+}
+
 impl ContainerValues {
     pub fn new() -> Self {
         Default::default()
     }
 
-    fn get<C: ContainerValue>(&self) -> Option<&ContainerEnv<C>> {
+    fn get_env<C: ContainerValue>(
+        &self,
+    ) -> Option<(ContainerValueId, &(dyn DynamicContainerEnv + Send + Sync))> {
         let id = self.container_ids.get(&TypeId::of::<C>())?;
-        let res = self.data.get(id)?.as_any();
-        Some(res.downcast_ref::<ContainerEnv<C>>().unwrap())
+        Some((id, &**self.data.get(id)?))
+    }
+
+    fn get_sequence_env<C: ContainerValue>(&self) -> Option<&SequenceContainerEnv<C>> {
+        self.get_env::<C>()?
+            .1
+            .as_any()
+            .downcast_ref::<SequenceContainerEnv<C>>()
+    }
+
+    /// Return the id of an already registered sequence environment.
+    ///
+    /// This check does not mutate the registry, so the database can distinguish
+    /// an idempotent registration from a first registration before installing
+    /// the corresponding maintenance-scheduler participant.
+    pub(crate) fn registered_sequence_type<C: SequenceContainerValue>(
+        &self,
+    ) -> Option<ContainerValueId> {
+        let (id, env) = self.get_env::<C>()?;
+        assert!(
+            env.as_any()
+                .downcast_ref::<SequenceContainerEnv<C>>()
+                .is_some(),
+            "container type was already registered with a different backend"
+        );
+        Some(id)
     }
 
     /// Iterate over the containers of the given type.
     pub fn for_each<C: ContainerValue>(&self, mut f: impl FnMut(&C, Value)) {
-        let Some(env) = self.get::<C>() else {
+        let Some((_, env)) = self.get_env::<C>() else {
             return;
         };
-        for ent in env.to_id.iter() {
-            f(ent.key(), *ent.value());
+        if let Some(env) = env.as_any().downcast_ref::<ContainerEnv<C>>() {
+            for ent in env.to_id.iter() {
+                f(ent.key(), *ent.value());
+            }
+        } else if let Some(env) = env.as_any().downcast_ref::<SequenceContainerEnv<C>>() {
+            env.for_each(&mut f);
+        } else {
+            unreachable!("container environment has the wrong concrete value type");
         }
     }
 
@@ -145,7 +233,30 @@ impl ContainerValues {
     /// The return type of this function may contain lock guards. Attempts to modify the contents
     /// of the containers database may deadlock if the given guard has not been dropped.
     pub fn get_val<C: ContainerValue>(&self, val: Value) -> Option<impl Deref<Target = C> + '_> {
-        self.get::<C>()?.get_container(val)
+        let (_, env) = self.get_env::<C>()?;
+        if let Some(env) = env.as_any().downcast_ref::<ContainerEnv<C>>() {
+            return Some(ContainerValueRef {
+                inner: ContainerValueRefInner::Legacy(Box::new(env.get_container(val)?)),
+            });
+        }
+        let env = env
+            .as_any()
+            .downcast_ref::<SequenceContainerEnv<C>>()
+            .expect("container environment has the wrong concrete value type");
+        Some(ContainerValueRef {
+            inner: ContainerValueRefInner::Sequence(env.get_container(val)?),
+        })
+    }
+
+    fn get_owned<C: ContainerValue>(&self, value: Value) -> Option<C> {
+        let (_, env) = self.get_env::<C>()?;
+        if let Some(env) = env.as_any().downcast_ref::<ContainerEnv<C>>() {
+            return Some(env.get_container(value)?.deref().clone());
+        }
+        env.as_any()
+            .downcast_ref::<SequenceContainerEnv<C>>()
+            .expect("container environment has the wrong concrete value type")
+            .get_container(value)
     }
 
     pub fn register_val<C: ContainerValue>(
@@ -153,10 +264,24 @@ impl ContainerValues {
         container: C,
         exec_state: &mut ExecutionState,
     ) -> Value {
-        let env = self
-            .get::<C>()
+        let (_, env) = self
+            .get_env::<C>()
             .expect("must register container type before registering a value");
-        env.get_or_insert(&container, exec_state)
+        if let Some(env) = env.as_any().downcast_ref::<ContainerEnv<C>>() {
+            env.get_or_insert(&container, exec_state)
+        } else {
+            env.as_any()
+                .downcast_ref::<SequenceContainerEnv<C>>()
+                .expect("container environment has the wrong concrete value type")
+                .get_or_insert(&container, exec_state)
+        }
+    }
+
+    /// Return the committed flat value sequence for a sequence-backed
+    /// container. This is the fast read path and performs no Rust-container
+    /// reconstruction.
+    pub fn get_sequence<C: ContainerValue>(&self, value: Value) -> Option<&[Value]> {
+        self.get_sequence_env::<C>()?.get_values(value)
     }
 
     /// Rebuild a single container value by remapping each contained value
@@ -191,20 +316,95 @@ impl ContainerValues {
         table: &WrappedTable,
         exec_state: &mut ExecutionState,
     ) -> ContainerRebuildSummary {
-        let Some(rebuilder) = table.rebuilder(&[]) else {
+        let Some(context) = self.prepare_rebuild(table_id, table) else {
             return Default::default();
         };
+        let mut summary = self.rebuild_sequence_pass(&context, exec_state);
+        summary.extend(self.rebuild_legacy_pass(&context, exec_state));
+        self.finish_rebuild(&mut summary);
+        summary
+    }
+
+    /// Prepare the immutable UF inputs shared by the backend-specific passes
+    /// in one container rebuild cycle.
+    fn prepare_rebuild<'a>(
+        &mut self,
+        table_id: TableId,
+        table: &'a WrappedTable,
+    ) -> Option<ContainerRebuildContext<'a>> {
+        let rebuilder = table.rebuilder(&[])?;
         let to_scan = rebuilder.hint_col().map(|_| {
-            // We may attempt an incremental rebuild.
+            // We may attempt an incremental rebuild. This must be computed
+            // exactly once and shared by both backend passes.
             self.subset_tracker.recent_updates(table_id, table)
         });
-        let mut summary = if parallelize_inter_container_op(self.data.next_id().index()) {
+        Some(ContainerRebuildContext {
+            table,
+            rebuilder,
+            to_scan,
+        })
+    }
+
+    /// Rebuild only sequence-backed container environments.
+    fn rebuild_sequence_pass(
+        &mut self,
+        context: &ContainerRebuildContext<'_>,
+        exec_state: &mut ExecutionState,
+    ) -> ContainerRebuildSummary {
+        self.rebuild_backend_pass(ContainerBackend::Sequence, context, exec_state)
+    }
+
+    /// Rebuild only legacy container environments.
+    fn rebuild_legacy_pass(
+        &mut self,
+        context: &ContainerRebuildContext<'_>,
+        exec_state: &mut ExecutionState,
+    ) -> ContainerRebuildSummary {
+        self.rebuild_backend_pass(ContainerBackend::Legacy, context, exec_state)
+    }
+
+    fn rebuild_backend_pass(
+        &mut self,
+        backend: ContainerBackend,
+        context: &ContainerRebuildContext<'_>,
+        exec_state: &mut ExecutionState,
+    ) -> ContainerRebuildSummary {
+        let (selected, selected_rows, largest_env) = self
+            .data
+            .iter()
+            .filter(|(_, env)| env.backend() == backend)
+            .fold(
+                (0usize, 0usize, 0usize),
+                |(count, rows, largest), (_, env)| {
+                    let len = env.len();
+                    (count + 1, rows.saturating_add(len), largest.max(len))
+                },
+            );
+        if selected == 0 {
+            return ContainerRebuildSummary::default();
+        }
+
+        // Sequence environments are themselves tables, so a few large types
+        // are enough useful work to parallelize even when the legacy
+        // environment-count heuristic does not fire. Keep the aggregate-size
+        // alternative sequence-only, and use it only while every individual
+        // sequence scan remains serial. This avoids nesting outer environment
+        // tasks around tables that already use all workers internally; legacy
+        // environments likewise retain their existing nested rebuild policy.
+        let parallelize_large_sequence_batch = backend == ContainerBackend::Sequence
+            && selected > 1
+            && !parallelize_rebuild(largest_env)
+            && parallelize_db_level_op(selected_rows);
+        if parallelize_inter_container_op(selected) || parallelize_large_sequence_batch {
             parallel::map_dense_id_map_mut(&mut self.data, |_, env| {
+                if env.backend() != backend {
+                    return ContainerRebuildSummary::default();
+                }
                 let mut exec_state = exec_state.clone();
                 env.apply_rebuild(
-                    table,
-                    &*rebuilder,
-                    to_scan.as_ref().map(|x| x.as_ref()),
+                    context.table,
+                    &*context.rebuilder,
+                    context.to_scan.as_ref().map(|subset| subset.as_ref()),
                     &mut exec_state,
                 )
             })
@@ -216,17 +416,27 @@ impl ContainerValues {
         } else {
             let mut summary = ContainerRebuildSummary::default();
             for (_, env) in self.data.iter_mut() {
+                if env.backend() != backend {
+                    continue;
+                }
                 summary.extend(env.apply_rebuild(
-                    table,
-                    &*rebuilder,
-                    to_scan.as_ref().map(|x| x.as_ref()),
+                    context.table,
+                    &*context.rebuilder,
+                    context.to_scan.as_ref().map(|subset| subset.as_ref()),
                     exec_state,
                 ));
             }
             summary
-        };
-        self.expand_dirty_id_closure(&mut summary);
-        summary
+        }
+    }
+
+    /// Finish a split container rebuild by propagating stable semantic changes
+    /// through all containing containers.
+    ///
+    /// Call this once, after every backend-specific pass has completed and all
+    /// temporarily removed environments have been restored.
+    fn finish_rebuild(&self, summary: &mut ContainerRebuildSummary) {
+        self.expand_dirty_id_closure(summary);
     }
 
     /// Add ancestor containers to the dirty-id set until it is transitively closed.
@@ -274,6 +484,117 @@ impl ContainerValues {
         });
         id
     }
+
+    /// Register a container type whose canonical representation is a
+    /// variable-length sequence followed by one non-key identity value.
+    pub(crate) fn register_sequence_type<C: SequenceContainerValue>(
+        &mut self,
+        id_counter: CounterId,
+        merge_fn: impl MergeFn + 'static,
+    ) -> ContainerValueId {
+        let id = self.container_ids.insert(TypeId::of::<C>());
+        self.data.get_or_insert(id, || {
+            Box::new(SequenceContainerEnv::<C>::new(
+                id,
+                Box::new(merge_fn),
+                id_counter,
+            ))
+        });
+        assert!(
+            self.data[id]
+                .as_any()
+                .downcast_ref::<SequenceContainerEnv<C>>()
+                .is_some(),
+            "container type was already registered with a different backend"
+        );
+        id
+    }
+
+    /// Return the storage backend for a registered type-erased environment.
+    #[cfg(test)]
+    pub(crate) fn env_backend(&self, id: ContainerValueId) -> ContainerBackend {
+        self.data[id].backend()
+    }
+
+    /// Return the current number of values in a registered environment.
+    #[cfg(test)]
+    pub(crate) fn env_len(&self, id: ContainerValueId) -> usize {
+        self.data[id].len()
+    }
+
+    /// Return the combined number of committed sequence-backed rows.
+    pub(crate) fn sequence_len(&self) -> usize {
+        self.data
+            .iter()
+            .filter(|(_, env)| env.backend() == ContainerBackend::Sequence)
+            .map(|(_, env)| env.len())
+            .sum()
+    }
+
+    /// Snapshot the ids of all sequence-backed environments.
+    #[cfg(test)]
+    pub(crate) fn sequence_env_ids(&self) -> Vec<ContainerValueId> {
+        self.data
+            .iter()
+            .filter_map(|(id, env)| (env.backend() == ContainerBackend::Sequence).then_some(id))
+            .collect()
+    }
+
+    pub(crate) fn take_env(
+        &mut self,
+        id: ContainerValueId,
+    ) -> Box<dyn DynamicContainerEnv + Send + Sync> {
+        self.data
+            .take(id)
+            .expect("pending container environment must still be registered")
+    }
+
+    pub(crate) fn put_env(
+        &mut self,
+        id: ContainerValueId,
+        env: Box<dyn DynamicContainerEnv + Send + Sync>,
+    ) {
+        let old = self.data.insert(id, env);
+        assert!(old.is_none(), "container environment inserted twice");
+    }
+}
+
+impl ExecutionState<'_> {
+    /// Decode a container visible to this execution, including an identity
+    /// predicted earlier by the same execution.
+    ///
+    /// This is the slow compatibility path for primitive implementations.
+    /// Sequence-backed containers are reconstructed from their flat key.
+    pub fn get_container<C: ContainerValue>(&self, value: Value) -> Option<C> {
+        if let Some(env) = self.db.containers.get_sequence_env::<C>() {
+            env.get_container_with_predictions(self, value)
+        } else {
+            self.db.containers.get_owned::<C>(value)
+        }
+    }
+
+    /// Borrow the fast serialized payload for a sequence-backed container
+    /// visible to this execution. No Rust container is constructed. The
+    /// payload may include type-specific metadata, such as compact counts.
+    pub fn container_sequence<C: ContainerValue>(&self, value: Value) -> Option<&[Value]> {
+        self.db
+            .containers
+            .get_sequence_env::<C>()?
+            .get_values_with_predictions(self, value)
+    }
+
+    /// Intern an already serialized key for a sequence-backed container.
+    ///
+    /// This is the fast write path. Callers avoid constructing a Rust
+    /// container but remain responsible for producing that type's canonical
+    /// key format.
+    pub fn register_container_sequence<C: ContainerValue>(&mut self, key: &[Value]) -> Value {
+        let containers = self.db.containers;
+        let env = containers
+            .get_sequence_env::<C>()
+            .expect("container type is not registered with the sequence backend");
+        env.get_or_insert_key(key, self)
+    }
 }
 
 /// A trait implemented by container types.
@@ -297,8 +618,14 @@ pub trait ContainerValue: Hash + Eq + Clone + Send + Sync + 'static {
     fn iter(&self) -> impl Iterator<Item = Value> + '_;
 }
 
-pub trait DynamicContainerEnv: Any + dyn_clone::DynClone + Send + Sync {
+pub(crate) trait DynamicContainerEnv: Any + dyn_clone::DynClone + Send + Sync {
     fn as_any(&self) -> &dyn Any;
+    fn backend(&self) -> ContainerBackend;
+    fn len(&self) -> usize;
+    /// Publish one epoch of staged sequence-table mutations.
+    fn merge_pending(&mut self, _exec_state: &mut ExecutionState) -> bool {
+        false
+    }
     fn apply_rebuild(
         &mut self,
         table: &WrappedTable,
@@ -345,6 +672,14 @@ struct ContainerEnv<C: Eq + Hash> {
 impl<C: ContainerValue> DynamicContainerEnv for ContainerEnv<C> {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn backend(&self) -> ContainerBackend {
+        ContainerBackend::Legacy
+    }
+
+    fn len(&self) -> usize {
+        self.to_id.len()
     }
 
     fn apply_rebuild(

--- a/core-relations/src/containers/sequence.rs
+++ b/core-relations/src/containers/sequence.rs
@@ -1,0 +1,659 @@
+//! Sequence-table storage for container values.
+//!
+//! A row is `[serialized container key..., identity]`. The identity is the
+//! table's sole non-key value, so equal serialized containers collide and run
+//! the ordinary container merge function. Producers predict identities in
+//! their execution-local cache; no shared eager interning map is involved.
+
+use std::{
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+};
+
+use crossbeam_queue::SegQueue;
+use rustc_hash::FxHasher;
+
+use crate::{
+    ExecutionState, Offset, RowId, SequenceTable, Subset, TableVersion, TaggedRowBuffer, Value,
+    common::{HashMap, IndexSet, ShardData, ShardId},
+    numeric_id::{DenseIdMap, NumericId},
+    offsets::Offsets,
+    parallel_heuristics::parallelize_intra_container_op,
+    table_spec::{Rebuilder, ValueRebuilder},
+};
+
+use super::{
+    ClosureRebuilder, ContainerBackend, ContainerRebuildSummary, ContainerValue, ContainerValueId,
+    DynamicContainerEnv, MergeFn, incremental_rebuild,
+};
+
+/// A container with a canonical flat sequence representation.
+///
+/// The default rebuild path is intentionally the slow compatibility path: it
+/// deserializes the sequence, invokes [`ContainerValue::rebuild_contents`],
+/// and serializes the result. Implementations may override
+/// [`SequenceContainerValue::rebuild_sequence`] to transform the flat values
+/// directly.
+pub trait SequenceContainerValue: ContainerValue {
+    /// Append the canonical serialized key to `out`.
+    fn encode_sequence(&self, out: &mut Vec<Value>);
+
+    /// Reconstruct the Rust container used by slow primitives and external
+    /// APIs.
+    fn decode_sequence(sequence: &[Value]) -> Self;
+
+    /// Return the fast primitive view of the serialized key.
+    ///
+    /// Metadata used only to distinguish container modes belongs outside this
+    /// slice. Most containers return their contained values directly; compact
+    /// encodings may return an encoded payload and override
+    /// [`SequenceContainerValue::visit_sequence_values`] for dependency
+    /// discovery.
+    fn sequence_values(sequence: &[Value]) -> &[Value];
+
+    /// Visit semantic child values used for transitive dirty-container
+    /// discovery. The default visits the fast primitive view directly.
+    fn visit_sequence_values(sequence: &[Value], visitor: &mut dyn FnMut(Value)) {
+        for value in Self::sequence_values(sequence) {
+            visitor(*value);
+        }
+    }
+
+    /// Rebuild a serialized key into the initially empty `out` buffer.
+    ///
+    /// Returning `false` requires leaving `out` empty. The default implements
+    /// the slow deserialize/rebuild/serialize round trip.
+    fn rebuild_sequence(
+        sequence: &[Value],
+        rebuilder: &dyn ValueRebuilder,
+        out: &mut Vec<Value>,
+    ) -> bool {
+        let mut container = Self::decode_sequence(sequence);
+        if container.rebuild_contents(rebuilder) {
+            container.encode_sequence(out);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SequenceCodec<C> {
+    encode: fn(&C, &mut Vec<Value>),
+    decode: fn(&[Value]) -> C,
+    values: for<'a> fn(&'a [Value]) -> &'a [Value],
+    rebuild: fn(&[Value], &dyn ValueRebuilder, &mut Vec<Value>) -> bool,
+    marker: PhantomData<fn() -> C>,
+}
+
+impl<C: SequenceContainerValue> SequenceCodec<C> {
+    fn new() -> Self {
+        Self {
+            encode: C::encode_sequence,
+            decode: C::decode_sequence,
+            values: C::sequence_values,
+            rebuild: C::rebuild_sequence,
+            marker: PhantomData,
+        }
+    }
+}
+
+/// A lock-free read-side reverse index, physically split into hash shards.
+///
+/// Merges update it under exclusive access to the environment. Rule execution
+/// only performs immutable shard lookups, so no `DashMap` or per-read locking
+/// is needed.
+#[derive(Clone)]
+struct SequenceReverse {
+    shard_data: ShardData,
+    shards: DenseIdMap<ShardId, HashMap<Value, RowId>>,
+}
+
+impl SequenceReverse {
+    fn new(shard_data: ShardData) -> Self {
+        let mut shards = DenseIdMap::with_capacity(shard_data.n_shards());
+        for index in 0..shard_data.n_shards() {
+            shards.insert(ShardId::from_usize(index), HashMap::default());
+        }
+        Self { shard_data, shards }
+    }
+
+    fn shard(&self, value: Value) -> ShardId {
+        let mut hasher = FxHasher::default();
+        value.hash(&mut hasher);
+        self.shard_data.shard_id(hasher.finish())
+    }
+
+    fn get(&self, value: Value) -> Option<RowId> {
+        self.shards[self.shard(value)].get(&value).copied()
+    }
+
+    fn insert(&mut self, value: Value, row: RowId) {
+        let shard = self.shard(value);
+        self.shards[shard].insert(value, row);
+    }
+
+    fn clear(&mut self) {
+        for (_, shard) in self.shards.iter_mut() {
+            shard.clear();
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct SequenceContainerEnv<C: ContainerValue> {
+    id: ContainerValueId,
+    counter: crate::CounterId,
+    table: SequenceTable,
+    reverse: SequenceReverse,
+    codec: SequenceCodec<C>,
+}
+
+impl<C: SequenceContainerValue> SequenceContainerEnv<C> {
+    pub(super) fn new(
+        id: ContainerValueId,
+        merge: Box<dyn MergeFn>,
+        counter: crate::CounterId,
+    ) -> Self {
+        let table_merge = move |state: &mut ExecutionState,
+                                current: &[Value],
+                                incoming: &[Value],
+                                out: &mut Vec<Value>| {
+            let current_id = *current.last().expect("container row must have an identity");
+            let incoming_id = *incoming
+                .last()
+                .expect("container row must have an identity");
+            let merged = merge(state, current_id, incoming_id);
+            if merged == current_id {
+                false
+            } else {
+                out.extend_from_slice(&current[..current.len() - 1]);
+                out.push(merged);
+                true
+            }
+        };
+        let table = SequenceTable::new_with_values_and_index(
+            1,
+            Box::new(table_merge),
+            Box::new(C::visit_sequence_values),
+        );
+        let reverse = SequenceReverse::new(table.shard_data());
+        Self {
+            id,
+            counter,
+            table,
+            reverse,
+            codec: SequenceCodec::new(),
+        }
+    }
+}
+
+impl<C: ContainerValue> SequenceContainerEnv<C> {
+    fn get_key(&self, value: Value) -> Option<&[Value]> {
+        let row = self.reverse.get(value)?;
+        let values = self.table.values(row)?;
+        if values != [value] {
+            return None;
+        }
+        self.table.key(row)
+    }
+
+    pub(super) fn get_values(&self, value: Value) -> Option<&[Value]> {
+        let key = self.get_key(value)?;
+        Some((self.codec.values)(key))
+    }
+
+    pub(super) fn get_container(&self, value: Value) -> Option<C> {
+        Some((self.codec.decode)(self.get_key(value)?))
+    }
+
+    pub(super) fn get_or_insert(&self, container: &C, exec_state: &mut ExecutionState) -> Value {
+        let mut key = Vec::new();
+        (self.codec.encode)(container, &mut key);
+        self.get_or_insert_key(&key, exec_state)
+    }
+
+    pub(super) fn get_or_insert_key(
+        &self,
+        key: &[Value],
+        exec_state: &mut ExecutionState,
+    ) -> Value {
+        if let Some(values) = self.table.get_values(key) {
+            return values[0];
+        }
+        exec_state.predict_container_value(self.id, key, self.counter, || self.table.new_buffer())
+    }
+
+    pub(super) fn get_key_with_predictions<'a>(
+        &'a self,
+        exec_state: &'a ExecutionState<'_>,
+        value: Value,
+    ) -> Option<&'a [Value]> {
+        if let Some(row) = exec_state.predicted_container_row(self.id, value) {
+            return row.get(..row.len().checked_sub(1)?);
+        }
+        self.get_key(value)
+    }
+
+    pub(super) fn get_values_with_predictions<'a>(
+        &'a self,
+        exec_state: &'a ExecutionState<'_>,
+        value: Value,
+    ) -> Option<&'a [Value]> {
+        Some((self.codec.values)(
+            self.get_key_with_predictions(exec_state, value)?,
+        ))
+    }
+
+    pub(super) fn get_container_with_predictions(
+        &self,
+        exec_state: &ExecutionState<'_>,
+        value: Value,
+    ) -> Option<C> {
+        Some((self.codec.decode)(
+            self.get_key_with_predictions(exec_state, value)?,
+        ))
+    }
+
+    pub(super) fn for_each(&self, f: &mut impl FnMut(&C, Value)) {
+        self.table
+            .scan_key_values(self.table.all().as_ref(), |_, key, values| {
+                let container = (self.codec.decode)(key);
+                f(&container, values[0]);
+            });
+    }
+
+    fn refresh_reverse(&mut self, previous: &TableVersion) {
+        let current = self.table.version();
+        let to_scan = if current.major == previous.major {
+            self.table.updates_since(previous.minor)
+        } else {
+            self.reverse.clear();
+            self.table.all()
+        };
+        let reverse = &mut self.reverse;
+        self.table
+            .scan_key_values(to_scan.as_ref(), |row, _, values| {
+                reverse.insert(values[0], row);
+            });
+    }
+
+    fn merge_table(&mut self, exec_state: &mut ExecutionState) -> bool {
+        let previous = self.table.version();
+        let changed = self.table.merge_with_state(exec_state);
+        self.refresh_reverse(&previous);
+        changed.added || changed.removed
+    }
+
+    /// Resolve the union-find delta through the sequence occurrence index.
+    ///
+    /// As with the fixed-table rebuild index, the UF supplies changed values
+    /// and the local index maps those values back to candidate rows. The
+    /// identity reverse map contributes a row when the container's own id is
+    /// one of the changed values. Stale index entries are harmless because the
+    /// subset rebuild reads rows through `SequenceTable::row`.
+    fn incremental_rebuild_subset(
+        &self,
+        table: &crate::WrappedTable,
+        rebuilder: &dyn Rebuilder,
+        to_scan: crate::SubsetRef<'_>,
+    ) -> Option<Subset> {
+        if !incremental_rebuild(
+            to_scan.size(),
+            self.table.len(),
+            parallelize_intra_container_op(self.table.len()),
+        ) {
+            return None;
+        }
+        let search_col = rebuilder
+            .hint_col()
+            .expect("incremental container rebuild requires a hint column");
+        let mut dirty = TaggedRowBuffer::new(1);
+        table.scan_project(
+            to_scan,
+            &[search_col],
+            Offset::new(0),
+            usize::MAX,
+            &[],
+            &mut dirty,
+        );
+
+        let mut candidate_rows = Vec::<RowId>::new();
+        for (_, value) in dirty.iter() {
+            let value = value[0];
+            if let Some(row) = self.reverse.get(value) {
+                candidate_rows.push(row);
+            }
+            if let Some(rows) = self.table.rows_for_indexed_value(value) {
+                rows.offsets(|row| candidate_rows.push(row));
+            }
+        }
+        candidate_rows.sort_unstable();
+        candidate_rows.dedup();
+        let mut subset = Subset::empty();
+        for row in candidate_rows {
+            subset.add_row_sorted(row);
+        }
+        Some(subset)
+    }
+}
+
+impl<C: ContainerValue> DynamicContainerEnv for SequenceContainerEnv<C> {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn backend(&self) -> ContainerBackend {
+        ContainerBackend::Sequence
+    }
+
+    fn len(&self) -> usize {
+        self.table.len()
+    }
+
+    fn merge_pending(&mut self, exec_state: &mut ExecutionState) -> bool {
+        self.merge_table(exec_state)
+    }
+
+    fn apply_rebuild(
+        &mut self,
+        table: &crate::WrappedTable,
+        rebuilder: &dyn Rebuilder,
+        subset: Option<crate::SubsetRef>,
+        exec_state: &mut ExecutionState,
+    ) -> ContainerRebuildSummary {
+        let rebuild_sequence = self.codec.rebuild;
+        let stable_changed_ids = SegQueue::new();
+        let previous = self.table.version();
+        let rebuild_row = |row: &[Value], rebuilt: &mut Vec<Value>| {
+            let key_end = row
+                .len()
+                .checked_sub(1)
+                .expect("container row must have an identity");
+            let key = &row[..key_end];
+            let old_id = row[key_end];
+            let new_id = rebuilder.rebuild_val(old_id);
+            let key_changed = rebuild_sequence(key, rebuilder, rebuilt);
+            if !key_changed && new_id == old_id {
+                debug_assert!(rebuilt.is_empty());
+                return false;
+            }
+            if !key_changed {
+                rebuilt.extend_from_slice(key);
+            }
+            rebuilt.push(new_id);
+            if key_changed && new_id == old_id {
+                stable_changed_ids.push(old_id);
+            }
+            true
+        };
+        let incremental =
+            subset.and_then(|subset| self.incremental_rebuild_subset(table, rebuilder, subset));
+        let change = if let Some(subset) = &incremental {
+            self.table.rebuild_full_rows_subset_with_state(
+                subset.as_ref(),
+                &rebuild_row,
+                exec_state,
+            )
+        } else {
+            self.table
+                .rebuild_full_rows_with_state(&rebuild_row, exec_state)
+        };
+        self.refresh_reverse(&previous);
+
+        let mut summary = ContainerRebuildSummary::default();
+        if change.added || change.removed {
+            summary.note_change();
+        }
+        while let Some(value) = stable_changed_ids.pop() {
+            if self.get_key(value).is_some() {
+                summary.note_dirty_id(value);
+            }
+        }
+        summary
+    }
+
+    fn extend_containers_containing(&self, values: &IndexSet<Value>, out: &mut IndexSet<Value>) {
+        for value in values {
+            let Some(rows) = self.table.rows_for_indexed_value(*value) else {
+                continue;
+            };
+            rows.offsets(|row| {
+                if let Some(ids) = self.table.values(row) {
+                    out.insert(ids[0]);
+                }
+            });
+        }
+    }
+
+    fn rebuild_val_with(
+        &self,
+        value: Value,
+        exec_state: &mut ExecutionState,
+        remap: &(dyn Fn(Value) -> Value + Send + Sync),
+    ) -> Option<Value> {
+        let key = self.get_key_with_predictions(exec_state, value)?.to_vec();
+        let mut rebuilt = Vec::new();
+        if !(self.codec.rebuild)(&key, &ClosureRebuilder { remap }, &mut rebuilt) {
+            return Some(value);
+        }
+        Some(self.get_or_insert_key(&rebuilt, exec_state))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::numeric_id::NumericId;
+    use crate::{
+        ColumnId, ContainerValue, Database, ExecutionState, Rebuilder, RowId, SortedWritesTable,
+        Table, Value, ValueRebuilder, WrappedTable, row_buffer::RowBuffer,
+        table_spec::WrappedTableRef,
+    };
+
+    use super::{DynamicContainerEnv, SequenceContainerEnv, SequenceContainerValue};
+
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    struct TestSequence(Vec<Value>);
+
+    impl ContainerValue for TestSequence {
+        fn rebuild_contents(&mut self, rebuilder: &dyn ValueRebuilder) -> bool {
+            rebuilder.rebuild_slice(&mut self.0)
+        }
+
+        fn iter(&self) -> impl Iterator<Item = Value> + '_ {
+            self.0.iter().copied()
+        }
+    }
+
+    impl SequenceContainerValue for TestSequence {
+        fn encode_sequence(&self, out: &mut Vec<Value>) {
+            out.extend_from_slice(&self.0);
+        }
+
+        fn decode_sequence(sequence: &[Value]) -> Self {
+            Self(sequence.to_vec())
+        }
+
+        fn sequence_values(sequence: &[Value]) -> &[Value] {
+            sequence
+        }
+
+        fn rebuild_sequence(
+            sequence: &[Value],
+            rebuilder: &dyn ValueRebuilder,
+            out: &mut Vec<Value>,
+        ) -> bool {
+            out.extend_from_slice(sequence);
+            if rebuilder.rebuild_slice(out) {
+                true
+            } else {
+                out.clear();
+                false
+            }
+        }
+    }
+
+    fn value(value: usize) -> Value {
+        Value::from_usize(value)
+    }
+
+    fn test_env(db: &mut Database) -> SequenceContainerEnv<TestSequence> {
+        let counter = db.add_reservable_counter(8);
+        SequenceContainerEnv::new(
+            crate::ContainerValueId::new(0),
+            Box::new(|_state: &mut ExecutionState, left, right| left.min(right)),
+            counter,
+        )
+    }
+
+    #[test]
+    fn local_prediction_is_immediately_readable_in_both_forms() {
+        let mut db = Database::new();
+        let env = test_env(&mut db);
+        db.with_execution_state(|state| {
+            let expected = TestSequence(vec![value(10), value(20)]);
+            let id = env.get_or_insert(&expected, state);
+            assert_eq!(
+                env.get_container_with_predictions(state, id),
+                Some(expected)
+            );
+            assert_eq!(
+                env.get_values_with_predictions(state, id),
+                Some([value(10), value(20)].as_slice())
+            );
+            assert_eq!(env.get_or_insert_key(&[value(10), value(20)], state), id);
+        });
+    }
+
+    #[test]
+    fn independent_predictions_coalesce_during_merge() {
+        let mut db = Database::new();
+        let mut env = test_env(&mut db);
+        let key = TestSequence(vec![value(7), value(8)]);
+        let first = db.with_execution_state(|state| env.get_or_insert(&key, state));
+        let second = db.with_execution_state(|state| env.get_or_insert(&key, state));
+        assert_ne!(first, second);
+
+        db.with_execution_state(|state| assert!(env.merge_table(state)));
+        let winner = first.min(second);
+        assert_eq!(env.get_container(winner), Some(key));
+        assert_eq!(env.get_container(first.max(second)), None);
+    }
+
+    #[test]
+    fn reverse_index_is_rebuilt_after_sequence_compaction() {
+        let mut db = Database::new();
+        let mut env = test_env(&mut db);
+        let ids = db.with_execution_state(|state| {
+            (0..40)
+                .map(|index| env.get_or_insert_key(&[value(100 + index)], state))
+                .collect::<Vec<_>>()
+        });
+        db.with_execution_state(|state| assert!(env.merge_table(state)));
+
+        let mut removals = env.table.new_buffer();
+        for index in 0..25 {
+            removals.stage_remove(&[value(100 + index)]);
+        }
+        drop(removals);
+        db.with_execution_state(|state| assert!(env.merge_table(state)));
+
+        for (index, id) in ids.into_iter().enumerate() {
+            if index < 25 {
+                assert_eq!(env.get_key(id), None);
+            } else {
+                assert_eq!(env.get_key(id), Some([value(100 + index)].as_slice()));
+            }
+        }
+    }
+
+    struct HintRebuilder {
+        from: Value,
+        to: Value,
+        visits: AtomicUsize,
+    }
+
+    impl ValueRebuilder for HintRebuilder {
+        fn rebuild_val(&self, value: Value) -> Value {
+            self.visits.fetch_add(1, Ordering::Relaxed);
+            if value == self.from { self.to } else { value }
+        }
+    }
+
+    impl Rebuilder for HintRebuilder {
+        fn hint_col(&self) -> Option<ColumnId> {
+            Some(ColumnId::new(0))
+        }
+
+        fn rebuild_buf(
+            &self,
+            _buf: &RowBuffer,
+            _start: RowId,
+            _end: RowId,
+            _out: &mut crate::TaggedRowBuffer,
+            _exec_state: &mut ExecutionState,
+        ) {
+            unreachable!("sequence incremental test does not bulk-rebuild tables")
+        }
+
+        fn rebuild_subset(
+            &self,
+            _other: WrappedTableRef<'_>,
+            _subset: crate::SubsetRef<'_>,
+            _out: &mut crate::TaggedRowBuffer,
+            _exec_state: &mut ExecutionState,
+        ) {
+            unreachable!("sequence incremental test does not bulk-rebuild tables")
+        }
+    }
+
+    #[test]
+    fn incremental_rebuild_uses_value_index_candidates() {
+        const CONTAINERS: usize = 1_002;
+        let from = value(50_000);
+        let to = value(60_000);
+        let mut db = Database::new();
+        let mut env = test_env(&mut db);
+        let ids = db.with_execution_state(|state| {
+            (0..CONTAINERS)
+                .map(|index| {
+                    let child = if index == 777 {
+                        from
+                    } else {
+                        value(100_000 + index)
+                    };
+                    env.get_or_insert_key(&[child], state)
+                })
+                .collect::<Vec<_>>()
+        });
+        db.with_execution_state(|state| assert!(env.merge_table(state)));
+
+        let mut dirty = SortedWritesTable::new(1, 1, None, vec![], Box::new(|_, _, _, _| false));
+        dirty.new_buffer().stage_insert(&[from]);
+        db.with_execution_state(|state| {
+            dirty.merge(state);
+        });
+        let dirty = WrappedTable::new(dirty);
+        let dirty_rows = dirty.all();
+        let rebuilder = HintRebuilder {
+            from,
+            to,
+            visits: AtomicUsize::new(0),
+        };
+        let summary = db.with_execution_state(|state| {
+            env.apply_rebuild(&dirty, &rebuilder, Some(dirty_rows.as_ref()), state)
+        });
+
+        assert!(summary.changed());
+        assert_eq!(
+            rebuilder.visits.load(Ordering::Relaxed),
+            2,
+            "only the selected row's identity and one child should rebuild"
+        );
+        assert_eq!(env.get_key(ids[777]), Some([to].as_slice()));
+        assert_eq!(env.get_key(ids[776]), Some([value(100_776)].as_slice()));
+    }
+}

--- a/core-relations/src/containers/tests.rs
+++ b/core-relations/src/containers/tests.rs
@@ -3,20 +3,25 @@
 //! This module has tests that verify specific behavior in a multithreaded setting that are harder
 //! to exercise deterministically when testing end to end.
 
-use std::sync::Arc;
+use std::{iter, sync::Arc};
 
 use crate::numeric_id::NumericId;
 use egglog_concurrency::Notification;
 
 use crate::{
-    ColumnId, Database, ExecutionState, Rebuilder, RowId, Value, ValueRebuilder,
-    row_buffer::RowBuffer, table_spec::WrappedTableRef,
+    ColumnId, Database, ExecutionState, Rebuilder, RowId, SequenceContainerValue,
+    SortedWritesTable, Value, ValueRebuilder, row_buffer::RowBuffer, table_spec::WrappedTableRef,
 };
 
-use super::{ContainerEnv, ContainerRebuildSummary, ContainerValue, hash_container};
+use super::{
+    ContainerBackend, ContainerEnv, ContainerRebuildSummary, ContainerValue, hash_container,
+};
 
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
 struct VecContainer(Vec<Value>);
+
+#[derive(Hash, PartialEq, Eq, Clone, Debug)]
+struct LegacyVecContainer(Vec<Value>);
 
 fn cont<const N: usize>(values: [usize; N]) -> VecContainer {
     VecContainer(values.iter().map(|&v| Value::from_usize(v)).collect())
@@ -29,6 +34,44 @@ impl ContainerValue for VecContainer {
 
     fn iter(&self) -> impl Iterator<Item = Value> + '_ {
         self.0.iter().copied()
+    }
+}
+
+impl ContainerValue for LegacyVecContainer {
+    fn rebuild_contents(&mut self, rebuilder: &dyn ValueRebuilder) -> bool {
+        rebuilder.rebuild_slice(&mut self.0)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = Value> + '_ {
+        self.0.iter().copied()
+    }
+}
+
+impl SequenceContainerValue for VecContainer {
+    fn encode_sequence(&self, out: &mut Vec<Value>) {
+        out.extend_from_slice(&self.0);
+    }
+
+    fn decode_sequence(sequence: &[Value]) -> Self {
+        Self(sequence.to_vec())
+    }
+
+    fn sequence_values(sequence: &[Value]) -> &[Value] {
+        sequence
+    }
+
+    fn rebuild_sequence(
+        sequence: &[Value],
+        rebuilder: &dyn ValueRebuilder,
+        out: &mut Vec<Value>,
+    ) -> bool {
+        out.extend_from_slice(sequence);
+        if rebuilder.rebuild_slice(out) {
+            true
+        } else {
+            out.clear();
+            false
+        }
     }
 }
 
@@ -221,4 +264,391 @@ fn nonincremental_dirty_ids_only_include_stable_ids() {
 
     run_case(false);
     run_case(true);
+}
+
+#[test]
+fn type_erased_backend_metadata_reports_sequence_lengths() {
+    let mut db = Database::new();
+    let legacy_counter = db.add_counter();
+    let sequence_counter = db.add_reservable_counter(8);
+    let legacy_id = db
+        .container_values_mut()
+        .register_type::<LegacyVecContainer>(legacy_counter, |_state, left, right| left.min(right));
+    let sequence_id = db.register_sequence_container_type::<VecContainer>(
+        sequence_counter,
+        |_state, left, right| left.min(right),
+        iter::empty(),
+        iter::empty(),
+    );
+
+    assert_eq!(
+        db.container_values().env_backend(legacy_id),
+        ContainerBackend::Legacy
+    );
+    assert_eq!(
+        db.container_values().env_backend(sequence_id),
+        ContainerBackend::Sequence
+    );
+    assert_eq!(db.container_values().sequence_env_ids(), vec![sequence_id]);
+
+    db.with_execution_state(|state| {
+        let containers = state.container_values();
+        containers.register_val(LegacyVecContainer(vec![Value::from_usize(1)]), state);
+        containers.register_val(VecContainer(vec![Value::from_usize(2)]), state);
+    });
+    assert_eq!(db.container_values().env_len(legacy_id), 1);
+    assert_eq!(db.container_values().env_len(sequence_id), 0);
+
+    assert!(db.merge_all());
+    assert_eq!(db.container_values().env_len(sequence_id), 1);
+}
+
+#[test]
+fn sequence_backend_round_trips_predictions_through_database_merge() {
+    let mut db = Database::new();
+    let counter = db.add_reservable_counter(8);
+    db.register_sequence_container_type::<VecContainer>(
+        counter,
+        |_state, left, right| left.min(right),
+        iter::empty(),
+        iter::empty(),
+    );
+    let expected = cont([1, 2, 3]);
+
+    let first = db.with_execution_state(|state| {
+        let containers = state.container_values();
+        let id = containers.register_val(expected.clone(), state);
+        assert_eq!(
+            state.get_container::<VecContainer>(id),
+            Some(expected.clone())
+        );
+        assert_eq!(
+            state.container_sequence::<VecContainer>(id),
+            Some(&expected.0[..])
+        );
+        id
+    });
+    let second = db.with_execution_state(|state| {
+        let containers = state.container_values();
+        containers.register_val(expected.clone(), state)
+    });
+    assert_ne!(
+        first, second,
+        "predictions are intentionally execution-local"
+    );
+
+    assert!(db.merge_all());
+    let winner = first.min(second);
+    assert_eq!(
+        db.container_values()
+            .get_val::<VecContainer>(winner)
+            .as_deref(),
+        Some(&expected)
+    );
+    assert!(
+        db.container_values()
+            .get_val::<VecContainer>(first.max(second))
+            .is_none()
+    );
+}
+
+#[test]
+fn cloned_databases_have_independent_sequence_notifications() {
+    let mut original = Database::new();
+    let counter = original.add_reservable_counter(8);
+    original.register_sequence_container_type::<VecContainer>(
+        counter,
+        |_state, left, right| left.min(right),
+        iter::empty(),
+        iter::empty(),
+    );
+    let expected = cont([4, 5, 6]);
+    let id = original.with_execution_state(|state| {
+        let containers = state.container_values();
+        containers.register_val(expected.clone(), state)
+    });
+    let mut cloned = original.clone();
+
+    assert!(original.merge_all());
+    assert!(cloned.merge_all());
+    assert_eq!(
+        original
+            .container_values()
+            .get_val::<VecContainer>(id)
+            .as_deref(),
+        Some(&expected)
+    );
+    assert_eq!(
+        cloned
+            .container_values()
+            .get_val::<VecContainer>(id)
+            .as_deref(),
+        Some(&expected)
+    );
+}
+
+#[test]
+fn sequence_merge_writes_participate_in_simple_fixed_point() {
+    let mut db = Database::new();
+    let sink = db.add_table(
+        SortedWritesTable::new(
+            2,
+            2,
+            None,
+            vec![],
+            Box::new(|_, current, incoming, _| {
+                assert_eq!(current, incoming);
+                false
+            }),
+        ),
+        iter::empty(),
+        iter::empty(),
+    );
+    let gate = db.add_table(
+        SortedWritesTable::new(1, 1, None, vec![], Box::new(|_, _, _, _| false)),
+        iter::empty(),
+        iter::empty(),
+    );
+    let counter = db.add_reservable_counter(8);
+    db.register_sequence_container_type::<VecContainer>(
+        counter,
+        move |state, left, right| {
+            assert_eq!(
+                state.get_table(gate).len(),
+                1,
+                "the simple scheduler must honor sequence read dependencies"
+            );
+            state.stage_insert(sink, &[left, right]);
+            left.min(right)
+        },
+        [gate.into()],
+        [sink],
+    );
+    db.with_execution_state(|state| {
+        state.stage_insert(gate, &[Value::from_usize(1)]);
+    });
+    let expected = cont([7, 8]);
+    let first = db.with_execution_state(|state| {
+        let containers = state.container_values();
+        containers.register_val(expected.clone(), state)
+    });
+    let second = db.with_execution_state(|state| {
+        let containers = state.container_values();
+        containers.register_val(expected, state)
+    });
+    assert_ne!(first, second);
+
+    assert!(db.merge_all());
+    assert_eq!(db.get_table(sink).len(), 1);
+}
+
+#[test]
+fn sequence_merge_writes_participate_in_dependency_aware_fixed_point() {
+    let mut db = Database::new();
+    let sink = db.add_table(
+        SortedWritesTable::new(
+            2,
+            2,
+            None,
+            vec![],
+            Box::new(|_, current, incoming, _| {
+                assert_eq!(current, incoming);
+                false
+            }),
+        ),
+        iter::empty(),
+        iter::empty(),
+    );
+    let mut add_flag_table = || {
+        db.add_table(
+            SortedWritesTable::new(1, 1, None, vec![], Box::new(|_, _, _, _| false)),
+            iter::empty(),
+            iter::empty(),
+        )
+    };
+    let gate = add_flag_table();
+    let first_bystander = add_flag_table();
+    let second_bystander = add_flag_table();
+    let counter = db.add_reservable_counter(8);
+    db.register_sequence_container_type::<VecContainer>(
+        counter,
+        move |state, left, right| {
+            assert_eq!(
+                state.get_table(gate).len(),
+                1,
+                "the sequence merge must run after its read dependency"
+            );
+            state.stage_insert(sink, &[left, right]);
+            left.min(right)
+        },
+        [gate.into()],
+        [sink],
+    );
+
+    db.with_execution_state(|state| {
+        state.stage_insert(gate, &[Value::from_usize(1)]);
+        state.stage_insert(first_bystander, &[Value::from_usize(2)]);
+        state.stage_insert(second_bystander, &[Value::from_usize(3)]);
+    });
+    let expected = cont([9, 10]);
+    let first = db.with_execution_state(|state| {
+        let containers = state.container_values();
+        containers.register_val(expected.clone(), state)
+    });
+    let second = db.with_execution_state(|state| {
+        let containers = state.container_values();
+        containers.register_val(expected, state)
+    });
+    assert_ne!(first, second);
+
+    // The sequence environment plus the three ordinary tables above force
+    // `merge_all` through its dependency-aware (four-or-more participant)
+    // path. The sequence merge then notifies the previously inactive sink,
+    // which must be consumed by the same call's fixed-point loop.
+    assert!(db.merge_all());
+    assert_eq!(db.get_table(sink).len(), 1);
+}
+
+#[test]
+fn relation_merge_can_depend_on_nonzero_level_sequence_container() {
+    let mut db = Database::new();
+    let gate = db.add_table(
+        SortedWritesTable::new(1, 1, None, vec![], Box::new(|_, _, _, _| false)),
+        iter::empty(),
+        iter::empty(),
+    );
+    let bystander = db.add_table(
+        SortedWritesTable::new(1, 1, None, vec![], Box::new(|_, _, _, _| false)),
+        iter::empty(),
+        iter::empty(),
+    );
+    let counter = db.add_reservable_counter(8);
+    let container = db.register_sequence_container_type::<VecContainer>(
+        counter,
+        |_state, left, right| left.min(right),
+        [gate.into()],
+        iter::empty(),
+    );
+    let expected = cont([11, 12]);
+    let relation = db.add_table_with_maintenance_deps(
+        SortedWritesTable::new(
+            1,
+            2,
+            None,
+            vec![],
+            Box::new({
+                let expected = expected.clone();
+                move |state, current, incoming, out| {
+                    let winner = current[0].min(incoming[0]);
+                    assert_eq!(
+                        state.container_sequence::<VecContainer>(winner),
+                        Some(expected.0.as_slice()),
+                        "the relation merge must run after its sequence dependency"
+                    );
+                    if current[0] == winner {
+                        false
+                    } else {
+                        out.push(winner);
+                        true
+                    }
+                }
+            }),
+        ),
+        [container.into()],
+        iter::empty(),
+    );
+
+    db.with_execution_state(|state| {
+        state.stage_insert(gate, &[Value::from_usize(1)]);
+        state.stage_insert(bystander, &[Value::from_usize(2)]);
+    });
+    let first = db.with_execution_state(|state| {
+        let containers = state.container_values();
+        containers.register_val(expected.clone(), state)
+    });
+    let second = db.with_execution_state(|state| {
+        let containers = state.container_values();
+        containers.register_val(expected, state)
+    });
+    assert_ne!(first, second);
+    db.with_execution_state(|state| {
+        state.stage_insert(relation, &[Value::from_usize(0), first]);
+        state.stage_insert(relation, &[Value::from_usize(0), second]);
+    });
+
+    assert!(db.merge_all());
+    assert_eq!(db.get_table(relation).len(), 1);
+}
+
+#[test]
+fn failed_table_dependency_registration_does_not_mutate_database() {
+    let mut db = Database::new();
+    let expected_id = db.next_table_id();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        db.add_table(
+            SortedWritesTable::new(1, 1, None, vec![], Box::new(|_, _, _, _| false)),
+            [expected_id],
+            iter::empty(),
+        );
+    }));
+    assert!(result.is_err());
+
+    let actual_id = db.add_table(
+        SortedWritesTable::new(1, 1, None, vec![], Box::new(|_, _, _, _| false)),
+        iter::empty(),
+        iter::empty(),
+    );
+    assert_eq!(actual_id, expected_id);
+    db.with_execution_state(|state| {
+        state.stage_insert(actual_id, &[Value::from_usize(1)]);
+    });
+    assert!(db.merge_all());
+    assert_eq!(db.get_table(actual_id).len(), 1);
+}
+
+#[test]
+fn failed_sequence_dependency_registration_can_be_retried() {
+    let mut db = Database::new();
+    let counter = db.add_reservable_counter(8);
+    let missing_table = db.next_table_id();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        db.register_sequence_container_type::<VecContainer>(
+            counter,
+            |_state, left, right| left.min(right),
+            [missing_table.into()],
+            iter::empty(),
+        );
+    }));
+    assert!(result.is_err());
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        db.register_sequence_container_type::<VecContainer>(
+            counter,
+            |_state, left, right| left.min(right),
+            iter::empty(),
+            [missing_table],
+        );
+    }));
+    assert!(result.is_err());
+
+    let container = db.register_sequence_container_type::<VecContainer>(
+        counter,
+        |_state, left, right| left.min(right),
+        iter::empty(),
+        iter::empty(),
+    );
+    let duplicate = db.register_sequence_container_type::<VecContainer>(
+        counter,
+        |_state, left, right| left.max(right),
+        [missing_table.into()],
+        [missing_table],
+    );
+    assert_eq!(duplicate, container, "the first registration owns the deps");
+    let expected = cont([13, 14]);
+    db.with_execution_state(|state| {
+        let containers = state.container_values();
+        containers.register_val(expected, state);
+    });
+    assert!(db.merge_all());
+    assert_eq!(db.container_values().env_len(container), 1);
 }

--- a/core-relations/src/dependency_graph.rs
+++ b/core-relations/src/dependency_graph.rs
@@ -1,64 +1,87 @@
 //! A simple data-structure for tracking the dependencies of the merge functions
 //! from different tables on one another.
 
-use crate::numeric_id::{DenseIdMap, NumericId, define_id};
+use crate::numeric_id::{DenseIdMap, define_id};
 
 use crate::{TableId, common::IndexSet};
 
 define_id!(
-    LevelId,
+    pub(crate) MaintenanceId,
     u32,
-    "an identifier for a level in the dependency graph"
+    "an identifier for a database maintenance participant"
 );
 
 #[derive(Clone, Default)]
 pub(crate) struct DependencyGraph {
-    levels: DenseIdMap<LevelId, IndexSet<TableId>>,
-    to_level: DenseIdMap<TableId, LevelId>,
-    write_deps: DenseIdMap<TableId, IndexSet<TableId>>,
+    to_level: DenseIdMap<MaintenanceId, usize>,
+    write_deps: DenseIdMap<MaintenanceId, IndexSet<TableId>>,
 }
 
 impl DependencyGraph {
-    /// Register a table's dependencies with the dependency graph.
+    /// Register one maintenance participant with the dependency graph.
     ///
-    /// Tables can have two kinds of dependences:
-    /// 1. Read dependencies are tables that must be readable during the table's merge function.
-    /// 2. Write dependencies are tables that must merely be writable during the table's merge
-    ///    function.
+    /// Participants can have two kinds of dependencies:
+    /// 1. Read dependencies are participants whose storage must remain readable
+    ///    during this participant's merge function.
+    /// 2. Write dependencies are fixed-arity tables that must merely be
+    ///    writable during this participant's merge function.
     ///
     /// Write dependencies are generally weaker than read dependencies. Two tables with write
     /// dependencies on one another can run their merge operations in parallel. The same is not
     /// true for read dependencies.
-    pub(crate) fn add_table(
+    pub(crate) fn add_participant(
         &mut self,
-        table: TableId,
-        read_deps: impl IntoIterator<Item = TableId>,
+        participant: MaintenanceId,
+        read_deps: impl IntoIterator<Item = MaintenanceId>,
         write_deps: impl IntoIterator<Item = TableId>,
     ) {
-        self.write_deps.get_or_default(table).extend(write_deps);
+        self.write_deps
+            .get_or_default(participant)
+            .extend(write_deps);
         assert!(
-            self.to_level.get(table).is_none(),
-            "table {table:?} already added to graph"
+            self.to_level.get(participant).is_none(),
+            "maintenance participant {participant:?} already added to graph"
         );
-        let level = match read_deps
-            .into_iter()
-            .map(|dep| *self.to_level.get(dep).unwrap())
-            .max()
-        {
-            Some(level) => level.inc(),
-            None => LevelId::new(0),
+        let level = match read_deps.into_iter().map(|dep| self.to_level[dep]).max() {
+            Some(level) => level + 1,
+            None => 0,
         };
-        self.to_level.insert(table, level);
-        self.levels.get_or_default(level).insert(table);
+        self.to_level.insert(participant, level);
     }
 
-    pub(crate) fn strata(&self) -> impl Iterator<Item = &IndexSet<TableId>> {
-        self.levels.iter().map(|(_, tables)| tables)
+    pub(crate) fn level(&self, participant: MaintenanceId) -> usize {
+        self.to_level[participant]
     }
-    pub(crate) fn write_deps(&self, table: TableId) -> impl Iterator<Item = TableId> + '_ {
+
+    pub(crate) fn write_deps(
+        &self,
+        participant: MaintenanceId,
+    ) -> impl Iterator<Item = TableId> + '_ {
         self.write_deps
-            .get(table)
+            .get(participant)
             .into_iter()
             .flat_map(|deps| deps.iter().copied())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::numeric_id::NumericId;
+
+    #[test]
+    fn maintenance_levels_keep_table_write_dependencies() {
+        let first = MaintenanceId::new(0);
+        let second = MaintenanceId::new(1);
+        let sink = TableId::new(7);
+        let mut graph = DependencyGraph::default();
+
+        graph.add_participant(first, [], [sink]);
+        graph.add_participant(second, [first], []);
+
+        assert_eq!(graph.level(first), 0);
+        assert_eq!(graph.level(second), 1);
+        assert_eq!(graph.write_deps(first).collect::<Vec<_>>(), vec![sink]);
+        assert!(graph.write_deps(second).next().is_none());
     }
 }

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use crate::{
-    common::IndexSet,
     hash_index::IndexCatalog,
     numeric_id::{DenseIdMap, DenseIdMapWithReuse, NumericId, define_id},
 };
@@ -17,12 +16,13 @@ use egglog_concurrency::{NotificationList, ResettableOnceLock};
 use smallvec::SmallVec;
 
 use crate::{
-    BaseValues, ContainerRebuildSummary, ContainerValues, PoolSet, QueryEntry, TupleIndex, Value,
+    BaseValues, ContainerValues, PoolSet, QueryEntry, TupleIndex, Value,
     action::{
         Bindings, DbView,
         mask::{Mask, MaskIter, ValueSource},
     },
-    dependency_graph::DependencyGraph,
+    containers::SequenceContainerValue,
+    dependency_graph::{DependencyGraph, MaintenanceId},
     hash_index::{ColumnIndex, Index, IndexBase},
     offsets::Subset,
     parallel,
@@ -66,6 +66,37 @@ impl TableId {
 
     pub fn is_dummy(&self) -> bool {
         self.rep == u32::MAX
+    }
+}
+
+/// A storage participant that must be readable before another participant's
+/// merge callback runs.
+///
+/// Write dependencies remain relation-table ids because they are used to
+/// preallocate [`MutationBuffer`]s while a relation stratum is temporarily
+/// removed from the database. Sequence-container buffers are initialized
+/// lazily and their environments remain installed during relation merges.
+///
+/// Dependencies must refer to participants that were previously registered in
+/// the same [`Database`]. This registration order makes the dependency graph
+/// acyclic. A [`MaintenanceReadDependency::SequenceContainer`] must name a
+/// sequence-backed container; legacy container environments are not scheduler
+/// participants.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MaintenanceReadDependency {
+    Table(TableId),
+    SequenceContainer(crate::ContainerValueId),
+}
+
+impl From<TableId> for MaintenanceReadDependency {
+    fn from(table: TableId) -> Self {
+        Self::Table(table)
+    }
+}
+
+impl From<crate::ContainerValueId> for MaintenanceReadDependency {
+    fn from(container: crate::ContainerValueId) -> Self {
+        Self::SequenceContainer(container)
     }
 }
 
@@ -366,7 +397,7 @@ impl Counters {
 /// A collection of tables and indexes over them.
 ///
 /// A database also owns the memory pools used by its tables.
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub struct Database {
     // NB: some fields are pub(crate) to allow some internal modules to avoid
     // borrowing the whole table.
@@ -376,10 +407,13 @@ pub struct Database {
     pub(crate) counters: Counters,
     pub(crate) external_functions: ExternalFunctions,
     container_values: ContainerValues,
-    /// `notification_list` contains the list of tables that have been modified since the last call
-    /// to [`Database::merge_all`].
-    notification_list: NotificationList<TableId>,
-    // Tracks the relative dependencies between tables during merge operations.
+    /// Maps the common maintenance namespace to its concrete storage owner.
+    maintenance_targets: DenseIdMap<MaintenanceId, MaintenanceTarget>,
+    table_maintenance: DenseIdMap<TableId, MaintenanceId>,
+    container_maintenance: DenseIdMap<crate::ContainerValueId, MaintenanceId>,
+    /// Participants modified since the last call to [`Database::merge_all`].
+    notification_list: NotificationList<MaintenanceId>,
+    // Tracks relative dependencies between maintenance participants.
     deps: DependencyGraph,
     base_values: BaseValues,
     /// A rough estimate of the total size of the database.
@@ -387,6 +421,41 @@ pub struct Database {
     /// This is primarily used to determine whether or not to attempt to do some operations in
     /// parallel.
     total_size_estimate: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum MaintenanceTarget {
+    Relation(TableId),
+    SequenceContainer(crate::ContainerValueId),
+}
+
+impl Clone for Database {
+    fn clone(&self) -> Self {
+        // Table/container storage owns a deep copy of its pending mutation
+        // epochs, so the scheduler queue must be independent too. The normal
+        // `NotificationList::clone` shares one queue; either database could
+        // then consume the other's only wakeup. Conservatively scheduling all
+        // copied participants preserves every pending epoch without mutating
+        // the source queue, and harmlessly performs one empty merge for
+        // participants that had no work.
+        let notification_list = NotificationList::default();
+        for (participant, _) in self.maintenance_targets.iter() {
+            notification_list.notify(participant);
+        }
+        Self {
+            tables: self.tables.clone(),
+            counters: self.counters.clone(),
+            external_functions: self.external_functions.clone(),
+            container_values: self.container_values.clone(),
+            maintenance_targets: self.maintenance_targets.clone(),
+            table_maintenance: self.table_maintenance.clone(),
+            container_maintenance: self.container_maintenance.clone(),
+            notification_list,
+            deps: self.deps.clone(),
+            base_values: self.base_values.clone(),
+            total_size_estimate: self.total_size_estimate,
+        }
+    }
 }
 
 impl Database {
@@ -432,26 +501,114 @@ impl Database {
         &mut self.container_values
     }
 
-    pub fn rebuild_containers(&mut self, table_id: TableId) -> ContainerRebuildSummary {
-        let mut containers = mem::take(&mut self.container_values);
-        let table = &self.tables[table_id].table;
-        let res = self.with_execution_state(|state| containers.rebuild_all(table_id, table, state));
-        self.container_values = containers;
-        res
+    /// Register a sequence-backed container as a normal database maintenance
+    /// participant. Its packed rows remain outside the fixed-schema query
+    /// table interface, but merge notifications and dependency ordering share
+    /// the same scheduler namespace as relation tables.
+    ///
+    /// Registration is idempotent by concrete Rust type. The first call fixes
+    /// that type's counter, merge callback, and dependency set; later calls
+    /// return the existing [`crate::ContainerValueId`].
+    ///
+    /// Every read and write dependency must already be registered in this
+    /// database. Container read dependencies must use the sequence backend.
+    pub fn register_sequence_container_type<C: SequenceContainerValue>(
+        &mut self,
+        id_counter: CounterId,
+        merge_fn: impl Fn(&mut ExecutionState, Value, Value) -> Value + Clone + Send + Sync + 'static,
+        read_deps: impl IntoIterator<Item = MaintenanceReadDependency>,
+        write_deps: impl IntoIterator<Item = TableId>,
+    ) -> crate::ContainerValueId {
+        if let Some(container) = self.container_values.registered_sequence_type::<C>() {
+            let existing = self
+                .container_maintenance
+                .get(container)
+                .expect("registered sequence container must have a maintenance target");
+            debug_assert!(matches!(
+                self.maintenance_targets[*existing],
+                MaintenanceTarget::SequenceContainer(id) if id == container
+            ));
+            return container;
+        }
+
+        let read_deps = read_deps.into_iter().collect::<Vec<_>>();
+        let write_deps = write_deps.into_iter().collect::<Vec<_>>();
+        let read_deps = read_deps
+            .into_iter()
+            .map(|dependency| self.resolve_maintenance_dependency(dependency))
+            .collect::<Vec<_>>();
+        self.validate_write_dependencies(&write_deps);
+
+        let container = self
+            .container_values
+            .register_sequence_type::<C>(id_counter, merge_fn);
+        let maintenance = self
+            .maintenance_targets
+            .push(MaintenanceTarget::SequenceContainer(container));
+        self.container_maintenance.insert(container, maintenance);
+        self.deps
+            .add_participant(maintenance, read_deps, write_deps);
+        container
     }
 
-    /// Apply the value-level rebuild encoded by `func_id` to all the tables in `to_rebuild`.
+    fn resolve_maintenance_dependency(
+        &self,
+        dependency: MaintenanceReadDependency,
+    ) -> MaintenanceId {
+        match dependency {
+            MaintenanceReadDependency::Table(table) => *self
+                .table_maintenance
+                .get(table)
+                .unwrap_or_else(|| panic!("table dependency {table:?} is not registered")),
+            MaintenanceReadDependency::SequenceContainer(container) => *self
+                .container_maintenance
+                .get(container)
+                .unwrap_or_else(|| {
+                    panic!("sequence-container dependency {container:?} is not registered")
+                }),
+        }
+    }
+
+    fn validate_write_dependencies(&self, dependencies: &[TableId]) {
+        for table in dependencies {
+            assert!(
+                self.table_maintenance.get(*table).is_some(),
+                "table write dependency {table:?} is not registered"
+            );
+        }
+    }
+
+    /// Apply one ordered database-maintenance cycle using the value-level
+    /// rebuild encoded by `func_id`.
     ///
-    /// The native [`Table::apply_rebuild`] method takes a `next_ts` argument for filling in new
-    /// values in a table like [`crate::SortedWritesTable`] where values in a certain column need
-    /// to be inserted in sorted order; the `next_ts` argument to this method is passed to
-    /// `apply_rebuild` for this purpose.
+    /// Sequence-backed containers use the same notification/dependency
+    /// scheduler as relation tables; legacy environments remain a rebuild-only
+    /// compatibility pass. Container canonicalization runs first because key
+    /// collisions can stage ordinary union-find writes. The common
+    /// [`Database::merge_all`] fixed point publishes those writes before
+    /// dependent fixed-schema relations rebuild. Stable container identities
+    /// are then propagated through the temporary opaque-read refresh path.
     pub fn apply_rebuild(
         &mut self,
         func_id: TableId,
         to_rebuild: &[TableId],
         next_ts: Value,
     ) -> bool {
+        let container_rebuild = {
+            let mut containers = mem::take(&mut self.container_values);
+            let table = &self.tables[func_id].table;
+            let result =
+                self.with_execution_state(|state| containers.rebuild_all(func_id, table, state));
+            self.container_values = containers;
+            result
+        };
+
+        let mut changed = container_rebuild.changed();
+        // This is a correctness barrier, not a separate fixed point: relation
+        // rebuilds must observe identity unions produced by container-key
+        // collisions (notably for :no-merge functions).
+        changed |= self.merge_all();
+
         let func = self.tables.take(func_id).unwrap();
         self.run_on_tables(to_rebuild, |_, info, view| {
             info.table.apply_rebuild(
@@ -462,29 +619,23 @@ impl Database {
             )
         });
         self.tables.insert(func_id, func);
-        self.merge_all()
-    }
+        // Ordinary table rebuilds stage their replacements. Publish those
+        // rows before dirty-id refresh scans the tables, otherwise the refresh
+        // can re-stage an obsolete pre-rebuild row.
+        changed |= self.merge_all();
 
-    pub fn refresh_rows_for_values(
-        &mut self,
-        to_refresh: &[TableId],
-        dirty_ids: &[Value],
-        next_ts: Value,
-    ) -> bool {
-        if dirty_ids.is_empty() {
-            return false;
+        let dirty_ids = container_rebuild
+            .dirty_ids()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+        if !dirty_ids.is_empty() {
+            self.run_on_tables(to_rebuild, |_, info, _| {
+                info.table.refresh_rows_for_values(&dirty_ids, next_ts)
+            });
+            changed |= self.merge_all();
         }
-        // This is the follow-up for `ContainerRebuildSummary::dirty_ids()`.
-        // These ids changed semantics without changing identity, so parent
-        // rows can become newly matchable without getting an ordinary table
-        // delta.
-        //
-        // It must run after ordinary table rebuild, which already handles
-        // changed-id cases by rewriting parent rows to the new id.
-        self.run_on_tables(to_refresh, |_, info, _| {
-            info.table.refresh_rows_for_values(dirty_ids, next_ts)
-        });
-        self.merge_all()
+        changed
     }
 
     fn run_on_tables(
@@ -500,7 +651,7 @@ impl Database {
             let view = self.read_only_view();
             parallel::for_each_mut(&mut tables, |_, (id, info)| {
                 if run(*id, info, &view) {
-                    self.notification_list.notify(*id);
+                    self.notification_list.notify(self.table_maintenance[*id]);
                 }
             });
             for (id, info) in tables {
@@ -514,7 +665,7 @@ impl Database {
                     run(*id, &mut info, &view)
                 };
                 if changed {
-                    self.notification_list.notify(*id);
+                    self.notification_list.notify(self.table_maintenance[*id]);
                 }
                 self.tables.insert(*id, info);
             }
@@ -547,6 +698,8 @@ impl Database {
             bases: &self.base_values,
             containers: &self.container_values,
             notification_list: &self.notification_list,
+            table_maintenance: &self.table_maintenance,
+            container_maintenance: &self.container_maintenance,
         }
     }
 
@@ -614,48 +767,77 @@ impl Database {
     pub fn merge_all(&mut self) -> bool {
         let mut ever_changed = false;
         let do_parallel = parallelize_db_level_op(self.total_size_estimate);
-        let mut to_merge = IndexSet::default();
         loop {
-            to_merge.clear();
-            let to_merge_vec = self.notification_list.reset();
-            if to_merge_vec.len() < 4 {
-                ever_changed |= self.merge_simple(to_merge_vec);
+            let mut active = self.notification_list.reset();
+            if active.len() < 4 {
+                ever_changed |= self.merge_simple(active);
                 break;
             }
-            for table in to_merge_vec {
-                to_merge.insert(table);
-            }
+            active.sort_unstable_by_key(|participant| self.deps.level(*participant));
 
             let mut changed = false;
-            let mut tables_merging = DenseIdMap::<
+            let mut stratum_start = 0;
+            let mut tables_merging = Vec::<(
                 TableId,
-                (
-                    // The info needed to merge this table.
-                    Option<TableInfo>,
-                    // Pre-allocated write buffers, according to the tables declared write
-                    // dependencies.
-                    DenseIdMap<TableId, Box<dyn MutationBuffer>>,
-                ),
-            >::with_capacity(self.tables.n_ids());
-            for stratum in self.deps.strata() {
-                // Initialize the write dependencies first.
-                for table in stratum.intersection(&to_merge).copied() {
+                Option<TableInfo>,
+                DenseIdMap<TableId, Box<dyn MutationBuffer>>,
+            )>::new();
+            while stratum_start < active.len() {
+                let level = self.deps.level(active[stratum_start]);
+                let stratum_end = active[stratum_start..]
+                    .iter()
+                    .position(|participant| self.deps.level(*participant) != level)
+                    .map_or(active.len(), |offset| stratum_start + offset);
+                let stratum = &active[stratum_start..stratum_end];
+
+                // Keep sequence environments locally owned and merge them one
+                // at a time. This leaves every other environment visible to a
+                // merge callback while still using the common scheduler and
+                // notification fixed point.
+                let sequence_participants = stratum
+                    .iter()
+                    .copied()
+                    .filter_map(|participant| match self.maintenance_targets[participant] {
+                        MaintenanceTarget::SequenceContainer(container) => {
+                            Some((participant, container))
+                        }
+                        MaintenanceTarget::Relation(_) => None,
+                    })
+                    .collect::<Vec<_>>();
+                for (participant, container) in sequence_participants {
                     let mut bufs = DenseIdMap::default();
-                    for dep in self.deps.write_deps(table) {
+                    for dep in self.deps.write_deps(participant) {
                         if let Some(info) = self.tables.get(dep) {
                             bufs.insert(dep, info.table.new_buffer());
                         }
                     }
-                    tables_merging.insert(table, (None, bufs));
+                    changed |= self.merge_sequence_container(container, bufs);
                 }
-                // Then initialize read dependencies (this two-phase structure is why we have an
-                // Option in the tables_merging map).
-                for table in stratum.intersection(&to_merge).copied() {
-                    tables_merging[table].0 = Some(self.tables.unwrap_val(table));
+
+                let relation_participants = stratum
+                    .iter()
+                    .copied()
+                    .filter_map(|participant| match self.maintenance_targets[participant] {
+                        MaintenanceTarget::Relation(table) => Some((participant, table)),
+                        MaintenanceTarget::SequenceContainer(_) => None,
+                    })
+                    .collect::<Vec<_>>();
+                tables_merging.reserve(relation_participants.len());
+                for (participant, table) in &relation_participants {
+                    let mut bufs = DenseIdMap::default();
+                    for dep in self.deps.write_deps(*participant) {
+                        if let Some(info) = self.tables.get(dep) {
+                            bufs.insert(dep, info.table.new_buffer());
+                        }
+                    }
+                    tables_merging.push((*table, None, bufs));
+                }
+                for (table, info, _) in &mut tables_merging {
+                    *info = Some(self.tables.unwrap_val(*table));
                 }
                 let db = self.read_only_view();
                 changed |= if do_parallel {
-                    parallel::map_dense_id_map_mut(&mut tables_merging, |_, (info, buffers)| {
+                    parallel::map_mut(&mut tables_merging, |_, (_, info, buffers)| {
                         let mut es = ExecutionState::new(db, mem::take(buffers));
                         info.as_mut().unwrap().table.merge(&mut es).added || es.changed
                     })
@@ -664,16 +846,17 @@ impl Database {
                 } else {
                     tables_merging
                         .iter_mut()
-                        .map(|(_, (info, buffers))| {
+                        .map(|(_, info, buffers)| {
                             let mut es = ExecutionState::new(db, mem::take(buffers));
                             info.as_mut().unwrap().table.merge(&mut es).added || es.changed
                         })
                         .max()
                         .unwrap_or(false)
                 };
-                for (id, (table, _)) in tables_merging.drain() {
+                for (id, table, _) in tables_merging.drain(..) {
                     self.tables.insert(id, table.unwrap());
                 }
+                stratum_start = stratum_end;
             }
             ever_changed |= changed;
         }
@@ -688,21 +871,58 @@ impl Database {
             });
             size_estimate += info.table.len();
         }
+        size_estimate += self.container_values.sequence_len();
         self.total_size_estimate = size_estimate;
         ever_changed
     }
 
-    /// A "fast path" merge method that is not optimized for parallelism and does not respect read
-    /// and write dependencies. This ends up being faster than the full "strata-aware" option in
-    /// the body of `merge_all`.
-    fn merge_simple(&mut self, mut to_merge: SmallVec<[TableId; 4]>) -> bool {
+    fn merge_sequence_container(
+        &mut self,
+        container: crate::ContainerValueId,
+        buffers: DenseIdMap<TableId, Box<dyn MutationBuffer>>,
+    ) -> bool {
+        let mut env = self.container_values.take_env(container);
+        let changed = {
+            let mut exec_state = ExecutionState::new(self.read_only_view(), buffers);
+            env.merge_pending(&mut exec_state) || exec_state.changed
+        };
+        self.container_values.put_env(container, env);
+        changed
+    }
+
+    /// A serial fast path for a small number of notified participants.
+    ///
+    /// It follows read-dependency strata, but avoids taking a whole stratum out
+    /// of the database and preallocating its declared write buffers. With only
+    /// a few participants, leaving each destination table installed lets
+    /// [`ExecutionState`] initialize those buffers lazily.
+    fn merge_simple(&mut self, mut to_merge: SmallVec<[MaintenanceId; 4]>) -> bool {
         let mut changed = false;
         while !to_merge.is_empty() {
-            for table_id in to_merge.iter().copied() {
-                let mut info = self.tables.unwrap_val(table_id);
-                let mut es = ExecutionState::new(self.read_only_view(), Default::default());
-                changed |= info.table.merge(&mut es).added || es.changed;
-                self.tables.insert(table_id, info);
+            // Even this small serial path must respect read dependencies:
+            // sequence merge callbacks are allowed to observe an ordinary
+            // table declared as a predecessor. Within one stratum, run
+            // sequence storage first so relation merges can consume writes it
+            // publishes without waiting for another fixed-point turn.
+            to_merge.sort_unstable_by_key(|participant| {
+                let target_order = match self.maintenance_targets[*participant] {
+                    MaintenanceTarget::SequenceContainer(_) => 0usize,
+                    MaintenanceTarget::Relation(_) => 1usize,
+                };
+                (self.deps.level(*participant), target_order)
+            });
+            for participant in to_merge.iter().copied() {
+                match self.maintenance_targets[participant] {
+                    MaintenanceTarget::SequenceContainer(container) => {
+                        changed |= self.merge_sequence_container(container, Default::default());
+                    }
+                    MaintenanceTarget::Relation(table) => {
+                        let mut info = self.tables.unwrap_val(table);
+                        let mut es = ExecutionState::new(self.read_only_view(), Default::default());
+                        changed |= info.table.merge(&mut es).added || es.changed;
+                        self.tables.insert(table, info);
+                    }
+                }
             }
             to_merge = self.notification_list.reset();
         }
@@ -738,21 +958,59 @@ impl Database {
     /// Add a table with the given schema to the database.
     ///
     /// The table must have a compatible spec with `types` (e.g. same number of
-    /// columns).
+    /// columns). Every read and write dependency must identify a table already
+    /// registered in this database.
     pub fn add_table<T: Table + Sized + 'static>(
         &mut self,
         table: T,
         read_deps: impl IntoIterator<Item = TableId>,
         write_deps: impl IntoIterator<Item = TableId>,
     ) -> TableId {
+        self.add_table_impl(
+            table,
+            None,
+            read_deps.into_iter().map(MaintenanceReadDependency::from),
+            write_deps,
+        )
+    }
+
+    /// Add a table whose merge callback may read relation tables, sequence
+    /// containers, or both.
+    ///
+    /// Every read and write dependency must already be registered in this
+    /// database. This ordering keeps the graph acyclic, and container read
+    /// dependencies must use the sequence backend.
+    pub fn add_table_with_maintenance_deps<T: Table + Sized + 'static>(
+        &mut self,
+        table: T,
+        read_deps: impl IntoIterator<Item = MaintenanceReadDependency>,
+        write_deps: impl IntoIterator<Item = TableId>,
+    ) -> TableId {
         self.add_table_impl(table, None, read_deps, write_deps)
     }
 
+    /// Named variant of [`Database::add_table`].
     pub fn add_table_named<T: Table + Sized + 'static>(
         &mut self,
         table: T,
         name: Arc<str>,
         read_deps: impl IntoIterator<Item = TableId>,
+        write_deps: impl IntoIterator<Item = TableId>,
+    ) -> TableId {
+        self.add_table_impl(
+            table,
+            Some(name),
+            read_deps.into_iter().map(MaintenanceReadDependency::from),
+            write_deps,
+        )
+    }
+
+    /// Named variant of [`Database::add_table_with_maintenance_deps`].
+    pub fn add_table_named_with_maintenance_deps<T: Table + Sized + 'static>(
+        &mut self,
+        table: T,
+        name: Arc<str>,
+        read_deps: impl IntoIterator<Item = MaintenanceReadDependency>,
         write_deps: impl IntoIterator<Item = TableId>,
     ) -> TableId {
         self.add_table_impl(table, Some(name), read_deps, write_deps)
@@ -762,9 +1020,17 @@ impl Database {
         &mut self,
         table: T,
         name: Option<Arc<str>>,
-        read_deps: impl IntoIterator<Item = TableId>,
+        read_deps: impl IntoIterator<Item = MaintenanceReadDependency>,
         write_deps: impl IntoIterator<Item = TableId>,
     ) -> TableId {
+        let read_deps = read_deps.into_iter().collect::<Vec<_>>();
+        let write_deps = write_deps.into_iter().collect::<Vec<_>>();
+        let read_deps = read_deps
+            .into_iter()
+            .map(|dependency| self.resolve_maintenance_dependency(dependency))
+            .collect::<Vec<_>>();
+        self.validate_write_dependencies(&write_deps);
+
         let spec = table.spec();
         let table = WrappedTable::new(table);
         let res = self.tables.push(TableInfo {
@@ -774,7 +1040,12 @@ impl Database {
             indexes: IndexCatalog::new(),
             column_indexes: IndexCatalog::new(),
         });
-        self.deps.add_table(res, read_deps, write_deps);
+        let maintenance = self
+            .maintenance_targets
+            .push(MaintenanceTarget::Relation(res));
+        self.table_maintenance.insert(res, maintenance);
+        self.deps
+            .add_participant(maintenance, read_deps, write_deps);
         res
     }
 
@@ -816,7 +1087,7 @@ impl Database {
     /// Unlike calling [`Table::new_buffer`] on a table returned from a getter, this method also
     /// triggers change notification metadata that is read by [`Database::merge_all`].
     pub fn new_buffer(&self, id: TableId) -> Box<dyn MutationBuffer> {
-        self.notification_list.notify(id);
+        self.notification_list.notify(self.table_maintenance[id]);
         self.get_table(id).new_buffer()
     }
 

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -26,10 +26,13 @@ mod tests;
 pub use action::{ExecutionState, MergeVal, QueryEntry, WriteVal};
 pub use base_values::{BaseValue, BaseValueId, BaseValuePrinter, BaseValues, Boxed};
 pub use common::Value;
-pub use containers::{ContainerRebuildSummary, ContainerValue, ContainerValueId, ContainerValues};
+pub use containers::{
+    ContainerRebuildSummary, ContainerValue, ContainerValueId, ContainerValues,
+    SequenceContainerValue,
+};
 pub use free_join::{
-    AtomId, CounterId, Database, ExternalFunction, ExternalFunctionId, TableId, Variable,
-    make_external_func, plan::PlanStrategy,
+    AtomId, CounterId, Database, ExternalFunction, ExternalFunctionId, MaintenanceReadDependency,
+    TableId, Variable, make_external_func, plan::PlanStrategy,
 };
 pub use hash_index::TupleIndex;
 #[doc(hidden)]

--- a/core-relations/src/table/sequence.rs
+++ b/core-relations/src/table/sequence.rs
@@ -1012,6 +1012,10 @@ impl SequenceTable {
         Box::new(self.new_sequence_buffer())
     }
 
+    pub(crate) fn shard_data(&self) -> ShardData {
+        self.hash.shard_data()
+    }
+
     /// Publish staged set mutations for a table with no non-key values.
     ///
     /// Removals are applied before insertions, so removing and inserting the

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -19,8 +19,8 @@ use std::{
 use crate::core_relations::{
     BaseValue, BaseValueId, BaseValues, ColumnId, Constraint, ContainerValue, ContainerValues,
     CounterId, Database, DisplacedTable, ExecutionState, ExternalFunction, ExternalFunctionId,
-    MergeVal, Offset, PlanStrategy, SortedWritesTable, TableId, TaggedRowBuffer, Value,
-    WrappedTable,
+    MergeVal, Offset, PlanStrategy, SequenceContainerValue, SortedWritesTable, TableId,
+    TaggedRowBuffer, Value, WrappedTable,
 };
 use crate::numeric_id::{DenseIdMap, DenseIdMapWithReuse, NumericId, define_id};
 use egglog_concurrency::ThreadPool;
@@ -303,8 +303,14 @@ impl EGraph {
     /// Intern the given container value into the EGraph.
     pub fn get_container_value<C: ContainerValue>(&mut self, val: C) -> Value {
         self.register_container_ty::<C>();
-        self.db
-            .with_execution_state(|state| state.clone().container_values().register_val(val, state))
+        let (value, changed) = self.db.with_execution_state_tracked(|state| {
+            let containers = state.container_values();
+            containers.register_val(val, state)
+        });
+        if changed {
+            self.flush_updates();
+        }
+        value
     }
 
     /// Register the given [`ContainerValue`] type with this EGraph.
@@ -325,6 +331,26 @@ impl EGraph {
                     old
                 }
             },
+        );
+    }
+
+    /// Register a container using the variable-arity sequence-table backend.
+    pub fn register_sequence_container_ty<C: SequenceContainerValue>(&mut self) {
+        let uf_table = self.uf_table;
+        let ts_counter = self.timestamp_counter;
+        self.db.register_sequence_container_type::<C>(
+            self.id_counter,
+            move |state, old, new| {
+                if old != new {
+                    let next_ts = Value::from_usize(state.read_counter(ts_counter));
+                    state.stage_insert(uf_table, &[old, new, next_ts]);
+                    std::cmp::min(old, new)
+                } else {
+                    old
+                }
+            },
+            std::iter::empty(),
+            [uf_table],
         );
     }
 
@@ -707,49 +733,10 @@ impl EGraph {
                 tables.push(func.table);
             }
             loop {
-                // Order matters here: we need to rebuild containers first and then rebuild the
-                // tables. Why?
-                //
-                // Say we have a sort that can map to and from a vector containing only itself:
-                // (sort X)
-                // (function to-vec (X) (Vec X) :no-merge)
-                // (constructor from-vec (Vec X) X)
-                // (constructor Num (i64) X)
-                // (constructor Add (X X) X)
-                //
-                // Along with rules:
-                // (rule ((= x (Num i))) ((set (to-vec x) (vec-of x))))
-                // (rule ((= x (Add i j))) ((set (to-vec x) (vec-of x))))
-                // (rule ((= x (from-vec v))) ((set (to-vec x) v))
-                // (rewrite (Add (Num i) (Num j)) (Num (+ i j)))
-                //
-                // These rules, while redundant, should be safe. However, if we rebuild tables
-                // before containers some schedules can cause us to violate the `:no-merge`
-                // directive, which asserts that all values written for a key are equal.
-                //
-                // Suppose we start off with x1=(Num 1), x2=(Num 3), and x3=(Add (Num 1) (Num 2)) as
-                // expressions, with `to-vec` and `from-vec` entries for all three expressions.
-                // We'll call (to-vec xi) vi for all i.
-                //
-                // Now suppose we run the `rewrite` above: now, x3 = x2. But v3 will only equal v2
-                // _after_ we rebuild the `Vec` container. That means that if we rebuild `to-vec`
-                // we will collapse the the rows for x3 and x2, but then fail to merge v3 and v2
-                // because they are not (yet) equal.
-                //
-                // Rebuilding containers first will find that v3 and v2 are equal, and the rest of
-                // the rules can proceed.
-                let container_rebuild = self.db.rebuild_containers(self.uf_table);
                 let next_ts = self.next_ts().to_value();
-                let table_rebuild = self.db.apply_rebuild(self.uf_table, &tables, next_ts);
-                // Container rebuild can make a parent row newly matchable without
-                // changing the row's stored id. Re-timestamp those parents so
-                // seminaive sees the newly enabled match on the next pass.
-                let dirty_ids: Vec<Value> = container_rebuild.dirty_ids().iter().copied().collect();
-                let refreshed_rows = self
-                    .db
-                    .refresh_rows_for_values(&tables, &dirty_ids, next_ts);
+                let changed = self.db.apply_rebuild(self.uf_table, &tables, next_ts);
                 self.inc_ts();
-                if !table_rebuild && !refreshed_rows && !container_rebuild.changed() {
+                if !changed {
                     break;
                 }
             }

--- a/src/exec_state.rs
+++ b/src/exec_state.rs
@@ -194,12 +194,33 @@ pub trait Core<'a, 'db: 'a>: Internal<'a, 'db> {
         self.es().base_values().get::<T>(x)
     }
 
-    /// Look up the Rust container behind an egglog [`Value`], if any.
+    /// Look up a committed Rust container behind an egglog [`Value`].
     fn value_to_container<T: ContainerValue>(
         &self,
         x: Value,
     ) -> Option<impl Deref<Target = T> + 'a> {
         self.es().container_values().get_val::<T>(x)
+    }
+
+    /// Reconstruct a container visible to this execution, including a local
+    /// prediction. This is the explicit slow sequence-container path.
+    fn value_to_owned_container<T: ContainerValue>(&self, x: Value) -> Option<T> {
+        self.es().get_container::<T>(x)
+    }
+
+    /// Run `f` over the fast serialized payload of a sequence-backed container
+    /// without reconstructing its Rust container.
+    fn with_container_sequence<T: ContainerValue, R>(
+        &self,
+        x: Value,
+        f: impl FnOnce(&[Value]) -> R,
+    ) -> Option<R> {
+        self.es().container_sequence::<T>(x).map(f)
+    }
+
+    /// Intern an already serialized sequence-container key.
+    fn register_container_sequence<T: ContainerValue>(&mut self, key: &[Value]) -> Value {
+        self.es_mut().register_container_sequence::<T>(key)
     }
 
     /// Intern a Rust container into the e-graph and return its

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2267,9 +2267,14 @@ impl EGraph {
 
     /// Convert from a Rust container type to an egglog value.
     pub fn container_to_value<T: ContainerValue>(&mut self, x: T) -> Value {
-        self.backend.with_execution_state(|state| {
-            self.backend.container_values().register_val::<T>(x, state)
-        })
+        let (value, changed) = self.backend.with_execution_state_tracked(|state| {
+            let containers = state.container_values();
+            containers.register_val::<T>(x, state)
+        });
+        if changed {
+            self.backend.flush_updates();
+        }
+        value
     }
 
     /// Get the size of a function in the e-graph.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -906,6 +906,9 @@ pub trait ContainerSort: Any + Send + Sync + Debug {
     fn inner_sorts(&self) -> Vec<ArcSort>;
     fn inner_values(&self, _: &ContainerValues, _: Value) -> Vec<(ArcSort, Value)>;
     fn register_primitives(&self, _eg: &mut EGraph) {}
+    fn register_type(&self, backend: &mut egglog_bridge::EGraph) {
+        backend.register_container_ty::<Self::Container>();
+    }
     fn reconstruct_termdag(
         &self,
         _: &ContainerValues,
@@ -944,7 +947,7 @@ impl<T: ContainerSort> Sort for ContainerSortImpl<T> {
     }
 
     fn register_type(&self, backend: &mut egglog_bridge::EGraph) {
-        backend.register_container_ty::<T::Container>();
+        self.0.register_type(backend);
     }
 
     fn value_type(&self) -> Option<TypeId> {

--- a/src/sort/add_primitive/src/lib.rs
+++ b/src/sort/add_primitive/src/lib.rs
@@ -184,7 +184,7 @@ fn build_add_primitive_impl(parsed: AddPrimitive, validator: Option<Expr>) -> To
         // via the `egglog::*` glob below).
         let cast1 = |x, t: &syn::Type, is_container| match is_container {
             false => quote!(state.base_values().unwrap::<#t>(*#x)),
-            true => quote!(state.container_values().get_val::<#t>(*#x).unwrap().clone()),
+            true => quote!(state.value_to_owned_container::<#t>(*#x).unwrap()),
         };
         let cast = if is_varargs {
             let Arg { x, t, is_mutable } = &args[0];

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -8,7 +8,8 @@ use std::{any::Any, sync::Arc};
 
 use crate::core_relations;
 pub use core_relations::{
-    BaseValues, Boxed, ContainerValue, ContainerValues, ExecutionState, ValueRebuilder,
+    BaseValues, Boxed, ContainerValue, ContainerValues, ExecutionState, SequenceContainerValue,
+    ValueRebuilder,
 };
 pub use egglog_bridge::ColumnTy;
 


### PR DESCRIPTION
## Summary

- Represent a container as a `SequenceTable` row containing `[canonical key..., identity]`.
- Add canonical sequence codecs with direct serialized fast paths and a deserialize/rebuild/serialize compatibility path.
- Add execution-local identity prediction, a sharded reverse map, occurrence-indexed rebuilds, and compatibility with the legacy backend.
- Wire sequence containers through actions, free join, dependency registration, the bridge, and public execution APIs.

## Stack

Draft, stacked on #976. This is PR 4 of 12 in the sequence-backed container stack.

## Validation

Validated on the complete 12-commit stack:

- `cargo nextest run --workspace`: 1,362 tests passed
- `cargo test --workspace --doc`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`