### PR TITLE
Move MultiSet containers to sequence storage

### DIFF
--- a/src/sort/multiset.rs
+++ b/src/sort/multiset.rs
@@ -1,12 +1,73 @@
 use super::*;
 use crate::Write;
 use crate::exec_state::Internal;
+use crate::numeric_id::NumericId;
 use inner::MultiSet;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct MultiSetContainer {
     pub do_rebuild: bool,
     pub data: MultiSet<Value>,
+}
+
+const MULTISET_ENTRY_WIDTH: usize = 3;
+
+fn encode_count(out: &mut Vec<Value>, count: usize) {
+    let count = count as u64;
+    out.push(Value::from_usize(count as u32 as usize));
+    out.push(Value::from_usize((count >> 32) as u32 as usize));
+}
+
+fn decode_count(encoded: &[Value]) -> usize {
+    let [low, high] = encoded else {
+        panic!("encoded multiset count must have two lanes");
+    };
+    let count = low.index() as u64 | ((high.index() as u64) << 32);
+    usize::try_from(count).expect("encoded multiset count exceeds usize")
+}
+
+fn encoded_multiset_entries(
+    payload: &[Value],
+) -> impl ExactSizeIterator<Item = (Value, usize)> + '_ {
+    assert_eq!(
+        payload.len() % MULTISET_ENTRY_WIDTH,
+        0,
+        "serialized MultiSetContainer has a partial entry"
+    );
+    payload.chunks_exact(MULTISET_ENTRY_WIDTH).map(|entry| {
+        let count = decode_count(&entry[1..]);
+        assert!(count > 0, "serialized multiset count must be positive");
+        (entry[0], count)
+    })
+}
+
+fn encoded_multiset_count(payload: &[Value], needle: Value) -> usize {
+    assert_eq!(
+        payload.len() % MULTISET_ENTRY_WIDTH,
+        0,
+        "serialized MultiSetContainer has a partial entry"
+    );
+    let (mut low, mut high) = (0, payload.len() / MULTISET_ENTRY_WIDTH);
+    while low < high {
+        let middle = low + (high - low) / 2;
+        let offset = middle * MULTISET_ENTRY_WIDTH;
+        match payload[offset].cmp(&needle) {
+            std::cmp::Ordering::Less => low = middle + 1,
+            std::cmp::Ordering::Greater => high = middle,
+            std::cmp::Ordering::Equal => {
+                return decode_count(&payload[offset + 1..offset + MULTISET_ENTRY_WIDTH]);
+            }
+        }
+    }
+    0
+}
+
+fn encoded_multiset_len(payload: &[Value]) -> Option<usize> {
+    encoded_multiset_entries(payload).try_fold(0usize, |total, (_, count)| {
+        let total = total.checked_add(count)?;
+        i64::try_from(total).ok()?;
+        Some(total)
+    })
 }
 
 /// Canonical multiset term form `(multiset-of e0 e1 ...)`: elements sorted by
@@ -41,6 +102,108 @@ impl ContainerValue for MultiSetContainer {
     }
     fn iter(&self) -> impl Iterator<Item = Value> + '_ {
         self.data.iter().copied()
+    }
+}
+
+impl SequenceContainerValue for MultiSetContainer {
+    fn encode_sequence(&self, out: &mut Vec<Value>) {
+        assert!(
+            i64::try_from(self.data.len()).is_ok(),
+            "multiset cardinality exceeds the i64 language representation"
+        );
+        out.push(Value::from_usize(self.do_rebuild as usize));
+        for (value, count) in self.data.iter_counts() {
+            out.push(value);
+            encode_count(out, count);
+        }
+    }
+
+    fn decode_sequence(sequence: &[Value]) -> Self {
+        let (&header, data) = sequence
+            .split_first()
+            .expect("serialized MultiSetContainer must include its rebuild flag");
+        assert!(
+            header == Value::from_usize(0) || header == Value::from_usize(1),
+            "serialized MultiSetContainer has an invalid rebuild flag"
+        );
+        assert!(
+            encoded_multiset_len(data).is_some(),
+            "serialized multiset cardinality exceeds the i64 language representation"
+        );
+        let mut decoded = MultiSet::new();
+        let mut previous = None;
+        for (value, count) in encoded_multiset_entries(data) {
+            debug_assert!(previous.is_none_or(|previous| previous < value));
+            previous = Some(value);
+            decoded
+                .checked_insert_multiple_mut(value, count)
+                .expect("serialized multiset cardinality overflow");
+        }
+        Self {
+            do_rebuild: header == Value::from_usize(1),
+            data: decoded,
+        }
+    }
+
+    fn sequence_values(sequence: &[Value]) -> &[Value] {
+        sequence
+            .get(1..)
+            .expect("serialized MultiSetContainer must include its rebuild flag")
+    }
+
+    fn visit_sequence_values(sequence: &[Value], visitor: &mut dyn FnMut(Value)) {
+        let (&header, data) = sequence
+            .split_first()
+            .expect("serialized MultiSetContainer must include its rebuild flag");
+        match header.index() {
+            0 => {}
+            1 => {
+                for (value, _) in encoded_multiset_entries(data) {
+                    visitor(value);
+                }
+            }
+            _ => panic!("serialized MultiSetContainer has an invalid rebuild flag"),
+        }
+    }
+
+    fn rebuild_sequence(
+        sequence: &[Value],
+        rebuilder: &dyn ValueRebuilder,
+        out: &mut Vec<Value>,
+    ) -> bool {
+        let (&header, data) = sequence
+            .split_first()
+            .expect("serialized MultiSetContainer must include its rebuild flag");
+        if header == Value::from_usize(0) {
+            return false;
+        }
+        assert_eq!(
+            header,
+            Value::from_usize(1),
+            "serialized MultiSetContainer has an invalid rebuild flag"
+        );
+
+        let entries = encoded_multiset_entries(data).collect::<Vec<_>>();
+        let mut rebuilt_values = entries.iter().map(|(value, _)| *value).collect::<Vec<_>>();
+        if !rebuilder.rebuild_slice(&mut rebuilt_values) {
+            return false;
+        }
+        let mut rebuilt = MultiSet::new();
+        for (rebuilt_value, (_, count)) in rebuilt_values.into_iter().zip(entries) {
+            rebuilt
+                .checked_insert_multiple_mut(rebuilt_value, count)
+                .expect("rebuilding a valid multiset cannot increase its cardinality");
+        }
+        Self {
+            do_rebuild: true,
+            data: rebuilt,
+        }
+        .encode_sequence(out);
+        if out.as_slice() == sequence {
+            out.clear();
+            return false;
+        }
+        true
     }
 }
 
@@ -123,6 +286,10 @@ impl ContainerSort for MultiSetSort {
         &self.name
     }
 
+    fn register_type(&self, backend: &mut egglog_bridge::EGraph) {
+        backend.register_sequence_container_ty::<MultiSetContainer>();
+    }
+
     fn inner_sorts(&self) -> Vec<ArcSort> {
         vec![self.element.clone()]
     }
@@ -180,40 +347,88 @@ impl ContainerSort for MultiSetSort {
             data: xs.collect()
         } }, multiset_of_validator);
 
-        add_primitive!(eg, "multiset-single" = {self.clone(): MultiSetSort} |x: # (self.element()), i: i64| -?> @MultiSetContainer (arc) {
-            i.try_into().ok().map(|i|
-                MultiSetContainer {
-                do_rebuild: self.ctx.is_eq_container_sort(),
-                data: std::iter::repeat_n(x, i).collect()
-            })
-        });
-        add_primitive!(eg, "multiset-pick" = |xs: @MultiSetContainer (arc)| -?> # (self.element()) { xs.data.pick().copied() });
-        add_primitive!(eg, "multiset-insert" = |mut xs: @MultiSetContainer (arc), x: # (self.element())| -> @MultiSetContainer (arc) { MultiSetContainer { data: xs.data.insert( x) , ..xs } });
-        add_primitive!(eg, "multiset-remove" = |mut xs: @MultiSetContainer (arc), x: # (self.element())| -?> @MultiSetContainer (arc) { Some(MultiSetContainer { data: xs.data.remove(&x)?, ..xs } )});
-        add_primitive!(eg, "multiset-remove-swapped" = |x: # (self.element()), mut xs: @MultiSetContainer (arc)| -?> @MultiSetContainer (arc) { Some(MultiSetContainer { data: xs.data.remove(&x)?, ..xs }) });
-        add_primitive!(eg, "multiset-subtract" = |mut xs: @MultiSetContainer (arc), other: @MultiSetContainer (arc)| -?> @MultiSetContainer (arc) { Some(MultiSetContainer { data: xs.data.subtract(&other.data)?, ..xs }) });
-        add_primitive!(eg, "multiset-subtract-swapped" = |other: @MultiSetContainer (arc), mut xs: @MultiSetContainer (arc)| -?> @MultiSetContainer (arc) { Some(MultiSetContainer { data: xs.data.subtract(&other.data)?, ..xs }) });
-        add_primitive_with_validator!(eg, "multiset-length"       = |xs: @MultiSetContainer (arc)| -> i64 { xs.data.len() as i64 }, multiset_length_validator);
-        add_primitive_with_validator!(eg, "multiset-contains"     = |xs: @MultiSetContainer (arc), x: # (self.element())| -?> () { ( xs.data.contains(&x)).then_some(()) }, multiset_contains_validator);
-        add_primitive_with_validator!(eg, "multiset-not-contains" = |xs: @MultiSetContainer (arc), x: # (self.element())| -?> () { (!xs.data.contains(&x)).then_some(()) }, multiset_not_contains_validator);
-        add_primitive!(eg, "multiset-contains-swapped" = |x: # (self.element()), xs: @MultiSetContainer (arc)| -?> () { (xs.data.contains(&x)).then_some(()) });
-        add_primitive!(eg, "multiset-not-contains-swapped" = |x: # (self.element()), xs: @MultiSetContainer (arc)| -?> () { (!xs.data.contains(&x)).then_some(()) });
-        add_primitive!(eg, "multiset-intersection" = |xs: @MultiSetContainer (arc), ys: @MultiSetContainer (arc)| -> @MultiSetContainer (arc) { MultiSetContainer { data: xs.data.intersection(ys.data), ..xs } });
-        add_primitive!(eg, "multiset-sum" = |xs: @MultiSetContainer (arc), ys: @MultiSetContainer (arc)| -> @MultiSetContainer (arc) { MultiSetContainer { data: xs.data.sum(ys.data), ..xs } });
-        // Set counts to one
-        add_primitive!(eg, "multiset-reset-counts" = |mut xs: @MultiSetContainer (arc)| -> @MultiSetContainer (arc) { {
-            let mut new_data = MultiSet::<Value>::new();
-            for (v, _) in xs.data.iter_counts() {
-                new_data.insert_multiple_mut(v, 1);
-            }
-            MultiSetContainer { data: new_data, ..xs }
-        }});
-        add_primitive!(eg, "multiset-pick-max" = |xs: @MultiSetContainer (arc)| -?>  # (self.element()) {
-            Some(xs.data.iter_counts().max_by_key(|(_, c)| *c)?.0)
-        });
-        add_primitive!(eg, "multiset-count" = |xs: @MultiSetContainer (arc), x: # (self.element())| -> i64 {
-            xs.data.iter_counts().find(|(v, _)| *v == x).map(|(_, c)| c as i64).unwrap_or(0)
-        });
+        eg.add_pure_primitive(
+            MultiSetSingle {
+                name: "multiset-single".into(),
+                multiset: arc.clone(),
+                element: self.element(),
+            },
+            None,
+        );
+        for (name, op, validator) in [
+            ("multiset-pick", MultiSetReadOp::Pick, None),
+            (
+                "multiset-length",
+                MultiSetReadOp::Length,
+                Some(Arc::new(multiset_length_validator) as PrimitiveValidator),
+            ),
+            (
+                "multiset-contains",
+                MultiSetReadOp::Contains,
+                Some(Arc::new(multiset_contains_validator) as PrimitiveValidator),
+            ),
+            (
+                "multiset-not-contains",
+                MultiSetReadOp::NotContains,
+                Some(Arc::new(multiset_not_contains_validator) as PrimitiveValidator),
+            ),
+            (
+                "multiset-contains-swapped",
+                MultiSetReadOp::ContainsSwapped,
+                None,
+            ),
+            (
+                "multiset-not-contains-swapped",
+                MultiSetReadOp::NotContainsSwapped,
+                None,
+            ),
+            ("multiset-pick-max", MultiSetReadOp::PickMax, None),
+            ("multiset-count", MultiSetReadOp::Count, None),
+        ] {
+            eg.add_pure_primitive(
+                MultiSetRead {
+                    name: name.into(),
+                    multiset: arc.clone(),
+                    element: self.element(),
+                    op,
+                },
+                validator,
+            );
+        }
+        for (name, op) in [
+            ("multiset-insert", MultiSetEditOp::Insert),
+            ("multiset-remove", MultiSetEditOp::Remove),
+            ("multiset-remove-swapped", MultiSetEditOp::RemoveSwapped),
+            ("multiset-reset-counts", MultiSetEditOp::ResetCounts),
+        ] {
+            eg.add_pure_primitive(
+                MultiSetEdit {
+                    name: name.into(),
+                    multiset: arc.clone(),
+                    element: self.element(),
+                    op,
+                },
+                None,
+            );
+        }
+        for (name, op) in [
+            ("multiset-subtract", MultiSetBinaryOp::Subtract),
+            (
+                "multiset-subtract-swapped",
+                MultiSetBinaryOp::SubtractSwapped,
+            ),
+            ("multiset-intersection", MultiSetBinaryOp::Intersection),
+            ("multiset-sum", MultiSetBinaryOp::Sum),
+        ] {
+            eg.add_pure_primitive(
+                MultiSetBinary {
+                    name: name.into(),
+                    multiset: arc.clone(),
+                    op,
+                },
+                None,
+            );
+        }
 
         // Add multiset-sum-multisets if the inner arcsort is also a multiset
         for other_multiset_sort in eg.type_info.get_arcsorts_by(|f| {
@@ -278,6 +493,428 @@ impl ContainerSort for MultiSetSort {
     fn serialized_name(&self, _container_values: &ContainerValues, _: Value) -> String {
         "multiset-of".to_owned()
     }
+}
+
+fn multiset_entries<'a, 'db: 'a>(
+    state: &impl Core<'a, 'db>,
+    value: Value,
+) -> Option<Vec<(Value, usize)>> {
+    state
+        .with_container_sequence::<MultiSetContainer, _>(value, |payload| {
+            encoded_multiset_entries(payload).collect()
+        })
+        .or_else(|| {
+            state
+                .value_to_owned_container::<MultiSetContainer>(value)
+                .map(|multiset| multiset.data.iter_counts().collect())
+        })
+}
+
+fn multiset_key(
+    rebuild: bool,
+    entries: impl IntoIterator<Item = (Value, usize)>,
+) -> Option<Vec<Value>> {
+    let entries = entries.into_iter();
+    let mut key = Vec::with_capacity(entries.size_hint().0 * MULTISET_ENTRY_WIDTH + 1);
+    key.push(Value::from_usize(rebuild as usize));
+    let mut previous = None;
+    let mut total = 0usize;
+    for (value, count) in entries {
+        debug_assert!(previous.is_none_or(|previous| previous < value));
+        debug_assert!(count > 0);
+        total = total.checked_add(count)?;
+        i64::try_from(total).ok()?;
+        previous = Some(value);
+        key.push(value);
+        encode_count(&mut key, count);
+    }
+    Some(key)
+}
+
+#[derive(Clone)]
+struct MultiSetSingle {
+    name: String,
+    multiset: ArcSort,
+    element: ArcSort,
+}
+
+impl Primitive for MultiSetSingle {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn get_type_constraints(&self, span: &Span) -> Box<dyn TypeConstraint> {
+        SimpleTypeConstraint::new(
+            self.name(),
+            vec![
+                self.element.clone(),
+                I64Sort.to_arcsort(),
+                self.multiset.clone(),
+            ],
+            span.clone(),
+        )
+        .into_box()
+    }
+}
+
+impl PurePrim for MultiSetSingle {
+    fn apply<'a, 'db>(
+        &self,
+        mut state: crate::PureState<'a, 'db>,
+        args: &[Value],
+    ) -> Option<Value> {
+        let [value, count] = args else { return None };
+        let count = usize::try_from(state.base_values().unwrap::<i64>(*count)).ok()?;
+        let entries = (count != 0).then_some((*value, count));
+        let key = multiset_key(self.multiset.is_eq_container_sort(), entries)?;
+        Some(state.register_container_sequence::<MultiSetContainer>(&key))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum MultiSetReadOp {
+    Pick,
+    Length,
+    Contains,
+    NotContains,
+    ContainsSwapped,
+    NotContainsSwapped,
+    PickMax,
+    Count,
+}
+
+#[derive(Clone)]
+struct MultiSetRead {
+    name: String,
+    multiset: ArcSort,
+    element: ArcSort,
+    op: MultiSetReadOp,
+}
+
+impl Primitive for MultiSetRead {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn get_type_constraints(&self, span: &Span) -> Box<dyn TypeConstraint> {
+        let types = match self.op {
+            MultiSetReadOp::Pick | MultiSetReadOp::PickMax => {
+                vec![self.multiset.clone(), self.element.clone()]
+            }
+            MultiSetReadOp::Length => vec![self.multiset.clone(), I64Sort.to_arcsort()],
+            MultiSetReadOp::Contains | MultiSetReadOp::NotContains => vec![
+                self.multiset.clone(),
+                self.element.clone(),
+                UnitSort.to_arcsort(),
+            ],
+            MultiSetReadOp::ContainsSwapped | MultiSetReadOp::NotContainsSwapped => vec![
+                self.element.clone(),
+                self.multiset.clone(),
+                UnitSort.to_arcsort(),
+            ],
+            MultiSetReadOp::Count => vec![
+                self.multiset.clone(),
+                self.element.clone(),
+                I64Sort.to_arcsort(),
+            ],
+        };
+        SimpleTypeConstraint::new(self.name(), types, span.clone()).into_box()
+    }
+}
+
+impl PurePrim for MultiSetRead {
+    fn apply<'a, 'db>(&self, state: crate::PureState<'a, 'db>, args: &[Value]) -> Option<Value> {
+        let (multiset, needle) = match self.op {
+            MultiSetReadOp::ContainsSwapped | MultiSetReadOp::NotContainsSwapped => {
+                let [needle, multiset] = args else {
+                    return None;
+                };
+                (*multiset, Some(*needle))
+            }
+            MultiSetReadOp::Contains | MultiSetReadOp::NotContains | MultiSetReadOp::Count => {
+                let [multiset, needle] = args else {
+                    return None;
+                };
+                (*multiset, Some(*needle))
+            }
+            _ => {
+                let [multiset] = args else { return None };
+                (*multiset, None)
+            }
+        };
+        if let Some(result) =
+            state.with_container_sequence::<MultiSetContainer, _>(multiset, |payload| {
+                match self.op {
+                    MultiSetReadOp::Pick => encoded_multiset_entries(payload)
+                        .next()
+                        .map(|(value, _)| value),
+                    MultiSetReadOp::Length => {
+                        let len = i64::try_from(encoded_multiset_len(payload)?).ok()?;
+                        Some(state.base_values().get::<i64>(len))
+                    }
+                    MultiSetReadOp::Contains | MultiSetReadOp::ContainsSwapped => {
+                        (encoded_multiset_count(payload, needle.unwrap()) != 0)
+                            .then(|| state.base_values().get::<()>(()))
+                    }
+                    MultiSetReadOp::NotContains | MultiSetReadOp::NotContainsSwapped => {
+                        (encoded_multiset_count(payload, needle.unwrap()) == 0)
+                            .then(|| state.base_values().get::<()>(()))
+                    }
+                    MultiSetReadOp::Count => {
+                        let count =
+                            i64::try_from(encoded_multiset_count(payload, needle.unwrap())).ok()?;
+                        Some(state.base_values().get::<i64>(count))
+                    }
+                    MultiSetReadOp::PickMax => encoded_multiset_entries(payload)
+                        .max_by_key(|(_, count)| *count)
+                        .map(|(value, _)| value),
+                }
+            })
+        {
+            return result;
+        }
+
+        let multiset = state.value_to_owned_container::<MultiSetContainer>(multiset)?;
+        match self.op {
+            MultiSetReadOp::Pick => multiset.data.pick().copied(),
+            MultiSetReadOp::Length => Some(
+                state
+                    .base_values()
+                    .get::<i64>(i64::try_from(multiset.data.len()).ok()?),
+            ),
+            MultiSetReadOp::Contains | MultiSetReadOp::ContainsSwapped => multiset
+                .data
+                .contains(&needle.unwrap())
+                .then(|| state.base_values().get::<()>(())),
+            MultiSetReadOp::NotContains | MultiSetReadOp::NotContainsSwapped => {
+                (!multiset.data.contains(&needle.unwrap()))
+                    .then(|| state.base_values().get::<()>(()))
+            }
+            MultiSetReadOp::Count => {
+                let count = multiset
+                    .data
+                    .iter_counts()
+                    .find(|(value, _)| *value == needle.unwrap())
+                    .map(|(_, count)| count)
+                    .unwrap_or(0);
+                Some(state.base_values().get::<i64>(i64::try_from(count).ok()?))
+            }
+            MultiSetReadOp::PickMax => multiset
+                .data
+                .iter_counts()
+                .max_by_key(|(_, count)| *count)
+                .map(|(value, _)| value),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum MultiSetEditOp {
+    Insert,
+    Remove,
+    RemoveSwapped,
+    ResetCounts,
+}
+
+#[derive(Clone)]
+struct MultiSetEdit {
+    name: String,
+    multiset: ArcSort,
+    element: ArcSort,
+    op: MultiSetEditOp,
+}
+
+impl Primitive for MultiSetEdit {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn get_type_constraints(&self, span: &Span) -> Box<dyn TypeConstraint> {
+        let types = match self.op {
+            MultiSetEditOp::Insert | MultiSetEditOp::Remove => vec![
+                self.multiset.clone(),
+                self.element.clone(),
+                self.multiset.clone(),
+            ],
+            MultiSetEditOp::RemoveSwapped => vec![
+                self.element.clone(),
+                self.multiset.clone(),
+                self.multiset.clone(),
+            ],
+            MultiSetEditOp::ResetCounts => {
+                vec![self.multiset.clone(), self.multiset.clone()]
+            }
+        };
+        SimpleTypeConstraint::new(self.name(), types, span.clone()).into_box()
+    }
+}
+
+impl PurePrim for MultiSetEdit {
+    fn apply<'a, 'db>(
+        &self,
+        mut state: crate::PureState<'a, 'db>,
+        args: &[Value],
+    ) -> Option<Value> {
+        let (multiset, needle) = match self.op {
+            MultiSetEditOp::Insert | MultiSetEditOp::Remove => {
+                let [multiset, needle] = args else {
+                    return None;
+                };
+                (*multiset, Some(*needle))
+            }
+            MultiSetEditOp::RemoveSwapped => {
+                let [needle, multiset] = args else {
+                    return None;
+                };
+                (*multiset, Some(*needle))
+            }
+            MultiSetEditOp::ResetCounts => {
+                let [multiset] = args else { return None };
+                (*multiset, None)
+            }
+        };
+        let mut entries = multiset_entries(&state, multiset)?;
+        match self.op {
+            MultiSetEditOp::Insert => {
+                let needle = needle.unwrap();
+                match entries.binary_search_by_key(&needle, |(value, _)| *value) {
+                    Ok(index) => entries[index].1 = entries[index].1.checked_add(1)?,
+                    Err(index) => entries.insert(index, (needle, 1)),
+                }
+            }
+            MultiSetEditOp::Remove | MultiSetEditOp::RemoveSwapped => {
+                let index = entries
+                    .binary_search_by_key(&needle.unwrap(), |(value, _)| *value)
+                    .ok()?;
+                if entries[index].1 == 1 {
+                    entries.remove(index);
+                } else {
+                    entries[index].1 -= 1;
+                }
+            }
+            MultiSetEditOp::ResetCounts => {
+                for (_, count) in &mut entries {
+                    *count = 1;
+                }
+            }
+        }
+        let key = multiset_key(self.multiset.is_eq_container_sort(), entries)?;
+        Some(state.register_container_sequence::<MultiSetContainer>(&key))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum MultiSetBinaryOp {
+    Subtract,
+    SubtractSwapped,
+    Intersection,
+    Sum,
+}
+
+#[derive(Clone)]
+struct MultiSetBinary {
+    name: String,
+    multiset: ArcSort,
+    op: MultiSetBinaryOp,
+}
+
+impl Primitive for MultiSetBinary {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn get_type_constraints(&self, span: &Span) -> Box<dyn TypeConstraint> {
+        SimpleTypeConstraint::new(
+            self.name(),
+            vec![
+                self.multiset.clone(),
+                self.multiset.clone(),
+                self.multiset.clone(),
+            ],
+            span.clone(),
+        )
+        .into_box()
+    }
+}
+
+impl PurePrim for MultiSetBinary {
+    fn apply<'a, 'db>(
+        &self,
+        mut state: crate::PureState<'a, 'db>,
+        args: &[Value],
+    ) -> Option<Value> {
+        let [left, right] = args else { return None };
+        let mut left = multiset_entries(&state, *left)?;
+        let mut right = multiset_entries(&state, *right)?;
+        if matches!(self.op, MultiSetBinaryOp::SubtractSwapped) {
+            std::mem::swap(&mut left, &mut right);
+        }
+        let entries = merge_multisets(&left, &right, self.op)?;
+        let key = multiset_key(self.multiset.is_eq_container_sort(), entries)?;
+        Some(state.register_container_sequence::<MultiSetContainer>(&key))
+    }
+}
+
+fn merge_multisets(
+    left: &[(Value, usize)],
+    right: &[(Value, usize)],
+    op: MultiSetBinaryOp,
+) -> Option<Vec<(Value, usize)>> {
+    let op = match op {
+        MultiSetBinaryOp::SubtractSwapped => MultiSetBinaryOp::Subtract,
+        other => other,
+    };
+    let mut out = Vec::with_capacity(left.len() + right.len());
+    let (mut l, mut r) = (0, 0);
+    while l < left.len() && r < right.len() {
+        match left[l].0.cmp(&right[r].0) {
+            std::cmp::Ordering::Less => {
+                if matches!(op, MultiSetBinaryOp::Subtract | MultiSetBinaryOp::Sum) {
+                    out.push(left[l]);
+                }
+                l += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                if matches!(op, MultiSetBinaryOp::Subtract) {
+                    return None;
+                }
+                if matches!(op, MultiSetBinaryOp::Sum) {
+                    out.push(right[r]);
+                }
+                r += 1;
+            }
+            std::cmp::Ordering::Equal => {
+                let (value, left_count) = left[l];
+                let right_count = right[r].1;
+                let count = match op {
+                    MultiSetBinaryOp::Subtract => left_count.checked_sub(right_count)?,
+                    MultiSetBinaryOp::Intersection => left_count.min(right_count),
+                    MultiSetBinaryOp::Sum => left_count.checked_add(right_count)?,
+                    MultiSetBinaryOp::SubtractSwapped => unreachable!(),
+                };
+                if count != 0 {
+                    out.push((value, count));
+                }
+                l += 1;
+                r += 1;
+            }
+        }
+    }
+    match op {
+        MultiSetBinaryOp::Subtract => {
+            if r != right.len() {
+                return None;
+            }
+            out.extend_from_slice(&left[l..]);
+        }
+        MultiSetBinaryOp::Sum => {
+            out.extend_from_slice(&left[l..]);
+            out.extend_from_slice(&right[r..]);
+        }
+        MultiSetBinaryOp::Intersection => {}
+        MultiSetBinaryOp::SubtractSwapped => unreachable!(),
+    }
+    Some(out)
 }
 
 /**
@@ -441,27 +1078,21 @@ impl PurePrim for Map {
         mut state: crate::PureState<'a, 'db>,
         args: &[Value],
     ) -> Option<Value> {
-        let fc = state
-            .container_values()
-            .get_val::<FunctionContainer>(args[0])
-            .unwrap()
-            .clone();
-        let multiset = state
-            .container_values()
-            .get_val::<MultiSetContainer>(args[1])
-            .unwrap()
-            .clone();
-        let mut new_data = MultiSet::<Value>::new();
-        for (v, c) in multiset.data.iter_counts() {
+        let fc = state.value_to_owned_container::<FunctionContainer>(args[0])?;
+        // Copy before callbacks: they may intern containers and grow the
+        // execution-local prediction storage backing the fast slice.
+        let entries = multiset_entries(&state, args[1])?;
+        let mut mapped_values = MultiSet::new();
+        for (v, count) in entries {
             if let Some(mapped) = state.apply_function(&fc, &[v]) {
-                new_data.insert_multiple_mut(mapped, c);
+                mapped_values.checked_insert_multiple_mut(mapped, count)?;
             }
         }
-        let new_ms = MultiSetContainer {
-            data: new_data,
-            ..multiset
-        };
-        Some(state.register_container(new_ms))
+        let key = multiset_key(
+            self.output_multiset.is_eq_container_sort(),
+            mapped_values.iter_counts(),
+        )?;
+        Some(state.register_container_sequence::<MultiSetContainer>(&key))
     }
 }
 
@@ -502,16 +1133,11 @@ impl FullPrim for FillIndex {
         mut state: crate::FullState<'a, 'db>,
         args: &[Value],
     ) -> Option<Value> {
-        let fc = state
-            .container_values()
-            .get_val::<FunctionContainer>(args[1])
-            .unwrap()
-            .clone();
-        let multiset = state
-            .container_values()
-            .get_val::<MultiSetContainer>(args[0])
-            .unwrap()
-            .clone();
+        let fc = state.value_to_owned_container::<FunctionContainer>(args[1])?;
+        let entries = multiset_entries(&state, args[0])?
+            .into_iter()
+            .map(|(value, count)| Some((value, i64::try_from(count).ok()?)))
+            .collect::<Option<Vec<_>>>()?;
         let action = match fc.0 {
             ResolvedFunctionId::Constructor(a) | ResolvedFunctionId::Function(a) => a,
             // Primitive functions cannot be used with
@@ -520,7 +1146,7 @@ impl FullPrim for FillIndex {
         };
         let unit_val = state.base_values().get::<()>(());
         let es = state.raw_exec_state();
-        for (v, c) in multiset.data.iter_counts() {
+        for (v, count) in entries {
             let mut row = vec![args[0], v];
             // Skip the whole fill if any index row already exists.
             // This relies on `unstable-multiset-fill-index` writing all
@@ -528,7 +1154,7 @@ impl FullPrim for FillIndex {
             if action.lookup(es, &row).is_some() {
                 break;
             }
-            row.push(es.base_values().get::<i64>(c.try_into().ok()?));
+            row.push(es.base_values().get::<i64>(count));
             action.insert(es, row.into_iter());
         }
         Some(unit_val)
@@ -567,16 +1193,8 @@ impl WritePrim for ClearIndex {
         mut state: crate::WriteState<'a, 'db>,
         args: &[Value],
     ) -> Option<Value> {
-        let fc = state
-            .container_values()
-            .get_val::<FunctionContainer>(args[1])
-            .unwrap()
-            .clone();
-        let multiset = state
-            .container_values()
-            .get_val::<MultiSetContainer>(args[0])
-            .unwrap()
-            .clone();
+        let fc = state.value_to_owned_container::<FunctionContainer>(args[1])?;
+        let entries = multiset_entries(&state, args[0])?;
         let action = match fc.0 {
             ResolvedFunctionId::Constructor(a) | ResolvedFunctionId::Function(a) => a,
             // Primitive functions cannot be used with
@@ -585,7 +1203,7 @@ impl WritePrim for ClearIndex {
         };
         let unit_val = state.base_values().get::<()>(());
         let es = state.raw_exec_state();
-        for (v, _) in multiset.data.iter_counts() {
+        for (v, _) in entries {
             action.remove(es, &[args[0], v]);
         }
         Some(unit_val)
@@ -626,36 +1244,25 @@ impl PurePrim for FlatMap {
         mut state: crate::PureState<'a, 'db>,
         args: &[Value],
     ) -> Option<Value> {
-        let fc = state
-            .container_values()
-            .get_val::<FunctionContainer>(args[0])
-            .unwrap()
-            .clone();
-        let multiset = state
-            .container_values()
-            .get_val::<MultiSetContainer>(args[1])
-            .unwrap()
-            .clone();
-        let mut new_data = MultiSet::<Value>::new();
-        for (v, c) in multiset.data.iter_counts() {
+        let fc = state.value_to_owned_container::<FunctionContainer>(args[0])?;
+        let entries = multiset_entries(&state, args[1])?;
+        let mut flattened = MultiSet::new();
+        for (v, count) in entries {
             let mapped = state.apply_function(&fc, &[v]);
             if let Some(mapped_ms) = mapped {
-                let mapped_ms = state
-                    .container_values()
-                    .get_val::<MultiSetContainer>(mapped_ms)
-                    .unwrap();
-                for (mv, mc) in mapped_ms.data.iter_counts() {
-                    new_data.insert_multiple_mut(mv, c.checked_mul(mc)?);
+                for (mapped, mapped_count) in multiset_entries(&state, mapped_ms)? {
+                    flattened
+                        .checked_insert_multiple_mut(mapped, count.checked_mul(mapped_count)?)?;
                 }
             } else {
-                new_data.insert_multiple_mut(v, c);
+                flattened.checked_insert_multiple_mut(v, count)?;
             }
         }
-        let new_container = MultiSetContainer {
-            data: new_data,
-            ..multiset
-        };
-        Some(state.register_container(new_container))
+        let key = multiset_key(
+            self.multiset.is_eq_container_sort(),
+            flattened.iter_counts(),
+        )?;
+        Some(state.register_container_sequence::<MultiSetContainer>(&key))
     }
 }
 
@@ -694,28 +1301,17 @@ impl PurePrim for Filter {
         mut state: crate::PureState<'a, 'db>,
         args: &[Value],
     ) -> Option<Value> {
-        let fc = state
-            .container_values()
-            .get_val::<FunctionContainer>(args[0])
-            .unwrap()
-            .clone();
-        let multiset = state
-            .container_values()
-            .get_val::<MultiSetContainer>(args[1])
-            .unwrap()
-            .clone();
-        let mut new_data = MultiSet::<Value>::new();
-        for (v, c) in multiset.data.iter_counts() {
+        let fc = state.value_to_owned_container::<FunctionContainer>(args[0])?;
+        let entries = multiset_entries(&state, args[1])?;
+        let mut filtered = Vec::with_capacity(entries.len());
+        for (v, count) in entries {
             let mapped = state.apply_function(&fc, &[v]);
             if mapped.is_some() == self.skip_empty {
-                new_data.insert_multiple_mut(v, c);
+                filtered.push((v, count));
             }
         }
-        let new_ms = MultiSetContainer {
-            data: new_data,
-            ..multiset
-        };
-        Some(state.register_container(new_ms))
+        let key = multiset_key(self.multiset.is_eq_container_sort(), filtered)?;
+        Some(state.register_container_sequence::<MultiSetContainer>(&key))
     }
 }
 
@@ -752,26 +1348,19 @@ impl PurePrim for SumMultisets {
         mut state: crate::PureState<'a, 'db>,
         args: &[Value],
     ) -> Option<Value> {
-        let mut data = MultiSet::<Value>::new();
-        let ms_of_ms = state
-            .container_values()
-            .get_val::<MultiSetContainer>(args[0])
-            .unwrap()
-            .clone();
-        for (ms_value, counts) in ms_of_ms.data.iter_counts() {
-            let ms = state
-                .container_values()
-                .get_val::<MultiSetContainer>(ms_value)
-                .unwrap();
-            for (v, c) in ms.data.iter_counts() {
-                data.insert_multiple_mut(v, c.checked_mul(counts)?);
+        let outer = multiset_entries(&state, args[0])?;
+        let mut flattened = MultiSet::new();
+        for (multiset, outer_count) in outer {
+            for (value, inner_count) in multiset_entries(&state, multiset)? {
+                flattened
+                    .checked_insert_multiple_mut(value, outer_count.checked_mul(inner_count)?)?;
             }
         }
-        let multiset = MultiSetContainer {
-            data,
-            do_rebuild: self.multiset.is_eq_container_sort(),
-        };
-        Some(state.register_container(multiset))
+        let key = multiset_key(
+            self.multiset.is_eq_container_sort(),
+            flattened.iter_counts(),
+        )?;
+        Some(state.register_container_sequence::<MultiSetContainer>(&key))
     }
 }
 
@@ -811,25 +1400,20 @@ impl PurePrim for Reduce {
         mut state: crate::PureState<'a, 'db>,
         args: &[Value],
     ) -> Option<Value> {
-        let fc = state
-            .container_values()
-            .get_val::<FunctionContainer>(args[0])
-            .unwrap()
-            .clone();
+        let fc = state.value_to_owned_container::<FunctionContainer>(args[0])?;
         let initial = args[1];
-        let multiset = state
-            .container_values()
-            .get_val::<MultiSetContainer>(args[2])
-            .unwrap()
-            .clone();
-        let mut values = multiset.data.iter().cloned().collect::<Vec<_>>();
-        let mut acc = if values.is_empty() {
-            initial
-        } else {
-            values.remove(0)
-        };
-        for v in values {
-            acc = state.apply_function(&fc, &[acc, v])?;
+        let entries = multiset_entries(&state, args[2])?;
+        let mut acc = initial;
+        let mut has_value = false;
+        for (value, count) in entries {
+            for _ in 0..count {
+                if has_value {
+                    acc = state.apply_function(&fc, &[acc, value])?;
+                } else {
+                    acc = value;
+                    has_value = true;
+                }
+            }
         }
         Some(acc)
     }
@@ -867,17 +1451,12 @@ impl WritePrim for UnionValues {
         mut state: crate::WriteState<'a, 'db>,
         args: &[Value],
     ) -> Option<Value> {
-        let values = state
-            .container_values()
-            .get_val::<MultiSetContainer>(args[0])?
-            .clone()
-            .data;
-        let values: Vec<_> = values.iter_counts().map(|(v, _c)| v).collect();
-        if values.is_empty() {
+        let entries = multiset_entries(&state, args[0])?;
+        if entries.is_empty() {
             return None;
         }
-        let first = values[0];
-        for v in values.into_iter().skip(1) {
+        let first = entries[0].0;
+        for (v, _) in entries.into_iter().skip(1) {
             state.union(first, v).ok()?;
         }
         Some(first)
@@ -970,18 +1549,33 @@ mod inner {
             Some(self)
         }
 
-        pub fn insert_multiple_mut(&mut self, value: T, n: usize) {
-            self.1 += n;
-            if let Some(v) = self.0.get(&value) {
-                self.0.insert(value, v + n);
-            } else {
-                self.0.insert(value, n);
+        pub fn checked_insert_multiple_mut(&mut self, value: T, n: usize) -> Option<()> {
+            if n == 0 {
+                return Some(());
             }
+            let total = self.1.checked_add(n)?;
+            let count = self
+                .0
+                .get(&value)
+                .copied()
+                .unwrap_or_default()
+                .checked_add(n)?;
+            self.1 = total;
+            self.0.insert(value, count);
+            Some(())
+        }
+
+        pub fn insert_multiple_mut(&mut self, value: T, n: usize) {
+            self.checked_insert_multiple_mut(value, n)
+                .expect("multiset cardinality overflow");
         }
 
         /// Compute the sum of two multisets.
         pub fn sum(mut self, MultiSet(other_map, other_count): Self) -> Self {
-            let target_count = self.1 + other_count;
+            let target_count = self
+                .1
+                .checked_add(other_count)
+                .expect("multiset cardinality overflow");
             for (k, v) in other_map {
                 self.insert_multiple_mut(k, v);
             }
@@ -1011,6 +1605,222 @@ mod inner {
                 multiset.insert_multiple_mut(value, 1);
             }
             multiset
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Collapse {
+        from: Value,
+        to: Value,
+    }
+
+    impl ValueRebuilder for Collapse {
+        fn rebuild_val(&self, value: Value) -> Value {
+            if value == self.from { self.to } else { value }
+        }
+    }
+
+    fn value(index: usize) -> Value {
+        Value::from_usize(index)
+    }
+
+    #[test]
+    fn compact_sequence_codec_round_trips_and_merges_counts() {
+        let mut data = MultiSet::new();
+        data.insert_multiple_mut(value(2), 3);
+        data.insert_multiple_mut(value(4), 5);
+        let multiset = MultiSetContainer {
+            do_rebuild: true,
+            data,
+        };
+        let mut encoded = Vec::new();
+        multiset.encode_sequence(&mut encoded);
+        assert_eq!(encoded.len(), 1 + 2 * MULTISET_ENTRY_WIDTH);
+        assert_eq!(MultiSetContainer::decode_sequence(&encoded), multiset);
+
+        let mut children = Vec::new();
+        MultiSetContainer::visit_sequence_values(&encoded, &mut |value| children.push(value));
+        assert_eq!(children, vec![value(2), value(4)]);
+
+        let mut rebuilt = Vec::new();
+        assert!(MultiSetContainer::rebuild_sequence(
+            &encoded,
+            &Collapse {
+                from: value(4),
+                to: value(2),
+            },
+            &mut rebuilt,
+        ));
+        let rebuilt = MultiSetContainer::decode_sequence(&rebuilt);
+        assert_eq!(
+            rebuilt.data.iter_counts().collect::<Vec<_>>(),
+            vec![(value(2), 8)]
+        );
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn compact_sequence_codec_preserves_both_count_lanes() {
+        let count = u32::MAX as usize + 17;
+        let mut data = MultiSet::new();
+        data.insert_multiple_mut(value(9), count);
+        let multiset = MultiSetContainer {
+            do_rebuild: false,
+            data,
+        };
+        let mut encoded = Vec::new();
+        multiset.encode_sequence(&mut encoded);
+        assert_ne!(encoded[3], value(0));
+        assert_eq!(MultiSetContainer::decode_sequence(&encoded), multiset);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    #[should_panic(expected = "cardinality exceeds the i64 language representation")]
+    fn compact_sequence_codec_rejects_oversized_cardinality() {
+        let mut encoded = vec![value(0), value(1)];
+        encode_count(&mut encoded, i64::MAX as usize);
+        encoded.push(value(2));
+        encode_count(&mut encoded, 1);
+        MultiSetContainer::decode_sequence(&encoded);
+    }
+
+    #[test]
+    fn compact_encoding_handles_large_multiplicity() {
+        let mut egraph = EGraph::default();
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+                (sort IntMultiSet (MultiSet i64))
+                (let $large (multiset-single 7 1000000000))
+                (check (= 1000000000 (multiset-length $large)))
+                (check (= 1000000000 (multiset-count $large 7)))
+                (check (= 7 (multiset-pick $large)))
+                "#,
+            )
+            .unwrap();
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn multiset_primitives_reject_counts_beyond_i64() {
+        let mut egraph = EGraph::default();
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+                (sort IntMultiSet (MultiSet i64))
+                (let $max (multiset-single 7 9223372036854775807))
+                (check (= 9223372036854775807 (multiset-length $max)))
+                (check (= 9223372036854775807 (multiset-count $max 7)))
+                (fail (multiset-insert $max 7))
+                (fail (multiset-sum $max (multiset-single 8 1)))
+
+                (let $two (multiset-single 8 2))
+                (sort NestedIntMultiSet (MultiSet IntMultiSet))
+                (fail (multiset-sum-multisets (multiset-of $max $max $two)))
+
+                (function expand (i64) IntMultiSet :no-merge)
+                (set (expand 1) $max)
+                (set (expand 2) $two)
+                (sort ExpandFn (UnstableFn (i64) IntMultiSet))
+                (fail (unstable-multiset-flat-map
+                    (unstable-fn "expand")
+                    (multiset-of 1 1 2)))
+                "#,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn sequence_primitives_consume_local_predictions() {
+        let mut egraph = EGraph::default();
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+                (sort IntMultiSet (MultiSet i64))
+                (sort NestedIntMultiSet (MultiSet IntMultiSet))
+                (check (= 4
+                    (multiset-count
+                        (multiset-sum (multiset-single 2 3) (multiset-of 1 2))
+                        2)))
+                (check (= (multiset-of 1 2)
+                    (multiset-subtract
+                        (multiset-of 1 1 2 3)
+                        (multiset-of 1 3))))
+                (check (= (multiset-of 2 2)
+                    (multiset-intersection
+                        (multiset-of 1 2 2 2)
+                        (multiset-of 2 2 3))))
+                (check (= 1
+                    (multiset-count
+                        (multiset-reset-counts (multiset-single 9 1000000000))
+                        9)))
+                (check (= 2 (multiset-pick-max (multiset-of 1 1 2 2))))
+                (check (= (multiset-of 1 1 2)
+                    (multiset-sum-multisets
+                        (multiset-of (multiset-of 1 2) (multiset-of 1)))))
+                "#,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn counted_slice_algebra_matches_multiset_oracle_exhaustively() {
+        fn sample(mut encoded: usize) -> MultiSet<Value> {
+            let mut result = MultiSet::new();
+            for index in 0..3 {
+                let count = encoded % 3;
+                encoded /= 3;
+                if count != 0 {
+                    result.insert_multiple_mut(value(index + 10), count);
+                }
+            }
+            result
+        }
+
+        for left_code in 0..27 {
+            for right_code in 0..27 {
+                let left = sample(left_code);
+                let right = sample(right_code);
+                let left_entries = left.iter_counts().collect::<Vec<_>>();
+                let right_entries = right.iter_counts().collect::<Vec<_>>();
+
+                let sum = left.clone().sum(right.clone()).iter_counts().collect();
+                assert_eq!(
+                    merge_multisets(&left_entries, &right_entries, MultiSetBinaryOp::Sum),
+                    Some(sum)
+                );
+
+                let intersection = left
+                    .clone()
+                    .intersection(right.clone())
+                    .iter_counts()
+                    .collect();
+                assert_eq!(
+                    merge_multisets(
+                        &left_entries,
+                        &right_entries,
+                        MultiSetBinaryOp::Intersection,
+                    ),
+                    Some(intersection)
+                );
+
+                let subtraction = left
+                    .clone()
+                    .subtract(&right)
+                    .map(|result| result.iter_counts().collect());
+                assert_eq!(
+                    merge_multisets(&left_entries, &right_entries, MultiSetBinaryOp::Subtract,),
+                    subtraction
+                );
+            }
         }
     }
 }

--- a/tests/container_rebuild.rs
+++ b/tests/container_rebuild.rs
@@ -427,3 +427,29 @@ fn nested_set_rebuild_term_only() {
         )
         .unwrap();
 }
+
+/// Compact MultiSet count lanes are metadata, not child IDs. Nested rebuild
+/// propagation must follow only the semantic values in each encoded entry.
+#[test]
+fn nested_multiset_rebuild_term_only() {
+    let mut egraph = EGraph::new_with_term_encoding();
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+            (sort Math)
+            (constructor A () Math)
+            (constructor B () Math)
+            (sort MathMS (MultiSet Math))
+            (sort NestedMS (MultiSet MathMS))
+            (constructor Holds (NestedMS) Math)
+            (Holds (multiset-of (multiset-of (A) (A))))
+            (Holds (multiset-of (multiset-of (B) (B))))
+            (union (A) (B))
+            (run 1)
+            (check (= (Holds (multiset-of (multiset-of (A) (A))))
+                      (Holds (multiset-of (multiset-of (B) (B))))))
+            "#,
+        )
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

- Add a compact canonical encoding using sorted `(value, count)` entries rather than repeated values.
- Implement reads, edits, and multiset algebra directly over counted sequence slices.
- Preserve multiplicities across rebuild collisions and enforce language-level cardinality limits.
- Cover count boundaries, large multiplicities, overflow rejection, algebra, predictions, and nested rebuilds.

## Stack

Draft, stacked on #981. This is PR 9 of 12 in the sequence-backed container stack.

## Validation

Validated on the complete 12-commit stack:

- `cargo nextest run --workspace`: 1,362 tests passed
- `cargo test --workspace --doc`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`