### PR TITLE
Avoid formatting unused rule names during desugaring

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,6 @@ jobs:
           - rust_rule_match_with_serialize
           - rust_rule_insert_loop
           - rust_rule_tableaction_hot_path
-          - resolve_declaration_heavy
           - factoring-multisets
           # CodSpeed filters by substring; `math` would also run
           # `math-microbenchmark` and `proof_testing_math`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
           - rust_rule_match_with_serialize
           - rust_rule_insert_loop
           - rust_rule_tableaction_hot_path
+          - resolve_declaration_heavy
           - factoring-multisets
           # CodSpeed filters by substring; `math` would also run
           # `math-microbenchmark` and `proof_testing_math`.

--- a/benches/rust_api_benchmarking.rs
+++ b/benches/rust_api_benchmarking.rs
@@ -1,3 +1,11 @@
+#[divan::bench(sample_count = 20)]
+fn resolve_declaration_heavy(bencher: divan::Bencher) {
+    let program = include_str!("../tests/taylor51.egg");
+    bencher
+        .with_inputs(egglog::EGraph::default)
+        .bench_local_values(|mut egraph| egraph.resolve_program(None, program).unwrap());
+}
+
 #[derive(Clone, Copy)]
 struct RustRuleBenchCase {
     n_facts_input: Option<usize>,

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -122,7 +122,7 @@ pub(crate) fn desugar_command(
         }
         Command::Rewrite(ruleset, mut rewrite, subsume) => {
             let name = RuleLikeCommand::Rewrite(&ruleset, &mut rewrite, subsume).resolve_name();
-            desugar_rewrite(ruleset, name, rewrite, subsume, parser)?
+            vec![desugar_rewrite(ruleset, name, rewrite, subsume, parser)?]
         }
         Command::BiRewrite(ruleset, mut rewrite) => {
             let name = RuleLikeCommand::BiRewrite(&ruleset, &mut rewrite).resolve_name();
@@ -354,16 +354,19 @@ fn desugar_rewrite(
     rewrite: Rewrite,
     subsume: bool,
     parser: &mut Parser,
-) -> Result<Vec<NCommand>, Error> {
-    let span = rewrite.span.clone();
+) -> Result<NCommand, Error> {
+    let span = rewrite.span;
+    let lhs = rewrite.lhs;
+    let rhs = rewrite.rhs;
+    let conditions = rewrite.conditions;
     let var = parser.symbol_gen.fresh("rewrite_var__");
     let mut head = Actions::singleton(Action::Union(
         span.clone(),
         Expr::Var(span.clone(), var.clone()),
-        rewrite.rhs.clone(),
+        rhs,
     ));
     if subsume {
-        match &rewrite.lhs {
+        match &lhs {
             Expr::Call(_, f, args) => {
                 head.0.push(Action::Change(
                     span.clone(),
@@ -374,7 +377,7 @@ fn desugar_rewrite(
             }
             _ => {
                 return Err(Error::DesugarError(
-                    rewrite.lhs.span(),
+                    lhs.span(),
                     "subsumed rewrite must have a function call on the lhs".to_string(),
                 ));
             }
@@ -383,17 +386,13 @@ fn desugar_rewrite(
     // make two rules- one to insert the rhs, and one to union
     // this way, the union rule can only be fired once,
     // which helps proofs not add too much info
-    Ok(vec![NCommand::NormRule {
+    Ok(NCommand::NormRule {
         rule: Rule {
             span: span.clone(),
-            body: [Fact::Eq(
-                span.clone(),
-                Expr::Var(span, var),
-                rewrite.lhs.clone(),
-            )]
-            .into_iter()
-            .chain(rewrite.conditions.clone())
-            .collect(),
+            body: [Fact::Eq(span.clone(), Expr::Var(span, var), lhs)]
+                .into_iter()
+                .chain(conditions)
+                .collect(),
             head,
             ruleset,
             name,
@@ -401,7 +400,7 @@ fn desugar_rewrite(
             no_decomp: false,
             include_subsumed: false,
         },
-    }])
+    })
 }
 
 fn desugar_birewrite(
@@ -410,30 +409,17 @@ fn desugar_birewrite(
     rewrite: Rewrite,
     parser: &mut Parser,
 ) -> Result<Vec<NCommand>, Error> {
-    let span = rewrite.span.clone();
-    let rw2 = Rewrite {
-        span,
-        lhs: rewrite.rhs.clone(),
-        rhs: rewrite.lhs.clone(),
-        conditions: rewrite.conditions.clone(),
-        name: String::new(),
-    };
-    Ok(desugar_rewrite(
+    let mut reverse = rewrite.clone();
+    std::mem::swap(&mut reverse.lhs, &mut reverse.rhs);
+    let forward = desugar_rewrite(
         ruleset.clone(),
         format!("{rewrite_name}=>"),
         rewrite,
         false,
         parser,
-    )?
-    .into_iter()
-    .chain(desugar_rewrite(
-        ruleset,
-        format!("{rewrite_name}<="),
-        rw2,
-        false,
-        parser,
-    )?)
-    .collect())
+    )?;
+    let backward = desugar_rewrite(ruleset, format!("{rewrite_name}<="), reverse, false, parser)?;
+    Ok(vec![forward, backward])
 }
 
 /// Desugar relation by making a new sort and a constructor for it.

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -9,15 +9,7 @@ pub(crate) fn desugar_command(
     parser: &mut Parser,
     proof_testing: bool,
 ) -> Result<Vec<NCommand>, Error> {
-    let rule_name = match &command {
-        Command::Rewrite(_, rewrite, _) | Command::BiRewrite(_, rewrite)
-            if rewrite.name.is_empty() =>
-        {
-            rule_name(&command)
-        }
-        Command::Rule { rule } if rule.name.is_empty() => rule_name(&command),
-        _ => String::new(),
-    };
+    let rule_name = command_rule_name(&command);
     let res = match command {
         Command::Function {
             span,
@@ -130,24 +122,18 @@ pub(crate) fn desugar_command(
             res
         }
         Command::Rewrite(ruleset, rewrite, subsume) => {
-            let resolved_name = if rewrite.name.is_empty() {
-                rule_name
-            } else {
-                rewrite.name.clone()
-            };
+            let resolved_name = rule_name.expect("rewrite command should have a rule name");
             desugar_rewrite(ruleset, resolved_name, rewrite, subsume, parser)?
         }
         Command::BiRewrite(ruleset, rewrite) => {
-            desugar_birewrite(ruleset, rule_name, rewrite, parser)?
+            let resolved_name = rule_name.expect("birewrite command should have a rule name");
+            desugar_birewrite(ruleset, resolved_name, rewrite, parser)?
         }
         Command::Include(_span, _file) => {
             unreachable!("Include commands should be expanded before desugaring")
         }
         Command::Rule { mut rule } => {
-            if rule.name.is_empty() {
-                // format rule and use it as the name
-                rule.name = rule_name;
-            }
+            rule.name = rule_name.expect("rule command should have a rule name");
             vec![NCommand::NormRule { rule }]
         }
         Command::Sort {
@@ -392,16 +378,11 @@ fn desugar_rewrite(
 
 fn desugar_birewrite(
     ruleset: String,
-    name: String,
+    rewrite_name: String,
     rewrite: Rewrite,
     parser: &mut Parser,
 ) -> Result<Vec<NCommand>, Error> {
     let span = rewrite.span.clone();
-    let rewrite_name = if rewrite.name.is_empty() {
-        name
-    } else {
-        rewrite.name.clone()
-    };
     let rw2 = Rewrite {
         span,
         lhs: rewrite.rhs.clone(),
@@ -460,6 +441,20 @@ fn desugar_relation(
             false,
         )),
     ]
+}
+
+/// Returns the supplied rule name, or generates one for an unnamed rule-like command.
+fn command_rule_name(command: &Command) -> Option<String> {
+    let supplied_name = match command {
+        Command::Rule { rule } => &rule.name,
+        Command::Rewrite(_, rewrite, _) | Command::BiRewrite(_, rewrite) => &rewrite.name,
+        _ => return None,
+    };
+    Some(if supplied_name.is_empty() {
+        rule_name(command)
+    } else {
+        supplied_name.clone()
+    })
 }
 
 pub fn rule_name<Head, Leaf>(command: &GenericCommand<Head, Leaf>) -> String

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -9,7 +9,6 @@ pub(crate) fn desugar_command(
     parser: &mut Parser,
     proof_testing: bool,
 ) -> Result<Vec<NCommand>, Error> {
-    let rule_name = command_rule_name(&command);
     let res = match command {
         Command::Function {
             span,
@@ -121,19 +120,19 @@ pub(crate) fn desugar_command(
 
             res
         }
-        Command::Rewrite(ruleset, rewrite, subsume) => {
-            let resolved_name = rule_name.expect("rewrite command should have a rule name");
-            desugar_rewrite(ruleset, resolved_name, rewrite, subsume, parser)?
+        Command::Rewrite(ruleset, mut rewrite, subsume) => {
+            let name = RuleLikeCommand::Rewrite(&ruleset, &mut rewrite, subsume).resolve_name();
+            desugar_rewrite(ruleset, name, rewrite, subsume, parser)?
         }
-        Command::BiRewrite(ruleset, rewrite) => {
-            let resolved_name = rule_name.expect("birewrite command should have a rule name");
-            desugar_birewrite(ruleset, resolved_name, rewrite, parser)?
+        Command::BiRewrite(ruleset, mut rewrite) => {
+            let name = RuleLikeCommand::BiRewrite(&ruleset, &mut rewrite).resolve_name();
+            desugar_birewrite(ruleset, name, rewrite, parser)?
         }
         Command::Include(_span, _file) => {
             unreachable!("Include commands should be expanded before desugaring")
         }
         Command::Rule { mut rule } => {
-            rule.name = rule_name.expect("rule command should have a rule name");
+            rule.name = RuleLikeCommand::Rule(&mut rule).resolve_name();
             vec![NCommand::NormRule { rule }]
         }
         Command::Sort {
@@ -218,6 +217,35 @@ pub(crate) fn desugar_command(
     };
 
     Ok(res)
+}
+
+enum RuleLikeCommand<'a> {
+    Rule(&'a mut Rule),
+    Rewrite(&'a str, &'a mut Rewrite, bool),
+    BiRewrite(&'a str, &'a mut Rewrite),
+}
+
+impl RuleLikeCommand<'_> {
+    fn resolve_name(mut self) -> String {
+        let supplied_name = match &mut self {
+            Self::Rule(rule) => std::mem::take(&mut rule.name),
+            Self::Rewrite(_, rw, _) | Self::BiRewrite(_, rw) => std::mem::take(&mut rw.name),
+        };
+        if !supplied_name.is_empty() {
+            return supplied_name;
+        }
+        self.to_string().replace('\"', "'")
+    }
+}
+
+impl std::fmt::Display for RuleLikeCommand<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rule(rule) => std::fmt::Display::fmt(&**rule, f),
+            Self::Rewrite(ruleset, rw, subsume) => rw.fmt_with_ruleset(f, ruleset, false, *subsume),
+            Self::BiRewrite(ruleset, rw) => rw.fmt_with_ruleset(f, ruleset, true, false),
+        }
+    }
 }
 
 /// Desugars a `prove` command into egglog commands.
@@ -388,7 +416,7 @@ fn desugar_birewrite(
         lhs: rewrite.rhs.clone(),
         rhs: rewrite.lhs.clone(),
         conditions: rewrite.conditions.clone(),
-        name: rewrite_name.clone(),
+        name: String::new(),
     };
     Ok(desugar_rewrite(
         ruleset.clone(),
@@ -441,20 +469,6 @@ fn desugar_relation(
             false,
         )),
     ]
-}
-
-/// Returns the supplied rule name, or generates one for an unnamed rule-like command.
-fn command_rule_name(command: &Command) -> Option<String> {
-    let supplied_name = match command {
-        Command::Rule { rule } => &rule.name,
-        Command::Rewrite(_, rewrite, _) | Command::BiRewrite(_, rewrite) => &rewrite.name,
-        _ => return None,
-    };
-    Some(if supplied_name.is_empty() {
-        rule_name(command)
-    } else {
-        supplied_name.clone()
-    })
 }
 
 pub fn rule_name<Head, Leaf>(command: &GenericCommand<Head, Leaf>) -> String

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -9,7 +9,15 @@ pub(crate) fn desugar_command(
     parser: &mut Parser,
     proof_testing: bool,
 ) -> Result<Vec<NCommand>, Error> {
-    let rule_name = rule_name(&command);
+    let rule_name = match &command {
+        Command::Rewrite(_, rewrite, _) | Command::BiRewrite(_, rewrite)
+            if rewrite.name.is_empty() =>
+        {
+            rule_name(&command)
+        }
+        Command::Rule { rule } if rule.name.is_empty() => rule_name(&command),
+        _ => String::new(),
+    };
     let res = match command {
         Command::Function {
             span,

--- a/tests/test_desugar.rs
+++ b/tests/test_desugar.rs
@@ -1,4 +1,42 @@
-use egglog::EGraph;
+use egglog::{EGraph, ast::GenericCommand};
+
+#[test]
+fn unnamed_rule_names_are_stable() {
+    let mut egraph = EGraph::default();
+    let commands = egraph
+        .resolve_program(
+            None,
+            r#"
+                (sort Math)
+                (constructor Var (String) Math)
+                (constructor Wrap (Math) Math)
+                (rule ((= x (Var "a"))) ((union x (Var "b"))))
+                (function table (Math) Math :no-merge)
+                (rewrite (Wrap (Var "c")) (Var "c"))
+                (relation edge (Math Math))
+                (birewrite (Wrap (Var "d")) (Var "d"))
+            "#,
+        )
+        .unwrap();
+
+    let rule_names = commands
+        .into_iter()
+        .filter_map(|command| match command {
+            GenericCommand::Rule { rule } => Some(rule.name),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        rule_names,
+        [
+            "(rule ((= x (Var 'a')))\n      ((union x (Var 'b')))\n         )",
+            "(rewrite (Wrap (Var 'c')) (Var 'c'))",
+            "(birewrite (Wrap (Var 'd')) (Var 'd'))=>",
+            "(birewrite (Wrap (Var 'd')) (Var 'd'))<=",
+        ]
+    );
+}
 
 #[test]
 fn test_desugar_includes() {

--- a/tests/test_desugar.rs
+++ b/tests/test_desugar.rs
@@ -1,7 +1,7 @@
 use egglog::{EGraph, ast::GenericCommand};
 
 #[test]
-fn unnamed_rule_names_are_stable() {
+fn rule_names_are_stable() {
     let mut egraph = EGraph::default();
     let commands = egraph
         .resolve_program(
@@ -15,6 +15,9 @@ fn unnamed_rule_names_are_stable() {
                 (rewrite (Wrap (Var "c")) (Var "c"))
                 (relation edge (Math Math))
                 (birewrite (Wrap (Var "d")) (Var "d"))
+                (rule ((= x (Var "e"))) ((union x (Var "f"))) :name "named-rule")
+                (rewrite (Wrap (Var "g")) (Var "g") :name "named-rewrite")
+                (birewrite (Wrap (Var "h")) (Var "h") :name "named-birewrite")
             "#,
         )
         .unwrap();
@@ -34,6 +37,10 @@ fn unnamed_rule_names_are_stable() {
             "(rewrite (Wrap (Var 'c')) (Var 'c'))",
             "(birewrite (Wrap (Var 'd')) (Var 'd'))=>",
             "(birewrite (Wrap (Var 'd')) (Var 'd'))<=",
+            "named-rule",
+            "named-rewrite",
+            "named-birewrite=>",
+            "named-birewrite<=",
         ]
     );
 }

--- a/tests/test_desugar.rs
+++ b/tests/test_desugar.rs
@@ -1,48 +1,44 @@
-use egglog::{EGraph, ast::GenericCommand};
+use egglog::EGraph;
 
 #[test]
 fn rule_names_are_stable() {
-    let mut egraph = EGraph::default();
-    let commands = egraph
+    let rule_names = EGraph::default()
         .resolve_program(
             None,
             r#"
-                (sort Math)
-                (constructor Var (String) Math)
-                (constructor Wrap (Math) Math)
-                (rule ((= x (Var "a"))) ((union x (Var "b"))))
-                (function table (Math) Math :no-merge)
-                (rewrite (Wrap (Var "c")) (Var "c"))
-                (relation edge (Math Math))
-                (birewrite (Wrap (Var "d")) (Var "d"))
+                (datatype Math (Var String) (Wrap Math))
+                (ruleset generated-names)
+                (rule ((= x (Var "a"))) ((union x (Var "b")))
+                    :ruleset generated-names :unsafe-seminaive :no-decomp
+                    :internal-include-subsumed)
+                (rewrite (Wrap (Var "c")) (Var "c") :subsume
+                    :when ((= (Var "c") (Var "c"))) :ruleset generated-names)
+                (birewrite (Wrap (Var "d")) (Var "d")
+                    :when ((= (Var "d") (Var "d"))) :ruleset generated-names)
                 (rule ((= x (Var "e"))) ((union x (Var "f"))) :name "named-rule")
                 (rewrite (Wrap (Var "g")) (Var "g") :name "named-rewrite")
                 (birewrite (Wrap (Var "h")) (Var "h") :name "named-birewrite")
             "#,
         )
-        .unwrap();
-
-    let rule_names = commands
+        .unwrap()
         .into_iter()
         .filter_map(|command| match command {
-            GenericCommand::Rule { rule } => Some(rule.name),
+            egglog::ast::GenericCommand::Rule { rule } => Some(rule.name),
             _ => None,
         })
         .collect::<Vec<_>>();
 
-    assert_eq!(
-        rule_names,
-        [
-            "(rule ((= x (Var 'a')))\n      ((union x (Var 'b')))\n         )",
-            "(rewrite (Wrap (Var 'c')) (Var 'c'))",
-            "(birewrite (Wrap (Var 'd')) (Var 'd'))=>",
-            "(birewrite (Wrap (Var 'd')) (Var 'd'))<=",
-            "named-rule",
-            "named-rewrite",
-            "named-birewrite=>",
-            "named-birewrite<=",
-        ]
-    );
+    let expected = [
+        "(rule ((= x (Var 'a')))\n      ((union x (Var 'b')))\n        :ruleset generated-names  :unsafe-seminaive :no-decomp :internal-include-subsumed)",
+        "(rewrite (Wrap (Var 'c')) (Var 'c') :subsume :when ((= (Var 'c') (Var 'c'))) :ruleset generated-names)",
+        "(birewrite (Wrap (Var 'd')) (Var 'd') :when ((= (Var 'd') (Var 'd'))) :ruleset generated-names)=>",
+        "(birewrite (Wrap (Var 'd')) (Var 'd') :when ((= (Var 'd') (Var 'd'))) :ruleset generated-names)<=",
+        "named-rule",
+        "named-rewrite",
+        "named-birewrite=>",
+        "named-birewrite<=",
+    ];
+    assert_eq!(rule_names, expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Generate automatic names only for unnamed `rule`, `rewrite`, and `birewrite` commands.
- Preserve supplied names without formatting or cloning them.
- Preserve generated names byte-for-byte, with exact regression coverage for rule options, rewrite conditions, quote normalization, and both birewrite directions.
- Keep a declaration-heavy local `resolve_program` benchmark over `tests/taylor51.egg`; it is intentionally absent from the CodSpeed CI matrix.

## Why

`desugar_command` previously formatted every command before matching on its variant, even though declarations and most other commands cannot consume an automatically generated rule name.

The final implementation resolves names inside the three relevant match arms. A borrowed `RuleLikeCommand` view ties the actual `Rule` or `Rewrite` name field to its canonical formatter. `resolve_name` moves a supplied name out unchanged and formats only when that field is empty. The original owned payload then continues through its already-refined desugaring arm.

This keeps one naming invariant without an `Option`- or sentinel-based resolver, AST reconstruction, name clone, partial match, or panic extraction. The public `rule_name` formatter remains unchanged. This PR does not touch the typechecker.

After the final simplification review, the scoped diff against fresh main is `87` additions and `21` deletions. The production file is 10 lines shorter, and the regression test is 9 lines shorter, than the preceding owned-wrapper candidate and expanded test reviewed during this iteration.

## Performance

I compared fresh upstream main at `7b1adf249c918226871b9b3d5e8f089585e46e99` with the final implementation using byte-identical benchmark code and the same Taylor51 fixture:

- Divan OS timer, sample size 1
- 5 warmups per endpoint
- 12 balanced blocks with 5 samples per endpoint per block (60 measurements each)
- all six endpoint orders repeated twice
- geometric mean of paired block-median ratios with a 20,000-resample block-bootstrap interval

| Endpoint | Median of block medians |
| --- | ---: |
| Fresh main | 20.180 ms |
| Intermediate owned wrapper | 19.870 ms |
| This patch | 19.745 ms |

The patch/main ratio was `0.9773`: **2.27% less time**, with a 95% interval of **1.80% to 2.77% less time**.

The patch/intermediate ratio was `0.9900`: **1.00% less time**, with a 95% interval of **0.12% to 2.08% less time**.

The final one-line source cleanup was rebuilt separately; its complete Mach-O `__TEXT,__text` section was byte-identical to the measured candidate. This Rust API benchmark uses the system allocator; both measured endpoints used the same allocator and harness.

## Validation

- `cargo test --release --test test_desugar` (2 passed)
- `make nits`
- `make test` (1,167 tests passed, plus doctests; no snapshot issues)
- `git diff --check`
