### PR TITLE
Add Read::eclass_enodes, and scope the old name to one table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **Add `Read::eclass_enodes`, and rename `Read::enodes_for_eclass` to `Read::constructor_enodes_for_eclass`.** The old name read as "the e-nodes of this e-class" but returned only the rows of the one table it was given. `eclass_enodes(eclass, f)` is the method that name promised: it spans every constructor, and `Enode` gained a `name` field saying which one each row came from. A caller that already knows the e-class's sort should still narrow to that sort's constructors and call `constructor_enodes_for_eclass`, which is one probe rather than one per constructor — a `Value` does not say what sort it belongs to, so the spanning version has to ask each of them.
 
+- Fix a panic when a `Read` or `Write` API names a table that a `pop` has since dropped. Lookups now report it missing and `table_sizes` leaves it out, instead of handing the backend an id it no longer has.
+
 ## [3.0.0] - 2026-08-18
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased] - ReleaseDate
 
-- **Add `Read::eclass_enodes`, and rename `Read::enodes_for_eclass` to `Read::constructor_enodes_for_eclass`.** The old name read as "the e-nodes of this e-class" but returned only the rows of the one table it was given. `eclass_enodes(eclass, f)` is the method that name promised: it spans every constructor, and `Enode` gained a `name` field saying which one each row came from. A caller that already knows the e-class's sort should still narrow to that sort's constructors and call `constructor_enodes_for_eclass`, which is one probe rather than one per constructor — a `Value` does not say what sort it belongs to, so the spanning version has to ask each of them.
+- Add `Read::eclass_enodes` to scan an e-class across every constructor, rename the single-constructor method to `constructor_enodes_for_eclass`, and add `Enode::name`.
 
-- Fix a panic when a `Read` or `Write` API names a table that a `pop` has since dropped. Lookups now report it missing and `table_sizes` leaves it out, instead of handing the backend an id it no longer has.
+- Treat tables dropped by `pop` as missing in the name-indexed `Read` and `Write` APIs.
 
 ## [3.0.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+- **Add `Read::eclass_enodes`, and rename `Read::enodes_for_eclass` to `Read::constructor_enodes_for_eclass`.** The old name read as "the e-nodes of this e-class" but returned only the rows of the one table it was given. `eclass_enodes(eclass, f)` is the method that name promised: it spans every constructor, and `Enode` gained a `name` field saying which one each row came from. A caller that already knows the e-class's sort should still narrow to that sort's constructors and call `constructor_enodes_for_eclass`, which is one probe rather than one per constructor — a `Value` does not say what sort it belongs to, so the spanning version has to ask each of them.
+
 ## [3.0.0] - 2026-08-18
 
 ### Breaking changes

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -497,6 +497,13 @@ impl<'a> ExecutionState<'a> {
         self.db.table_info.iter().map(|(id, _)| id)
     }
 
+    /// Whether `table` is visible to this execution state. Ids obtained
+    /// elsewhere can name a table this state does not have, and every accessor
+    /// here panics on those.
+    pub fn table_exists(&self, table: TableId) -> bool {
+        self.db.table_info.get(table).is_some()
+    }
+
     /// Get an immutable reference to the table with id `table`.
     /// Dangerous: Reading from a table during action execution may break the semi-naive evaluation
     pub fn get_table(&self, table: TableId) -> &'a WrappedTable {

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -497,11 +497,11 @@ impl<'a> ExecutionState<'a> {
         self.db.table_info.iter().map(|(id, _)| id)
     }
 
-    /// Whether `table` is visible to this execution state. Ids obtained
-    /// elsewhere can name a table this state does not have, and every accessor
-    /// here panics on those.
-    pub fn table_exists(&self, table: TableId) -> bool {
-        self.db.table_info.get(table).is_some()
+    /// Return the stable identity of `table`, or `None` if it is not visible to
+    /// this execution state.
+    #[doc(hidden)]
+    pub fn table_identity(&self, table: TableId) -> Option<crate::TableIdentity> {
+        self.db.table_info.get(table).map(TableInfo::identity)
     }
 
     /// Get an immutable reference to the table with id `table`.
@@ -569,7 +569,7 @@ impl<'a> ExecutionState<'a> {
 
     /// Get the human-readable name for a table, if one exists.
     pub fn table_name(&self, table: TableId) -> Option<&'a str> {
-        self.db.table_info[table].name()
+        self.db.table_info.get(table).and_then(TableInfo::name)
     }
 
     pub fn base_values(&self) -> &'a BaseValues {

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -131,7 +131,25 @@ pub(crate) struct VarInfo {
 pub(crate) type HashIndex = Arc<ResettableOnceLock<Index<TupleIndex>>>;
 pub(crate) type HashColumnIndex = Arc<ResettableOnceLock<Index<ColumnIndex>>>;
 
+static NEXT_TABLE_IDENTITY: AtomicUsize = AtomicUsize::new(0);
+
+/// An opaque identity for one table allocation.
+///
+/// Unlike [`TableId`], identities are not reused after a database snapshot is
+/// restored. This is exposed for workspace crates that retain table handles
+/// across snapshots; most users should use [`TableId`] instead.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct TableIdentity(usize);
+
+impl TableIdentity {
+    fn fresh() -> Self {
+        Self(NEXT_TABLE_IDENTITY.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
 pub struct TableInfo {
+    identity: TableIdentity,
     pub(crate) name: Option<Arc<str>>,
     pub(crate) spec: TableSpec,
     pub(crate) table: WrappedTable,
@@ -140,6 +158,11 @@ pub struct TableInfo {
 }
 
 impl TableInfo {
+    #[doc(hidden)]
+    pub fn identity(&self) -> TableIdentity {
+        self.identity
+    }
+
     pub fn table(&self) -> &WrappedTable {
         &self.table
     }
@@ -170,6 +193,7 @@ impl Clone for TableInfo {
             })
         }
         TableInfo {
+            identity: self.identity,
             name: self.name.clone(),
             spec: self.spec.clone(),
             table: self.table.dyn_clone(),
@@ -719,6 +743,7 @@ impl Database {
         let spec = table.spec();
         let table = WrappedTable::new(table);
         let res = self.tables.push(TableInfo {
+            identity: TableIdentity::fresh(),
             name,
             spec,
             table,

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -28,8 +28,8 @@ pub use base_values::{BaseValue, BaseValueId, BaseValuePrinter, BaseValues, Boxe
 pub use common::Value;
 pub use containers::{ContainerRebuildSummary, ContainerValue, ContainerValueId, ContainerValues};
 pub use free_join::{
-    AtomId, CounterId, Database, ExternalFunction, ExternalFunctionId, TableId, Variable,
-    make_external_func, plan::PlanStrategy,
+    AtomId, CounterId, Database, ExternalFunction, ExternalFunctionId, TableId, TableIdentity,
+    Variable, make_external_func, plan::PlanStrategy,
 };
 pub use hash_index::TupleIndex;
 #[doc(hidden)]

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -71,15 +71,19 @@ impl ActionRegistry {
     }
 
     /// Look up the [`TableAction`] for a table by name, or `None` if
-    /// no table with that name has been registered.
+    /// no table with that name has been registered. The registry outlives
+    /// `push`/`pop`, so a hit may name a table a given execution state no
+    /// longer has; check it with [`TableAction::is_live`] before use.
     pub fn lookup_table(&self, name: &str) -> Option<&TableAction> {
         self.table_actions.get(name)
     }
 
-    /// Snapshot the registered table names and their current row counts.
+    /// Snapshot the names and row counts of the registered tables that exist
+    /// in `state`.
     pub fn table_sizes(&self, state: &ExecutionState) -> Vec<(&str, usize)> {
         self.table_actions
             .iter()
+            .filter(|(_, action)| action.is_live(state))
             .map(|(name, action)| (name.as_str(), action.row_count(state)))
             .collect()
     }
@@ -1421,6 +1425,14 @@ impl TableAction {
             timestamp: egraph.timestamp_counter,
             kind,
         }
+    }
+
+    /// Whether the table this acts on still exists in `state`. Every other
+    /// method taking a state panics when it does not: a table declared inside
+    /// a `push` is dropped by the `pop`, while `TableAction`s handed out
+    /// beforehand keep naming it.
+    pub fn is_live(&self, state: &ExecutionState) -> bool {
+        state.table_exists(self.table)
     }
 
     /// Whether this table is a `Function` (no auto-insert) or a

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -19,7 +19,7 @@ use std::{
 use crate::core_relations::{
     BaseValue, BaseValueId, BaseValues, ColumnId, Constraint, ContainerValue, ContainerValues,
     CounterId, Database, DisplacedTable, ExecutionState, ExternalContext, ExternalFunction,
-    ExternalFunctionId, MergeVal, Offset, PlanStrategy, SortedWritesTable, TableId,
+    ExternalFunctionId, MergeVal, Offset, PlanStrategy, SortedWritesTable, TableId, TableIdentity,
     TaggedRowBuffer, Value, WrappedTable,
 };
 use crate::numeric_id::{DenseIdMap, DenseIdMapWithReuse, NumericId, define_id};
@@ -71,9 +71,10 @@ impl ActionRegistry {
     }
 
     /// Look up the [`TableAction`] for a table by name, or `None` if
-    /// no table with that name has been registered. The registry outlives
-    /// `push`/`pop`, so a hit may name a table a given execution state no
-    /// longer has; check it with [`TableAction::is_live`] before use.
+    /// no table with that name has been registered. The registry may become
+    /// obsolete because of `push`/`pop`, so a hit may name a table a given
+    /// execution state no longer has; check it with [`TableAction::is_live`]
+    /// before use.
     pub fn lookup_table(&self, name: &str) -> Option<&TableAction> {
         self.table_actions.get(name)
     }
@@ -1396,6 +1397,8 @@ impl TableKind {
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct TableAction {
     table: TableId,
+    identity: TableIdentity,
+    name: Arc<str>,
     table_math: SchemaMath,
     default: Option<MergeVal>,
     timestamp: CounterId,
@@ -1413,6 +1416,8 @@ impl TableAction {
         };
         TableAction {
             table: func_info.table,
+            identity: egraph.db.get_table_info(func_info.table).identity(),
+            name: Arc::clone(&func_info.name),
             table_math: SchemaMath {
                 func_cols: func_info.schema.len(),
                 subsume: func_info.can_subsume,
@@ -1427,12 +1432,14 @@ impl TableAction {
         }
     }
 
-    /// Whether the table this acts on still exists in `state`. Every other
-    /// method taking a state panics when it does not: a table declared inside
-    /// a `push` is dropped by the `pop`, while `TableAction`s handed out
-    /// beforehand keep naming it.
+    /// Whether this still names the same table allocation in `state`.
+    ///
+    /// A table declared inside a `push` is dropped by the corresponding `pop`.
+    /// Its [`TableId`] may then be reused by a different table, while handles
+    /// handed out before the pop still hold the old id.
     pub fn is_live(&self, state: &ExecutionState) -> bool {
-        state.table_exists(self.table)
+        state.table_identity(self.table) == Some(self.identity)
+            && state.table_name(self.table) == Some(self.name.as_ref())
     }
 
     /// Whether this table is a `Function` (no auto-insert) or a

--- a/src/exec_state.rs
+++ b/src/exec_state.rs
@@ -339,7 +339,8 @@ pub trait Core<'a, 'db: 'a>: Internal<'a, 'db> {
 /// The single-entry methods (`lookup`, `eclass_of`, `contains`)
 /// return `None` if absent — never insert. The iteration /
 /// introspection methods (`function_entries`, `constructor_enodes`,
-/// `enodes_for_eclass`, `table_size`, `table_sizes`) walk the current
+/// `constructor_enodes_for_eclass`, `eclass_enodes`, `table_size`,
+/// `table_sizes`) walk the current
 /// contents of the database, while `constructor_schema` /
 /// `function_schema` / `table_subtype` report how a table is declared
 /// rather than what it holds.
@@ -449,6 +450,7 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
                 .split_last()
                 .expect("constructor row has at least an eclass column");
             f(Enode {
+                name,
                 children,
                 eclass: *eclass,
                 subsumed: row.subsumed,
@@ -457,11 +459,14 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
         Ok(())
     }
 
-    /// Call `f` on each [`Enode`] of a constructor / relation table whose
-    /// eclass column holds exactly `eclass`. Rows whose eclass has since been
-    /// merged into another are matched under the id they store, not their
-    /// canonical one. Errors with `WrongSubtype` if `name` is a function.
-    fn enodes_for_eclass(
+    /// Call `f` on the [`Enode`]s of the *one* table `name` whose eclass column
+    /// holds exactly `eclass`. For every constructor at once, use
+    /// [`Read::eclass_enodes`].
+    ///
+    /// Rows whose eclass has since been merged into another are matched under
+    /// the id they store, not their canonical one. Errors with `WrongSubtype`
+    /// if `name` is a function.
+    fn constructor_enodes_for_eclass(
         &self,
         name: &str,
         eclass: Value,
@@ -475,11 +480,40 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
                 .split_last()
                 .expect("constructor row has at least an eclass column");
             f(Enode {
+                name,
                 children,
                 eclass: *eclass,
                 subsumed: row.subsumed,
             });
         });
+        Ok(())
+    }
+
+    /// Call `f` on every [`Enode`] of `eclass`, across every constructor.
+    /// [`Enode::name`] says which one each row came from.
+    ///
+    /// A [`Value`] does not say what sort it belongs to, so this probes each
+    /// constructor whose output is an eq-sort. A caller that already knows the
+    /// sort should narrow to those constructors itself and use
+    /// [`Read::constructor_enodes_for_eclass`], which is one probe rather than
+    /// one per constructor.
+    fn eclass_enodes(&self, eclass: Value, mut f: impl FnMut(Enode<'_>)) -> Result<(), Error> {
+        let names: Vec<String> = self
+            .table_sizes()
+            .into_iter()
+            .map(|(name, _)| name.to_owned())
+            .collect();
+        for name in names {
+            // A function's last column is an output, not an eclass, and a
+            // constructor over a base sort has no eclass column to match.
+            let Ok(func_type) = self.constructor_schema(&name) else {
+                continue;
+            };
+            if !func_type.output.is_eq_sort() {
+                continue;
+            }
+            self.constructor_enodes_for_eclass(&name, eclass, &mut f)?;
+        }
         Ok(())
     }
 
@@ -525,6 +559,8 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
 /// [`Value`]s; convert with [`Core::value_to_base`] / [`Core::value_to_container`].
 #[derive(Clone, Copy, Debug)]
 pub struct Enode<'a> {
+    /// The constructor this row belongs to.
+    pub name: &'a str,
     /// The constructor's input columns.
     pub children: &'a [Value],
     /// The eclass id this enode belongs to.

--- a/src/exec_state.rs
+++ b/src/exec_state.rs
@@ -358,7 +358,7 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
     /// **Only valid for `function` tables.** Constructors error;
     /// use [`Read::eclass_of`] for those.
     fn lookup<K: IntoValues>(&self, name: &str, key: K) -> Result<Option<Value>, Error> {
-        let action = lookup_action(self.registry(), name)?;
+        let action = lookup_action(self.registry(), self.es(), name)?;
         check_subtype(name, &action, TableKind::Function)?;
         let key_values: ValueRow = key.into_values(self.base_values()).collect();
         check_arity(name, &action, key_values.len())?;
@@ -371,7 +371,7 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
     /// **Only valid for constructor tables.** Functions error;
     /// use [`Read::lookup`] for those.
     fn eclass_of<K: IntoValues>(&self, name: &str, inputs: K) -> Result<Option<Value>, Error> {
-        let action = lookup_action(self.registry(), name)?;
+        let action = lookup_action(self.registry(), self.es(), name)?;
         check_subtype(name, &action, TableKind::Constructor)?;
         let key_values: ValueRow = inputs.into_values(self.base_values()).collect();
         check_arity(name, &action, key_values.len())?;
@@ -381,7 +381,7 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
     /// True iff a row with the given key exists in the table. Works
     /// for any subtype — never mints.
     fn contains<K: IntoValues>(&self, name: &str, key: K) -> Result<bool, Error> {
-        let action = lookup_action(self.registry(), name)?;
+        let action = lookup_action(self.registry(), self.es(), name)?;
         let key_values: ValueRow = key.into_values(self.base_values()).collect();
         check_arity(name, &action, key_values.len())?;
         Ok(action.lookup(self.es(), &key_values).is_some())
@@ -415,8 +415,8 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
     /// Return the current row count for the named table, or `None` if no table
     /// with that name is registered.
     fn table_size(&self, name: &str) -> Option<usize> {
-        self.registry()
-            .lookup_table(name)
+        lookup_action(self.registry(), self.es(), name)
+            .ok()
             .map(|action| action.row_count(self.es()))
     }
 
@@ -442,7 +442,7 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
         name: &str,
         mut f: impl FnMut(Enode<'_>) -> bool,
     ) -> Result<(), Error> {
-        let action = lookup_action(self.registry(), name)?;
+        let action = lookup_action(self.registry(), self.es(), name)?;
         check_subtype(name, &action, TableKind::Constructor)?;
         action.for_each_while(self.es(), |row| {
             let (eclass, children) = row
@@ -472,7 +472,7 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
         eclass: Value,
         mut f: impl FnMut(Enode<'_>),
     ) -> Result<(), Error> {
-        let action = lookup_action(self.registry(), name)?;
+        let action = lookup_action(self.registry(), self.es(), name)?;
         check_subtype(name, &action, TableKind::Constructor)?;
         action.for_each_output_value(self.es(), eclass, |row| {
             let (eclass, children) = row
@@ -538,7 +538,7 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
         name: &str,
         mut f: impl FnMut(FunctionEntry<'_>) -> bool,
     ) -> Result<(), Error> {
-        let action = lookup_action(self.registry(), name)?;
+        let action = lookup_action(self.registry(), self.es(), name)?;
         check_subtype(name, &action, TableKind::Function)?;
         action.for_each_while(self.es(), |row| {
             let (output, inputs) = row
@@ -601,7 +601,7 @@ pub trait Write<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
         key: K,
         value: V,
     ) -> Result<(), Error> {
-        let action = lookup_action(self.registry(), name)?;
+        let action = lookup_action(self.registry(), self.es(), name)?;
         check_subtype(name, &action, TableKind::Function)?;
         let bv = self.base_values();
         let mut row: ValueRow = key.into_values(bv).collect();
@@ -619,7 +619,7 @@ pub trait Write<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
     /// **Only valid for constructor tables.** Functions error;
     /// use [`Write::set`] for those.
     fn add<R: IntoValues>(&mut self, name: &str, inputs: R) -> Result<Value, Error> {
-        let action = lookup_action(self.registry(), name)?;
+        let action = lookup_action(self.registry(), self.es(), name)?;
         check_subtype(name, &action, TableKind::Constructor)?;
         let key: ValueRow = inputs.into_values(self.base_values()).collect();
         check_arity(name, &action, key.len())?;
@@ -631,7 +631,7 @@ pub trait Write<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
 
     /// Remove a row from the named table. Works for any subtype.
     fn remove<K: IntoValues>(&mut self, name: &str, key: K) -> Result<(), Error> {
-        let action = lookup_action(self.registry(), name)?;
+        let action = lookup_action(self.registry(), self.es(), name)?;
         let key_values: ValueRow = key.into_values(self.base_values()).collect();
         check_arity(name, &action, key_values.len())?;
         action.remove(self.es_mut(), &key_values);
@@ -640,7 +640,7 @@ pub trait Write<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
 
     /// Subsume a row in the named table.
     fn subsume<K: IntoValues>(&mut self, name: &str, key: K) -> Result<(), Error> {
-        let action = lookup_action(self.registry(), name)?;
+        let action = lookup_action(self.registry(), self.es(), name)?;
         let key_values: ValueRow = key.into_values(self.base_values()).collect();
         check_arity(name, &action, key_values.len())?;
         action.subsume(self.es_mut(), key_values.into_iter());
@@ -693,13 +693,24 @@ fn func_type_of<'db>(
     Ok(func_type)
 }
 
-fn lookup_action(registry: &ActionRegistry, name: &str) -> Result<TableAction, Error> {
-    registry.lookup_table(name).cloned().ok_or_else(|| {
-        ApiError::MissingTable {
-            name: name.to_string(),
-        }
-        .into()
-    })
+/// The registry outlives `push`/`pop`, so it can still name a table this
+/// execution state no longer has. Those read as missing rather than reaching
+/// the backend, which would panic on them.
+fn lookup_action(
+    registry: &ActionRegistry,
+    es: &ExecutionState,
+    name: &str,
+) -> Result<TableAction, Error> {
+    registry
+        .lookup_table(name)
+        .filter(|action| action.is_live(es))
+        .cloned()
+        .ok_or_else(|| {
+            ApiError::MissingTable {
+                name: name.to_string(),
+            }
+            .into()
+        })
 }
 
 fn check_subtype(name: &str, action: &TableAction, expected: TableKind) -> Result<(), Error> {
@@ -732,7 +743,7 @@ fn apply_registered_function<'a, 'db: 'a>(
     func: &FuncType,
     args: &[Value],
 ) -> Option<Value> {
-    let action = lookup_action(state.registry(), &func.name).ok()?;
+    let action = lookup_action(state.registry(), state.es(), &func.name).ok()?;
     state.apply_table_function(func.subtype, &action, args)
 }
 

--- a/src/exec_state.rs
+++ b/src/exec_state.rs
@@ -340,7 +340,7 @@ pub trait Core<'a, 'db: 'a>: Internal<'a, 'db> {
 /// return `None` if absent — never insert. The iteration /
 /// introspection methods (`function_entries`, `constructor_enodes`,
 /// `constructor_enodes_for_eclass`, `eclass_enodes`, `table_size`,
-/// `table_sizes`) walk the current
+/// `tables`, `table_sizes`) walk the current
 /// contents of the database, while `constructor_schema` /
 /// `function_schema` / `table_subtype` report how a table is declared
 /// rather than what it holds.
@@ -388,7 +388,7 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
     }
 
     /// A constructor's declared signature: its input sorts and the sort of the
-    /// eclass column. Pair with [`Read::table_sizes`] to walk every table.
+    /// eclass column. Pair with [`Read::tables`] to walk every table.
     ///
     /// **Only valid for constructor tables.** Functions error; use
     /// [`Read::function_schema`] for those.
@@ -423,6 +423,11 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
     /// Snapshot the registered table names and their current row counts.
     fn table_sizes(&self) -> Vec<(&str, usize)> {
         self.registry().table_sizes(self.es())
+    }
+
+    /// Iterate over the registered table names visible to this state.
+    fn tables(&self) -> impl Iterator<Item = &str> {
+        self.table_sizes().into_iter().map(|(name, _)| name)
     }
 
     /// Call `f` on each [`Enode`] of a constructor / relation table.
@@ -498,11 +503,7 @@ pub trait Read<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
     /// [`Read::constructor_enodes_for_eclass`], which is one probe rather than
     /// one per constructor.
     fn eclass_enodes(&self, eclass: Value, mut f: impl FnMut(Enode<'_>)) -> Result<(), Error> {
-        let names: Vec<String> = self
-            .table_sizes()
-            .into_iter()
-            .map(|(name, _)| name.to_owned())
-            .collect();
+        let names: Vec<String> = self.tables().map(str::to_owned).collect();
         for name in names {
             // A function's last column is an output, not an eclass, and a
             // constructor over a base sort has no eclass column to match.

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -292,6 +292,7 @@ impl<C: Cost + Ord + Eq + Clone + Debug> Extractor<C> {
         let head_name = func.extraction_term_name();
         let output_idx = func.extraction_output_index();
         let enode = Enode {
+            name: head_name,
             children: &row.vals[..output_idx],
             eclass: row.vals[output_idx],
             subsumed: row.subsumed,

--- a/tests/api_introspection.rs
+++ b/tests/api_introspection.rs
@@ -7,7 +7,7 @@ use egglog::ast::Span;
 use egglog::constraint::{SimpleTypeConstraint, TypeConstraint};
 use egglog::prelude::*;
 use egglog::sort::{I64Sort, MapContainer, S, StringSort, VecContainer};
-use egglog::{ApiError, Core, Error, Primitive, Read, ReadPrim, ReadState, Value};
+use egglog::{ApiError, Core, Error, Primitive, RawValues, Read, ReadPrim, ReadState, Value};
 use std::any::TypeId;
 
 const MATH: &str = "
@@ -314,6 +314,34 @@ fn a_popped_table_is_missing_rather_than_stale() -> Result<(), Error> {
         assert!(!state.table_sizes().iter().any(|(name, _)| *name == "Neg"));
         Ok::<_, Error>(())
     })?;
+    Ok(())
+}
+
+/// A later declaration may reuse a popped table's id. The old registry entry
+/// must stay missing instead of silently reading from or writing to the new
+/// table.
+#[test]
+fn a_reused_table_id_does_not_revive_a_popped_name() -> Result<(), Error> {
+    let mut egraph = EGraph::default();
+    egraph.parse_and_run_program(None, MATH)?;
+    egraph.parse_and_run_program(
+        None,
+        "(push)\n(constructor Neg (Math) Math)\n(pop)\n(constructor Other (Math) Math)",
+    )?;
+
+    assert!(matches!(
+        egraph.constructor_enodes("Neg", |_| {}),
+        Err(Error::ApiError(ApiError::MissingTable { .. }))
+    ));
+    assert!(matches!(
+        egraph.update(|mut state| state.add("Neg", RawValues(vec![Value::new_const(0)]))),
+        Err(Error::ApiError(ApiError::MissingTable { .. }))
+    ));
+    egraph.read(|state| {
+        assert_eq!(state.table_size("Neg"), None);
+        assert!(state.tables().all(|name| name != "Neg"));
+        assert!(state.tables().any(|name| name == "Other"));
+    });
     Ok(())
 }
 

--- a/tests/api_introspection.rs
+++ b/tests/api_introspection.rs
@@ -1,5 +1,6 @@
 //! Tests for the e-graph introspection a primitive body can reach:
-//! `Read::enodes_for_eclass`, `Read::constructor_schema` /
+//! `Read::constructor_enodes_for_eclass`, `Read::eclass_enodes`,
+//! `Read::constructor_schema` /
 //! `function_schema` / `table_subtype`, and `Core::map_container`.
 
 use egglog::ast::Span;
@@ -17,11 +18,11 @@ const MATH: &str = "
 (function cost (Math) i64 :no-merge)
 ";
 
-/// `enodes_for_eclass` returns exactly the rows a full scan would, filtered on
-/// the eclass column — that equivalence is the invariant the indexed path has
-/// to preserve.
+/// `constructor_enodes_for_eclass` returns exactly the rows a full scan would,
+/// filtered on the eclass column — that equivalence is the invariant the
+/// indexed path has to preserve.
 #[test]
-fn enodes_for_eclass_agrees_with_a_filtered_scan() -> Result<(), Error> {
+fn constructor_enodes_for_eclass_agrees_with_a_filtered_scan() -> Result<(), Error> {
     let mut egraph = EGraph::default();
     egraph.parse_and_run_program(
         None,
@@ -53,7 +54,7 @@ fn enodes_for_eclass_agrees_with_a_filtered_scan() -> Result<(), Error> {
 
         let mut indexed: Vec<Vec<Value>> = Vec::new();
         egraph.read(|state| {
-            state.enodes_for_eclass("Add", eclass, |enode| {
+            state.constructor_enodes_for_eclass("Add", eclass, |enode| {
                 indexed.push(enode.children.to_vec());
             })
         })?;
@@ -72,16 +73,51 @@ fn enodes_for_eclass_agrees_with_a_filtered_scan() -> Result<(), Error> {
 }
 
 #[test]
-fn enodes_for_eclass_rejects_a_function_table() -> Result<(), Error> {
+fn constructor_enodes_for_eclass_rejects_a_function_table() -> Result<(), Error> {
     let mut egraph = EGraph::default();
     egraph.parse_and_run_program(None, MATH)?;
     let err = egraph
-        .read(|state| state.enodes_for_eclass("cost", Value::new_const(0), |_| {}))
+        .read(|state| state.constructor_enodes_for_eclass("cost", Value::new_const(0), |_| {}))
         .unwrap_err();
     assert!(
         matches!(err, Error::ApiError(ApiError::WrongSubtype { .. })),
         "expected WrongSubtype, got {err}"
     );
+    Ok(())
+}
+
+/// `eclass_enodes` finds an e-class's e-nodes across every constructor, and
+/// says which one each came from — the caller does not have to know the sort,
+/// or which tables to ask.
+#[test]
+fn eclass_enodes_spans_every_constructor() -> Result<(), Error> {
+    let mut egraph = EGraph::default();
+    egraph.parse_and_run_program(
+        None,
+        &format!(
+            "{MATH}
+(constructor Neg (Math) Math)
+(datatype Other (Wrap Math))
+(let $a (Add (Num 1) (Num 2)))
+(union $a (Neg (Num 3)))
+(let $unrelated (Wrap $a))
+"
+        ),
+    )?;
+    let eclass = egraph.eval_expr(&exprs::var("$a"))?.1;
+
+    let mut found: Vec<String> = Vec::new();
+    egraph.read(|state| {
+        state.eclass_enodes(eclass, |enode| {
+            assert_eq!(enode.eclass, eclass);
+            found.push(enode.name.to_owned());
+        })
+    })?;
+    found.sort();
+
+    // Both of the class's constructors, and neither the `Other`-sorted
+    // constructor that merely references it nor the `cost` function table.
+    assert_eq!(found, ["Add", "Neg"]);
     Ok(())
 }
 

--- a/tests/api_introspection.rs
+++ b/tests/api_introspection.rs
@@ -264,3 +264,76 @@ fn a_primitive_can_resolve_a_signature_from_inside_a_rule() -> Result<(), Error>
     )?;
     Ok(())
 }
+
+/// A primitive reporting how many tables it can see, so a program can observe
+/// the registry from inside a rule.
+#[derive(Clone)]
+struct TableCount;
+impl Primitive for TableCount {
+    fn name(&self) -> &str {
+        "table-count"
+    }
+    fn get_type_constraints(&self, span: &Span) -> Box<dyn TypeConstraint> {
+        SimpleTypeConstraint::new(
+            self.name(),
+            vec![StringSort.to_arcsort(), I64Sort.to_arcsort()],
+            span.clone(),
+        )
+        .into_box()
+    }
+}
+impl ReadPrim for TableCount {
+    fn apply<'a, 'db>(&self, state: ReadState<'a, 'db>, _args: &[Value]) -> Option<Value> {
+        let n = state.table_sizes().len();
+        Some(state.base_values().get::<i64>(i64::try_from(n).ok()?))
+    }
+}
+
+/// A table declared inside a `push` is gone after the `pop`, but the registry
+/// naming it is shared across snapshots and keeps the entry. Every lookup has
+/// to report it as missing rather than hand the backend an id it no longer has.
+#[test]
+fn a_popped_table_is_missing_rather_than_stale() -> Result<(), Error> {
+    let mut egraph = EGraph::default();
+    egraph.parse_and_run_program(None, MATH)?;
+    egraph.parse_and_run_program(
+        None,
+        "(push)
+(constructor Neg (Math) Math)
+(let $n (Neg (Num 1)))
+(pop)
+",
+    )?;
+
+    assert!(matches!(
+        egraph.constructor_enodes("Neg", |_| {}),
+        Err(Error::ApiError(ApiError::MissingTable { .. }))
+    ));
+    egraph.read(|state| {
+        assert_eq!(state.table_size("Neg"), None);
+        assert!(!state.table_sizes().iter().any(|(name, _)| *name == "Neg"));
+        Ok::<_, Error>(())
+    })?;
+    Ok(())
+}
+
+/// Enumerating the tables during rule execution reaches the same stale entry
+/// through the row count rather than through a lookup by name.
+#[test]
+fn table_sizes_skips_a_popped_table_from_inside_a_rule() -> Result<(), Error> {
+    let mut egraph = EGraph::default();
+    egraph.add_read_primitive(TableCount, None);
+    egraph.parse_and_run_program(None, MATH)?;
+    // Declared before the `push`, so nothing reclaims the id the `pop` frees
+    // and the registry's entry for `Neg` stays dangling.
+    egraph.parse_and_run_program(None, "(function count-of (String) i64 :no-merge)")?;
+    egraph.parse_and_run_program(None, "(push)\n(constructor Neg (Math) Math)\n(pop)")?;
+    egraph.parse_and_run_program(
+        None,
+        r#"
+(rule () ((set (count-of "n") (table-count "x"))) :naive)
+(run 1)
+"#,
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
Follow-up to #986, from using that API to build `unstable-subst` in
egglog-experimental.

### The name was a promise the method did not keep

`Read::enodes_for_eclass(name, eclass, f)` reads as "the e-nodes of this
e-class", but it returns only the rows of the one table it is handed. A caller
who genuinely wants an e-class's e-nodes has to know which constructors could
produce it and loop over them — which is what `unstable-subst` does today.

So this splits the two ideas:

| method | scope |
| --- | --- |
| `constructor_enodes(name, f)` | every row of one table |
| `constructor_enodes_for_eclass(name, eclass, f)` | rows of one table, one e-class |
| `eclass_enodes(eclass, f)` | rows of **every** constructor, one e-class |

The renamed one reads as "`constructor_enodes`, filtered" and sits with its
neighbours; the new one is what the old name was reaching for.

### `Enode` gained a `name`

A caller that did not name a table cannot otherwise interpret what it gets
back: the children's sorts come from the constructor's signature, and
re-applying it needs the name. Both existing scans fill it in, so there is one
`Enode` shape across all three methods.

### Which one to reach for

`eclass_enodes` probes every constructor whose output is an eq-sort. It has to:
a `Value` does not say what sort it belongs to — there is no value-to-sort map,
only one global id counter — so there is nothing to narrow by. That same fact
is what makes it sound: probing a constructor of the wrong sort simply finds
nothing.

A caller that *does* know the sort should keep narrowing to that sort's
constructors and use `constructor_enodes_for_eclass`, which is one probe rather
than one per constructor. The doc on each says so. In `unstable-subst` the
distinction is load-bearing: it knows each child's sort from its parent's
signature and narrows there, and only the root — the one e-class whose sort it
cannot know — needs the spanning version.

### Notes

- Additive apart from the rename and the new `Enode` field. `Enode` is only
  constructed inside egglog, so downstream code that reads its fields is
  unaffected.
- `tests/api_introspection.rs` covers the new method: an e-class with e-nodes
  from two different constructors, checking both come back with the right
  `name`, and that neither a constructor of another sort that merely references
  the e-class nor a `function` table is included.
- Full workspace suite, clippy, and `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
