### PR TITLE
Avoid rebuilding rule query constraints

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -1,8 +1,5 @@
 use crate::{
-    core::{
-        Atom, CoreAction, CoreRule, GenericCoreActions, GenericCoreRule, HeadOrEq, Query,
-        StringOrEq,
-    },
+    core::{Atom, CoreAction, GenericCoreActions, GenericCoreRule, HeadOrEq, Query, StringOrEq},
     *,
 };
 use std::{cmp, rc::Rc};
@@ -770,30 +767,6 @@ impl Problem<AtomTerm, ArcSort> {
                 _ => (),
             }
         }
-        Ok(())
-    }
-
-    pub(crate) fn add_rule(
-        &mut self,
-        rule: &CoreRule,
-        typeinfo: &TypeInfo,
-        symbol_gen: &mut SymbolGen,
-        query_ctx: crate::Context,
-        action_ctx: crate::Context,
-    ) -> Result<(), TypeError> {
-        let CoreRule {
-            span: _,
-            head,
-            body,
-        } = rule;
-        // Rule body atoms run as the LHS query; head atoms run as the
-        // RHS action. Contexts come from the caller — currently rule
-        // bodies always typecheck under `Read` and actions under
-        // `Full`; whether the rule actually opts out of seminaive is
-        // decided post-typecheck by walking for non-`Pure`/non-`Write`
-        // primitive kinds.
-        self.add_query(body, typeinfo, query_ctx)?;
-        self.add_actions(head, typeinfo, symbol_gen, action_ctx)?;
         Ok(())
     }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -908,7 +908,6 @@ pub struct GenericCoreRule<HeadQ, HeadA, Leaf> {
     pub head: GenericCoreActions<HeadA, Leaf>,
 }
 
-pub(crate) type CoreRule = GenericCoreRule<StringOrEq, String, String>;
 pub(crate) type ResolvedCoreRule = GenericCoreRule<ResolvedCall, ResolvedCall, ResolvedVar>;
 
 impl<Head1, Head2, Leaf> GenericCoreRule<Head1, Head2, Leaf>

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -3,7 +3,7 @@ use std::hash::Hasher;
 use crate::Context;
 use crate::proofs::proof_container_rebuild::register_container_rebuild_from_spec;
 use crate::{
-    core::{CoreActionContext, CoreRule, GenericActionsExt, ResolvedCall},
+    core::{CoreActionContext, GenericActionsExt, ResolvedCall},
     *,
 };
 use ast::{
@@ -886,8 +886,6 @@ impl TypeInfo {
             no_decomp,
             include_subsumed,
         } = rule;
-        let mut constraints = vec![];
-
         // Compile with the permissive Read/Full primitive contexts (so the RHS
         // can read the database) when the whole EGraph is non-seminaive, or the
         // rule's own mode requires it (`:naive` / `:unsafe-seminaive`).
@@ -903,26 +901,15 @@ impl TypeInfo {
         };
 
         let (query, mapped_query) = Facts(body.clone()).to_query(self, symbol_gen);
-        constraints.extend(query.get_constraints(self, query_ctx)?);
+        let mut problem = Problem::default();
+        problem.add_query(&query, self, query_ctx)?;
 
         let mut binding = query.get_vars();
         // We lower to core actions with `union_to_set_optimization`
         // later in the pipeline. For typechecking we do not need it.
         let mut ctx = CoreActionContext::new(self, &mut binding, symbol_gen, false);
         let (actions, mapped_action) = head.to_core_actions(&mut ctx)?;
-
-        let mut problem = Problem::default();
-        problem.add_rule(
-            &CoreRule {
-                span: span.clone(),
-                body: query,
-                head: actions,
-            },
-            self,
-            symbol_gen,
-            query_ctx,
-            action_ctx,
-        )?;
+        problem.add_actions(&actions, self, symbol_gen, action_ctx)?;
 
         let assignment = problem
             .solve(|sort: &ArcSort| sort.name())


### PR DESCRIPTION
## Summary

- add each rule query's constraints directly to its real `Problem` instead of constructing and discarding them first
- preserve query constraint construction before action lowering, so existing error precedence remains unchanged
- remove the now-unused `Problem::add_rule` forwarding method and `CoreRule` alias

## Performance

The removed direct `Query::get_constraints` pass accounted for these sampled shares of typechecking in baseline profiles:

| Workload | Share |
|---|---:|
| `python_array_optimize` | 2.251% and 2.704% in two independent profiles |
| `eggcc-2mm` | 2.716% |
| `gemma4_moe` | 1.010% |
| `stresstest_large_expr` | 0.064% |

Post-change profiles attribute zero samples to that caller. This establishes that the duplicate typechecking work is removed; it is not a claim of a precise end-to-end CI benchmark speedup.

The production diff is 5 insertions and 46 deletions (net -41 lines).

## Validation

- `cargo check -p egglog --no-default-features --lib`
- `cargo nextest run -p egglog --test typed_primitive` (13 passed)
- `make test` (1,166 release tests passed, plus doctests)
- `make nits`
- `git diff --check`

An independent review loop checked DRY, code complexity, diff size, correctness, and speed attribution and found no remaining changes.

The larger inferred-primitive-resolution experiment is intentionally deferred in [saulshanabrook/egglog-encoding#66](https://github.com/saulshanabrook/egglog-encoding/issues/66), with the full prototype and measurement evidence preserved there.
