### PR TITLE
Prepare for egglog 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,40 +2,47 @@
 
 ## [Unreleased] - ReleaseDate
 
-- Fix a crash where bounded table scans with column constraints could yield stale (deleted) rows, leaking the stale value marker into primitives and panicking with an out-of-bounds intern-table read (e.g. `index out of bounds: the len is 0 but the index is 2147483647`).
-- Fix a build failure when egglog is compiled without default features (as a library dependency). The `egglog-add-primitive` proc macro parses full Rust expressions and now declares `syn`'s `full` feature directly, instead of relying on another crate (`clap_derive`, via the `bin` feature) to unify it onto our `syn`. This surfaced when `clap_derive` moved to `syn` 3.x. A CI job now builds `-p egglog --no-default-features` to catch regressions.
-- Convert many reachable `panic!`/`unwrap`/`expect`/`todo!` sites into recoverable errors, so malformed or edge-case programs report an error instead of aborting the process. Examples now returning `Error`/`TypeError`/`ParseError`/`ProveExistsError`: malformed sort-constructor declarations like `(sort S (Vec))` or `(sort S (UnstableFn))`; negative `extract` variant counts; duplicate rule names; `unstable-fn` referencing an unknown, non-literal, or mis-typed target; `(fail ...)` wrapping `include` or an empty expansion; subsuming a non-call rewrite; running `prove`/`prove-exists` without proofs enabled; and missing/unreadable files for `input`, `print-function`, `print-overall-statistics`, and the CLI. Several primitives became partial (returning no result instead of panicking) on out-of-range input: `vec-set`/`vec-remove` indices, `multiset-pick` on an empty multiset, count overflow in `multiset` operations, and the numeric primitives `bigint <<`/`>>`, `bigrat`, and `log2`. A few scheduler edge cases (unknown ruleset, rules with no free variables) no longer panic; variable-free rules now correctly apply their actions when scheduled. Primitive resolution now returns `TypeError::AmbiguousPrimitive`/`TypeError::UnresolvedPrimitive` instead of panicking when duplicate same-signature registrations are indistinguishable or nothing resolves; both direct calls and `unstable-fn` primitive targets report the same variants. `step_rules_with_scheduler` now restores its `rulesets`/`schedulers` on every fallible path, so an error during scheduled rule compilation no longer leaves the `EGraph` in a corrupted state.
-- **Breaking:** a function's signature is stored once, in `TypeInfo`, instead of copied into `Function`, `GenericFunctionDecl`, and every resolved call site. `Function::schema() -> &ResolvedSchema` becomes `Function::func_type() -> &FuncType` and `ResolvedSchema` is removed (its `get_by_pos` moves to `FuncType`); `ResolvedCall::Func` holds an `Arc<FuncType>`; and `GenericFunctionDecl::resolved_schema` is gone, along with the placeholder `String` an unresolved decl used to carry in it.
-- **Breaking:** an operation that runs external functions now takes an `ExternalContext` — a borrowed value it makes visible to them, which `ExecutionState::external_context` reads back. `Database::run_rule_set` / `with_execution_state` / `with_execution_state_tracked` and the bridge's `EGraph::run_rules` / `with_execution_state*` take one; pass `None` if there is nothing to share. egglog passes its `&TypeInfo`, which is how a primitive resolves a signature without the e-graph handing out a shared, lock-guarded copy: the borrow is live for exactly the operation that supplied it, so nothing can be declared while a rule is running.
-- **Breaking:** `EGraph::print_function` now takes its output sink as `Option<(File, PathBuf)>` plus a `Span`, so write failures return `Error::IoError` instead of panicking.
-- Speed up query evaluation by building on-the-fly per-subset column indexes as sorted arrays (`SortedColumnIndex`) instead of hash maps. These indexes are typically iterated once and probed a bounded number of times over high-cardinality columns, so skipping hash-table construction is a large win (e.g. ~33% faster on the `gemma` benchmark).
-- Share trie roots (and their cached sub-indexes and child nodes) across query plans within a single `run_rule_set` instead of rebuilding a fresh trie per plan. Plans that scan the same table under the same header (fast) constraints reuse one root, so on-the-fly per-subset index builds happen once rather than per plan; only roots that more than one plan uses are shared, so workloads that would not benefit keep the per-plan behavior. Large speedups on transformer workloads (e.g. ~15% faster on `whisper`, ~12% on `gemma`, ~8% on `qwen3_moe`).
-- Add `make nightly` and `scripts/nightly_bench.py`, a hyperfine-based benchmark harness that measures every `tests/**/*.egg` program at 1/2/4/8 threads and (where supported) in proof-testing mode, caps each run at a 2-minute timeout, skips sub-50ms programs, and emits an HTML dashboard (one row per benchmark, one column per configuration) for nightly.cs.washington.edu. The dashboard uses [eval-live](https://github.com/oflatt/eval-live) for interactive filtering and sorting.
-- Add typed `EGraph` extension state that clones with `EGraph` and is restored by `push`/`pop`.
-- Fix custom scheduler queries so subsumed rows are not offered as fresh matches.
-- Replace the global Rayon thread pool with an `egglog-concurrency` scoped `ThreadPool`; configure parallelism per `EGraph` via `with_num_threads` / `set_num_threads`.
-- Report full source file paths in egglog span and error messages.
-- Fix seminaive matching after nested containers rebuild in place by propagating dirty container ids through parent containers.
-- Fix multi-column secondary index rebuilds so each value's rows come back sorted by row id, and make all rebuild paths (serial, parallel, and bulk) record a row once even when its value repeats across covered columns (#914).
-- Render nullary AST calls without a trailing space, e.g. (foo) instead of (foo ).
-- Escape `"` and `\` when displaying string literals so printed/serialized programs round-trip through the parser.
-- Add a BigRat to-i64 primitive for integral rationals.
-- Add f64 exp, log, and sqrt primitives.
-- Add `RunReport::can_stop` so scheduler progress can be reported separately from database updates.
-- Add `EGraph::typecheck_expr_with_bindings_and_output`, `Core::eval_resolved_expr`, and `Core::apply_primitive` for body-defined primitive support, including normal command-path global rewrites for expressions typechecked through the helper.
-- Allow `unstable-fn` function containers to target primitive overloads.
-- Desugar `relation`s to `constructor`s to simplify the language and implementation. Relations no longer return unit `()` values.
-- Refactored API to use [`TermId`] more consistently instead of `Term` where possible, simplifying egglog code.
-- **Typed primitive surface for seminaive safety (#772).** Custom primitives now pick one of `PurePrim` / `ReadPrim` / `WritePrim` / `FullPrim` based on what the body needs, and register via the matching `add_*_primitive`. Rust enforces capability bounds via the state wrapper passed to the body; the egglog typechecker enforces context bounds. See the `egglog::exec_state` module docs and the `*Prim` trait docs for the full picture. Migration: `rust_rule` callbacks now take `&mut WriteState` (replacing `RustRuleContext`); a new `rust_rule_full` gives action callbacks read access. Higher-order primitives over `unstable-fn` values dispatch via `state.apply_function(&fc, args)`.
-- Expose `Read::table_size(name)` and `Read::table_sizes()` so read-capable primitives can inspect row counts without raw execution-state access, while avoiding an all-table scan when only one table is needed.
-- **`:naive` and `:unsafe-seminaive` rule options** (mutually exclusive). Both compile a rule under the permissive `Read`/`Full` contexts so its RHS can read the database (read-primitives and function-table lookups). `:naive` matches the whole database every iteration; `:unsafe-seminaive` keeps seminaive (delta) matching, which is faster but **unsafe** — an RHS read observes the database mid-iteration, so results can depend on evaluation order. `:unsafe-seminaive` is rejected by the term/proof encoding.
-- **Name-indexed e-graph access from primitives and `rust_rule` callbacks (#745, #751).** New `Read` / `Write` capability traits on the state wrappers let primitive bodies and rule callbacks read/write tables by name (`fs.lookup`, `fs.set`, `fs.add`, `fs.union`, `fs.function_entries`, `fs.constructor_enodes`, etc.) instead of through raw `FunctionId` + `&[Value]`; `EGraph::update(|fs| ...)` gives the same surface outside a rule, and `EGraph::function_entries` / `EGraph::constructor_enodes` expose the table scans directly at the top level. Misuse (wrong subtype, wrong arity, unknown table) surfaces as `Error::ApiError`. Also `Read::enodes_for_eclass` (a constructor's rows by output e-class, through the backend's column index rather than a scan), `Read::constructor_schema` / `Read::function_schema` / `Read::table_subtype` (a table's declared signature and subtype, which a primitive body could not previously see at all), and `Core::rebuild_container` (remap a container value's contents and intern the result, for container sorts whose Rust type the caller cannot name). Together these let an out-of-tree primitive walk and rebuild a sub-e-graph — see `unstable-subst` in `egglog-experimental`.
-- **Container support in the term/proof encoding.** Programs using container sorts (`Vec`, `Set`, `Map`, `MultiSet`, `Pair`) now work under the term/proof encoding (previously rejected), including containers read (`vec-get`, `map-get`, …) or constructed (`vec-of`, `set-of`, …) in a rule body (`set-get` excepted: it indexes an internal runtime order that proofs cannot reproduce). A container built in the body is a *side condition* with no carryable proof: it is marked with an `Eval` proof step and re-evaluated against the typed rule when checked, so it can be read or matched in the query but not carried into an action (that is rejected). Two user-visible extraction changes: container terms extract in a deterministic, reproducible order rather than value-id order, and maps extract in a flat `(map-of k0 v0 …)` form (new `map-of` constructor) instead of nested `map-insert`s.
+## [3.0.0] - 2026-08-18
+
+### Breaking changes
+
+- **Relations are now constructors.** A `relation` is desugared to a non-unionable constructor instead of a function returning unit `()`.
+- **Custom primitives use capability-specific traits (#772).** Implement `PurePrim`, `ReadPrim`, `WritePrim`, or `FullPrim` and register it with the corresponding `add_*_primitive` method. `rust_rule` callbacks now take `&mut WriteState` instead of `RustRuleContext`; use `rust_rule_full` when a callback also needs read access. Higher-order primitives dispatch through `state.apply_function`.
+- **Thread configuration is now per e-graph.** The global Rayon pool is replaced by a scoped `egglog-concurrency` pool. `EGraph::set_num_threads` now takes `&mut self`; `EGraph::new`, `with_num_threads`, and `set_num_threads` configure one e-graph without affecting others.
+- **The function schema API has changed.** `Function::schema()` is replaced by `Function::func_type()`, `ResolvedSchema` is replaced by `FuncType`, and `GenericFunctionDecl::resolved_schema` is removed.
+- **Backend execution APIs now take an `ExternalContext`.** `Database::run_rule_set`, `with_execution_state`, `with_execution_state_tracked`, and the corresponding bridge APIs require the context; pass `None` when no external data is needed.
+- **`EGraph::print_function` has a new signature.** It now takes an `Option<(File, PathBuf)>` output sink and a `Span`, allowing write failures to return `Error::IoError`.
+
+### New features and improvements
+
+- **Add name-indexed e-graph access for primitives and `rust_rule` callbacks (#745, #751).** The `Read` and `Write` APIs now support table lookup and mutation, table and constructor scans, schema queries, table-size queries, and indexed e-class traversal by name. `EGraph::read`, `EGraph::update`, and top-level scan methods expose the same capabilities outside callbacks. Invalid names, types, and arities return `Error::ApiError`. These APIs support out-of-tree extensions such as `unstable-subst` in `egglog-experimental`.
+- **Add container support to the term/proof encoding.** Programs can read and construct `Vec`, `Set`, `Map`, `MultiSet`, and `Pair` values in rule bodies (`set-get` remains unsupported). Body-created containers are proof side conditions and cannot be carried into actions. Container extraction is now deterministic, and maps extract in flat `(map-of k0 v0 …)` form.
+- **Add `:naive` and `:unsafe-seminaive` rule options.** Both permit database reads on a rule's right-hand side. `:naive` matches the full database each iteration; `:unsafe-seminaive` keeps delta matching but can be evaluation-order dependent and is rejected by the term/proof encoding. The options are mutually exclusive.
+- Add typed `EGraph` extension state that clones with the e-graph and is restored by `push` and `pop`.
+- Add typechecking and evaluation APIs for body-defined primitives: `EGraph::typecheck_expr_with_bindings_and_output`, `Core::eval_resolved_expr`, and `Core::apply_primitive`. `unstable-fn` containers can now target primitive overloads.
+- Add `f64` `exp`, `log`, and `sqrt` primitives, plus `BigRat`-to-`i64` conversion for integral values.
+- Add `RunReport::can_stop` so scheduler progress can be distinguished from database updates.
+- Report full source paths in spans and error messages.
+
+### Performance
+
+- Speed up query evaluation with sorted-array subset indexes and by sharing trie roots across compatible query plans. Measured improvements include about 33% on `gemma` from sorted indexes and about 15% on `whisper`, 12% on `gemma`, and 8% on `qwen3_moe` from trie sharing.
+
+### Bug fixes
+
+- Fix a crash where constrained bounded scans could return stale, deleted rows to primitives.
+- Replace many reachable panics with recoverable errors, including malformed declarations and commands, invalid primitive calls, unavailable proof operations, missing files, duplicate rule names, and unknown rulesets. Out-of-range partial primitives now return no result, variable-free scheduled rules execute correctly, and scheduler state is restored after errors.
+- Fix seminaive matching after nested containers are rebuilt in place.
+- Fix custom scheduler queries offering subsumed rows as fresh matches.
+- Fix multi-column secondary indexes returning rows out of order or recording duplicates during rebuilds (#914).
+- Fix builds of egglog as a library with default features disabled.
+- Improve printed syntax: nullary calls render as `(foo)`, and string literals escape `"` and `\` so they round-trip through the parser.
 
 ## [2.0.0] - 2026-02-11
 
 Bigger changes
 
+- **Breaking:** extraction APIs now return `TermId` values paired with a `TermDag` instead of returning owned `Term` values. This affects `EGraph::extract_value`, `Extractor::extract_best`, `EGraph::function_to_dag`, and the extraction variants of `CommandOutput`.
 - Index catalog optimized for small set of indices (#719)
 - Warn when globals lack the $ prefix; require globals to use the `$` prefix; missing prefixes now log a warning by default and can be upgraded to errors with `--strict-mode` or `EGraph::set_strict_mode`. (#722)
 - Rename global vars in tests (#792, #800)
@@ -254,7 +261,7 @@ This is egglog's first release! Egglog is ready for use, but is still fairly exp
 As of yet, the rust interface is not documented or well supported. We recommend using the language interface. Egglog also lacks proofs, a feature that egg has.
 
 
-[Unreleased]: https://github.com/egraphs-good/egglog/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/egraphs-good/egglog/compare/v3.0.0...HEAD
 [0.1.0]: https://github.com/egraphs-good/egglog/tree/v0.1.0
 [0.2.0]: https://github.com/egraphs-good/egglog/tree/v0.2.0
 [0.3.0]: https://github.com/egraphs-good/egglog/tree/v0.3.0
@@ -262,6 +269,7 @@ As of yet, the rust interface is not documented or well supported. We recommend 
 [0.5.0]: https://github.com/egraphs-good/egglog/tree/v0.5.0
 [1.0.0]: https://github.com/egraphs-good/egglog/tree/v1.0.0
 [2.0.0]: https://github.com/egraphs-good/egglog/tree/v2.0.0
+[3.0.0]: https://github.com/egraphs-good/egglog/tree/v3.0.0
 
 
 See release-instructions.md for more information on how to do a release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,43 +6,43 @@
 
 ### Breaking changes
 
-- **Relations are now constructors.** A `relation` is desugared to a non-unionable constructor instead of a function returning unit `()`.
-- **Custom primitives use capability-specific traits (#772).** Implement `PurePrim`, `ReadPrim`, `WritePrim`, or `FullPrim` and register it with the corresponding `add_*_primitive` method. `rust_rule` callbacks now take `&mut WriteState` instead of `RustRuleContext`; use `rust_rule_full` when a callback also needs read access. Higher-order primitives dispatch through `state.apply_function`.
-- **Thread configuration is now per e-graph.** The global Rayon pool is replaced by a scoped `egglog-concurrency` pool. `EGraph::set_num_threads` now takes `&mut self`; `EGraph::new`, `with_num_threads`, and `set_num_threads` configure one e-graph without affecting others.
-- **The function schema API has changed.** `Function::schema()` is replaced by `Function::func_type()`, `ResolvedSchema` is replaced by `FuncType`, and `GenericFunctionDecl::resolved_schema` is removed.
-- **Backend execution APIs now take an `ExternalContext`.** `Database::run_rule_set`, `with_execution_state`, `with_execution_state_tracked`, and the corresponding bridge APIs require the context; pass `None` when no external data is needed.
-- **`EGraph::print_function` has a new signature.** It now takes an `Option<(File, PathBuf)>` output sink and a `Span`, allowing write failures to return `Error::IoError`.
+- **Relations are now constructors.** A `relation` is desugared to a non-unionable constructor instead of a function returning unit `()` (#770).
+- **Custom primitives use capability-specific traits.** Implement `PurePrim`, `ReadPrim`, `WritePrim`, or `FullPrim` and register it with the corresponding `add_*_primitive` method. `rust_rule` callbacks now take `&mut WriteState` instead of `RustRuleContext`; use `rust_rule_full` when a callback also needs read access. Higher-order primitives dispatch through `state.apply_function` (#856).
+- **Thread configuration is now per e-graph.** The global Rayon pool is replaced by a scoped `egglog-concurrency` pool. `EGraph::set_num_threads` now takes `&mut self`; `EGraph::new`, `with_num_threads`, and `set_num_threads` configure one e-graph without affecting others (#910).
+- **The function schema API has changed.** `Function::schema()` is replaced by `Function::func_type()`, `ResolvedSchema` is replaced by `FuncType`, and `GenericFunctionDecl::resolved_schema` is removed (#986).
+- **Backend execution APIs now take an `ExternalContext`.** `Database::run_rule_set`, `with_execution_state`, `with_execution_state_tracked`, and the corresponding bridge APIs require the context; pass `None` when no external data is needed (#986).
+- **`EGraph::print_function` has a new signature.** It now takes an `Option<(File, PathBuf)>` output sink and a `Span`, allowing write failures to return `Error::IoError` (#920).
 
 ### New features and improvements
 
-- **Add name-indexed e-graph access for primitives and `rust_rule` callbacks (#745, #751).** The `Read` and `Write` APIs now support table lookup and mutation, table and constructor scans, schema queries, table-size queries, and indexed e-class traversal by name. `EGraph::read`, `EGraph::update`, and top-level scan methods expose the same capabilities outside callbacks. Invalid names, types, and arities return `Error::ApiError`. These APIs support out-of-tree extensions such as `unstable-subst` in `egglog-experimental`.
-- **Add container support to the term/proof encoding.** Programs can read and construct `Vec`, `Set`, `Map`, `MultiSet`, and `Pair` values in rule bodies (`set-get` remains unsupported). Body-created containers are proof side conditions and cannot be carried into actions. Container extraction is now deterministic, and maps extract in flat `(map-of k0 v0 …)` form.
-- **Add `:naive` and `:unsafe-seminaive` rule options.** Both permit database reads on a rule's right-hand side. `:naive` matches the full database each iteration; `:unsafe-seminaive` keeps delta matching but can be evaluation-order dependent and is rejected by the term/proof encoding. The options are mutually exclusive.
-- Add typed `EGraph` extension state that clones with the e-graph and is restored by `push` and `pop`.
-- Add typechecking and evaluation APIs for body-defined primitives: `EGraph::typecheck_expr_with_bindings_and_output`, `Core::eval_resolved_expr`, and `Core::apply_primitive`. `unstable-fn` containers can now target primitive overloads.
-- Add `f64` `exp`, `log`, and `sqrt` primitives, plus `BigRat`-to-`i64` conversion for integral values.
-- Add `RunReport::can_stop` so scheduler progress can be distinguished from database updates.
-- Report full source paths in spans and error messages.
+- **Add name-indexed e-graph access for primitives and `rust_rule` callbacks.** The `Read` and `Write` APIs now support table lookup and mutation, table and constructor scans, schema queries, table-size queries, and indexed e-class traversal by name. `EGraph::read`, `EGraph::update`, and top-level scan methods expose the same capabilities outside callbacks. Invalid names, types, and arities return `Error::ApiError`. These APIs support out-of-tree extensions such as `unstable-subst` in `egglog-experimental` (#892, #895, #901, #986).
+- **Add container support to the term/proof encoding.** Programs can read and construct `Vec`, `Set`, `Map`, `MultiSet`, and `Pair` values in rule bodies (`set-get` remains unsupported). Body-created containers are proof side conditions and cannot be carried into actions. Container extraction is now deterministic, and maps extract in flat `(map-of k0 v0 …)` form (#927).
+- **Add `:naive` and `:unsafe-seminaive` rule options.** Both permit database reads on a rule's right-hand side. `:naive` matches the full database each iteration; `:unsafe-seminaive` keeps delta matching but can be evaluation-order dependent and is rejected by the term/proof encoding. The options are mutually exclusive (#912).
+- Add typed `EGraph` extension state that clones with the e-graph and is restored by `push` and `pop` (#884).
+- Add typechecking and evaluation APIs for body-defined primitives: `EGraph::typecheck_expr_with_bindings_and_output`, `Core::eval_resolved_expr`, and `Core::apply_primitive`. `unstable-fn` containers can now target primitive overloads (#881, #889).
+- Add `f64` `exp`, `log`, and `sqrt` primitives, plus `BigRat`-to-`i64` conversion for integral values (#890, #891).
+- Add `RunReport::can_stop` so scheduler progress can be distinguished from database updates (#882).
+- Report full source paths in spans and error messages (#886).
 
 ### Performance
 
-- Speed up query evaluation with sorted-array subset indexes and by sharing trie roots across compatible query plans. Measured improvements include about 33% on `gemma` from sorted indexes and about 15% on `whisper`, 12% on `gemma`, and 8% on `qwen3_moe` from trie sharing.
+- Speed up query evaluation with sorted-array subset indexes and by sharing trie roots across compatible query plans. Measured improvements include about 33% on `gemma` from sorted indexes and about 15% on `whisper`, 12% on `gemma`, and 8% on `qwen3_moe` from trie sharing (#948, #949).
 
 ### Bug fixes
 
-- Fix a crash where constrained bounded scans could return stale, deleted rows to primitives.
-- Replace many reachable panics with recoverable errors, including malformed declarations and commands, invalid primitive calls, unavailable proof operations, missing files, duplicate rule names, and unknown rulesets. Out-of-range partial primitives now return no result, variable-free scheduled rules execute correctly, and scheduler state is restored after errors.
-- Fix seminaive matching after nested containers are rebuilt in place.
-- Fix custom scheduler queries offering subsumed rows as fresh matches.
+- Fix a crash where constrained bounded scans could return stale, deleted rows to primitives (#964).
+- Replace many reachable panics with recoverable errors, including malformed declarations and commands, invalid primitive calls, unavailable proof operations, missing files, duplicate rule names, and unknown rulesets. Out-of-range partial primitives now return no result, variable-free scheduled rules execute correctly, and scheduler state is restored after errors (#876, #908, #920).
+- Fix seminaive matching after nested containers are rebuilt in place (#888).
+- Fix custom scheduler queries offering subsumed rows as fresh matches (#885).
 - Fix multi-column secondary indexes returning rows out of order or recording duplicates during rebuilds (#914).
-- Fix builds of egglog as a library with default features disabled.
-- Improve printed syntax: nullary calls render as `(foo)`, and string literals escape `"` and `\` so they round-trip through the parser.
+- Fix builds of egglog as a library with default features disabled (#961).
+- Improve printed syntax: nullary calls render as `(foo)`, and string literals escape `"` and `\` so they round-trip through the parser (#887, #920).
 
 ## [2.0.0] - 2026-02-11
 
 Bigger changes
 
-- **Breaking:** extraction APIs now return `TermId` values paired with a `TermDag` instead of returning owned `Term` values. This affects `EGraph::extract_value`, `Extractor::extract_best`, `EGraph::function_to_dag`, and the extraction variants of `CommandOutput`.
+- **Breaking:** extraction APIs now return `TermId` values paired with a `TermDag` instead of returning owned `Term` values. This affects `EGraph::extract_value`, `Extractor::extract_best`, `EGraph::function_to_dag`, and the extraction variants of `CommandOutput` (#789).
 - Index catalog optimized for small set of indices (#719)
 - Warn when globals lack the $ prefix; require globals to use the `$` prefix; missing prefixes now log a warning by default and can be upgraded to errors with `--strict-mode` or `EGraph::set_strict_mode`. (#722)
 - Rename global vars in tests (#792, #800)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "egglog"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "chrono",
  "clap",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "egglog-add-primitive"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -504,14 +504,14 @@ dependencies = [
 
 [[package]]
 name = "egglog-ast"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "ordered-float",
 ]
 
 [[package]]
 name = "egglog-bridge"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "dyn-clone",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "egglog-concurrency"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "arc-swap",
  "bumpalo",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "egglog-core-relations"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -580,11 +580,11 @@ dependencies = [
 
 [[package]]
 name = "egglog-numeric-id"
-version = "2.0.0"
+version = "3.0.0"
 
 [[package]]
 name = "egglog-reports"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "clap",
  "hashbrown 0.16.0",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "egglog-union-find"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "codspeed-divan-compat",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "3.0.0"
 edition = "2024"
 description = "egglog is a language that combines the benefits of equality saturation and datalog. It can be used for analysis, optimization, and synthesis of programs. It is the successor to the popular rust library egg."
 repository = "https://github.com/egraphs-good/egglog"
@@ -70,15 +70,15 @@ libtest-mimic = "0.8"
 ######################
 # member crates
 ######################
-egglog-core-relations = { path = "core-relations", version = "2.0.0" }
-egglog-ast = { path = "egglog-ast", version = "2.0.0" }
-egglog-bridge = { path = "egglog-bridge", version = "2.0.0" }
-egglog-concurrency = { path = "concurrency", version = "2.0.0" }
-egglog-numeric-id = { path = "numeric-id", version = "2.0.0" }
-egglog-union-find = { path = "union-find", version = "2.0.0" }
-egglog-add-primitive = { path = "src/sort/add_primitive", version = "2.0.0" }
-egglog-reports = { path = "egglog-reports", version = "2.0.0" }
-egglog = { path = ".", default-features = false, version = "2.0.0" }
+egglog-core-relations = { path = "core-relations", version = "3.0.0" }
+egglog-ast = { path = "egglog-ast", version = "3.0.0" }
+egglog-bridge = { path = "egglog-bridge", version = "3.0.0" }
+egglog-concurrency = { path = "concurrency", version = "3.0.0" }
+egglog-numeric-id = { path = "numeric-id", version = "3.0.0" }
+egglog-union-find = { path = "union-find", version = "3.0.0" }
+egglog-add-primitive = { path = "src/sort/add_primitive", version = "3.0.0" }
+egglog-reports = { path = "egglog-reports", version = "3.0.0" }
+egglog = { path = ".", default-features = false, version = "3.0.0" }
 
 ######################
 # wasm

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ One can also use `egglog` as a Rust library by adding the following to your `Car
 
 ```
 [dependencies]
-egglog = "2.0.0"
+egglog = "3.0.0"
 ```
 
 See also the [Python binding](https://github.com/egraphs-good/egglog-python) for using `egglog` in Python.
@@ -102,9 +102,10 @@ egglog single-threaded; the codspeed benchmarks only evaluate single-threaded
 performance. However, please take care not to pessimize parallel performance
 where possible (e.g. by adding coarse-grained locks).
 
-We use rayon's global thread pool for parallelism, and the number of threads used
-is set to `1` by default when egglog's CLI is run. If you use egglog as a library,
-you can control the level of parallelism by setting rayon's `num_threads`.
+Each `EGraph` has its own scoped thread pool. The CLI uses one thread by default;
+pass `-j 0` to use the available parallelism or `-j N` to select a fixed number
+of threads. Library users can configure an e-graph with `EGraph::new`,
+`with_num_threads`, or `set_num_threads`.
 
 ## Benchmarks
 

--- a/release-instructions.md
+++ b/release-instructions.md
@@ -33,7 +33,9 @@ Make these edits:
 3. In `CHANGELOG.md`, rename the current `Unreleased` section to the new
    version and release date, add a new empty `Unreleased` section, update its
    comparison link, and add a link for the new version. Do not rewrite links
-   for old releases.
+   for old releases. Check every entry against the git history, put it under
+   the release that first contained the change, and include the relevant PR
+   number or numbers.
 4. Search for any remaining references to the old version and decide whether
    each should change:
 
@@ -60,7 +62,9 @@ cargo publish --dry-run --workspace --exclude egglog-wasm-example
 ```
 
 This catches packaging errors across the workspace before any upload is made.
-Then push the branch, open a PR, and merge it after CI passes.
+Then push the branch and open a PR. Let the normal review process finish: wait
+for CI and human approval, and do not have the agent that prepared the PR merge
+it. A maintainer should merge it after review.
 
 ## 2. Tag the egglog release
 
@@ -86,9 +90,30 @@ git show --stat "v$EGGLOG_RELEASE"
 Authenticate once with `cargo login` if this machine does not already have a
 crates.io token.
 
-The workspace crates must be published in dependency order. Run each dry-run
-and publish pair separately, from the repository root, and do not proceed to
-the next pair unless both commands succeed:
+The workspace crates must be published in dependency order. The crate list can
+change, so regenerate this report for every release (it requires `jq`):
+
+```sh
+cargo metadata --format-version 1 |
+  jq -r '
+    . as $m
+    | $m.packages[]
+    | select(.id as $id | $m.workspace_members | index($id))
+    | select(.publish != [])
+    | [.name, ([.dependencies[]
+        | select(.path != null and .kind != "dev")
+        | .name] | unique | join(", "))]
+    | @tsv
+  ' | sort
+```
+
+The first column lists every publishable workspace crate; the second lists its
+non-development workspace dependencies. Compare the report with the command
+block below: every crate must appear exactly once, and every dependency must be
+published before the crate that depends on it. Update the block whenever a
+crate or dependency is added. Then run each dry-run and publish pair
+separately, from the repository root, and do not proceed to the next pair
+unless both commands succeed:
 
 ```sh
 cargo publish --dry-run -p egglog-numeric-id
@@ -132,8 +157,11 @@ the upload succeeded before running it again:
 cargo info "egglog-numeric-id@$EGGLOG_RELEASE"
 ```
 
-Substitute the crate that was just uploaded. After the final publish, verify
-the main package:
+Substitute the crate that was just uploaded. Publishing many crates can also
+trigger crates.io rate limiting. If that happens, do not retry in a tight loop:
+wait for the cooldown, verify whether the current upload succeeded with
+`cargo info`, and resume with that crate's dry run. After the final publish,
+verify the main package:
 
 ```sh
 cargo info "egglog@$EGGLOG_RELEASE"
@@ -153,12 +181,19 @@ git switch -c "release-v$EXPERIMENTAL_RELEASE"
 Update its `Cargo.toml` as follows:
 
 1. Set `package.version` to `$EXPERIMENTAL_RELEASE`.
-2. Update the `egglog`, `egglog-ast`, and `egglog-reports` dependencies to the
-   new egglog release. For crates.io, each dependency must have a `version`
-   whose value is `$EGGLOG_RELEASE`. It may also retain a `git` and `rev` for
-   repository development; if so, point `rev` at the tagged egglog release
-   commit. Cargo uses the Git source locally and the versioned registry source
-   in the published package.
+2. Search every `Cargo.toml` for `egglog` and update every dependency package
+   whose name starts with `egglog`, including renamed, development, build, and
+   target-specific dependencies:
+
+   ```sh
+   rg -n 'egglog' --glob Cargo.toml
+   ```
+
+   For crates.io, each dependency must have a `version` whose value is
+   `$EGGLOG_RELEASE`. It may also retain a `git` and `rev` for repository
+   development; if so, point `rev` at the tagged egglog release commit. Cargo
+   uses the Git source locally and the versioned registry source in the
+   published package.
 3. Update version examples or release notes in that repository as needed.
 
 Update its lockfile and test it:
@@ -170,8 +205,10 @@ git diff --check
 git status --short
 ```
 
-Commit these changes, open and merge an egglog-experimental release PR, then
-tag the merged commit and publish it:
+Commit these changes and open an egglog-experimental release PR. Wait for CI
+and human approval, and do not have the agent that prepared the PR merge it. A
+maintainer should merge it after review. Then tag the merged commit and publish
+it:
 
 ```sh
 git switch main
@@ -185,5 +222,5 @@ cargo publish
 cargo info "egglog-experimental@$EXPERIMENTAL_RELEASE"
 ```
 
-Finally, create the corresponding GitHub releases from the two pushed tags if
-the repositories do not automate that step.
+The tags and crates.io uploads complete the release. These repositories
+currently use tags only; do not create GitHub Release objects.

--- a/release-instructions.md
+++ b/release-instructions.md
@@ -1,12 +1,189 @@
+# Releasing egglog
 
+An egglog release has two parts: publish the crates in this workspace, then
+release `egglog-experimental` against the new egglog version. Publishing a
+crate version is permanent, so run the dry run immediately before each real
+publish and stop if it reports an error.
 
-How to do a release:
-1. Update `CHANGELOG.md` with a new entry and new link at the bottom.
-2. Find and replace in the codebase to update the version number. Make sure to get `Cargo.toml` and places in the changelog. Be careful not the screw up old links though!
-4. Commit.
-5. Tag the commit with the version number.
-6. Make a PR and make sure the tag gets added.
-7. Merge the PR
-8. `cargo publish --dry-run`
-   1. Sometimes this can result in an error- you may need to run `cargo update` to update `cargo.lock`
-9.  `cargo publish`
+Set both versions before running the commands below. These example values do
+not prescribe the next release number, and they do not include a leading `v`:
+
+```sh
+EGGLOG_RELEASE=3.0.0
+EXPERIMENTAL_RELEASE=1.0.0
+```
+
+## 1. Prepare the egglog release PR
+
+Start from an up-to-date `main` and create a release branch:
+
+```sh
+git switch main
+git pull --ff-only
+git switch -c "release-v$EGGLOG_RELEASE"
+```
+
+Make these edits:
+
+1. In `Cargo.toml`, update `workspace.package.version` and the `version` of
+   every internal crate in `workspace.dependencies`. All publishable workspace
+   crates use the same release version, and the dependency versions must match
+   it.
+2. In `README.md`, update the example egglog dependency version.
+3. In `CHANGELOG.md`, rename the current `Unreleased` section to the new
+   version and release date, add a new empty `Unreleased` section, update its
+   comparison link, and add a link for the new version. Do not rewrite links
+   for old releases.
+4. Search for any remaining references to the old version and decide whether
+   each should change:
+
+   ```sh
+   rg '2\.0\.0|v2\.0\.0'
+   ```
+
+   Replace `2.0.0` in that command with the version being superseded.
+
+Regenerate the workspace entries in `Cargo.lock`, then run the release checks:
+
+```sh
+cargo update --workspace
+make all
+git diff --check
+git status --short
+```
+
+Commit the changes. From that clean commit, verify all of the publishable
+packages as a set:
+
+```sh
+cargo publish --dry-run --workspace --exclude egglog-wasm-example
+```
+
+This catches packaging errors across the workspace before any upload is made.
+Then push the branch, open a PR, and merge it after CI passes.
+
+## 2. Tag the egglog release
+
+Tag the merged commit, not the pre-merge release-branch commit:
+
+```sh
+git switch main
+git pull --ff-only
+git status --short
+git tag -a "v$EGGLOG_RELEASE" -m "egglog $EGGLOG_RELEASE"
+git push origin "v$EGGLOG_RELEASE"
+```
+
+`git status --short` should print nothing. Check that the tag points at the
+intended release commit before publishing:
+
+```sh
+git show --stat "v$EGGLOG_RELEASE"
+```
+
+## 3. Publish the egglog workspace
+
+Authenticate once with `cargo login` if this machine does not already have a
+crates.io token.
+
+The workspace crates must be published in dependency order. Run each dry-run
+and publish pair separately, from the repository root, and do not proceed to
+the next pair unless both commands succeed:
+
+```sh
+cargo publish --dry-run -p egglog-numeric-id
+cargo publish -p egglog-numeric-id
+
+cargo publish --dry-run -p egglog-reports
+cargo publish -p egglog-reports
+
+cargo publish --dry-run -p egglog-ast
+cargo publish -p egglog-ast
+
+cargo publish --dry-run -p egglog-add-primitive
+cargo publish -p egglog-add-primitive
+
+cargo publish --dry-run -p egglog-concurrency
+cargo publish -p egglog-concurrency
+
+cargo publish --dry-run -p egglog-union-find
+cargo publish -p egglog-union-find
+
+cargo publish --dry-run -p egglog-core-relations
+cargo publish -p egglog-core-relations
+
+cargo publish --dry-run -p egglog-bridge
+cargo publish -p egglog-bridge
+
+cargo publish --dry-run -p egglog
+cargo publish -p egglog
+```
+
+`egglog-wasm-example` has `publish = false` and is intentionally omitted. The
+four crates without internal dependencies at the start can be published in any
+order, but the order shown above is a valid order for the entire workspace.
+
+crates.io index updates can take a little time. If the next crate reports that
+the version it depends on is unavailable, wait and retry that next crate's dry
+run. If `cargo publish` times out while polling the index, first check whether
+the upload succeeded before running it again:
+
+```sh
+cargo info "egglog-numeric-id@$EGGLOG_RELEASE"
+```
+
+Substitute the crate that was just uploaded. After the final publish, verify
+the main package:
+
+```sh
+cargo info "egglog@$EGGLOG_RELEASE"
+```
+
+## 4. Release egglog-experimental
+
+Do this only after the new egglog packages are visible on crates.io. In a
+separate clone of <https://github.com/egraphs-good/egglog-experimental>:
+
+```sh
+git switch main
+git pull --ff-only
+git switch -c "release-v$EXPERIMENTAL_RELEASE"
+```
+
+Update its `Cargo.toml` as follows:
+
+1. Set `package.version` to `$EXPERIMENTAL_RELEASE`.
+2. Update the `egglog`, `egglog-ast`, and `egglog-reports` dependencies to the
+   new egglog release. For crates.io, each dependency must have a `version`
+   whose value is `$EGGLOG_RELEASE`. It may also retain a `git` and `rev` for
+   repository development; if so, point `rev` at the tagged egglog release
+   commit. Cargo uses the Git source locally and the versioned registry source
+   in the published package.
+3. Update version examples or release notes in that repository as needed.
+
+Update its lockfile and test it:
+
+```sh
+cargo update
+cargo test --release
+git diff --check
+git status --short
+```
+
+Commit these changes, open and merge an egglog-experimental release PR, then
+tag the merged commit and publish it:
+
+```sh
+git switch main
+git pull --ff-only
+git status --short
+git tag -a "v$EXPERIMENTAL_RELEASE" -m "egglog-experimental $EXPERIMENTAL_RELEASE"
+git push origin "v$EXPERIMENTAL_RELEASE"
+
+cargo publish --dry-run
+cargo publish
+cargo info "egglog-experimental@$EXPERIMENTAL_RELEASE"
+```
+
+Finally, create the corresponding GitHub releases from the two pushed tags if
+the repositories do not automate that step.


### PR DESCRIPTION
## Summary

- bump all publishable workspace crates and internal dependency requirements to 3.0.0
- organize and tighten the 3.0.0 changelog, with migration guidance for breaking changes
- document dependency-ordered workspace publishing and the follow-up egglog-experimental release
- update README version and per-e-graph parallelism guidance

## Checks

- cargo test --release --workspace
- cargo fmt --check
- cargo clippy --tests --workspace -- -D warnings
- cargo doc --no-deps --all-features --workspace
- cargo build --release -p egglog --no-default-features
- cargo publish --dry-run --workspace --exclude egglog-wasm-example

The workspace publish check was run from a clean detached worktree and did not upload any crates.