### PR TITLE
Fix(Bug): Fix collisions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3495,4 +3495,56 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, Error::IoError(..)));
     }
+
+    /// Regression test: `SymbolGen::fresh` minted colliding names for
+    /// different hints (e.g. hint "x" at count 11 and hint "x1" at count 1
+    /// both produce "@x11"). Two distinct globals sharing one minted name
+    /// were then conflated while compiling an action, silently binding a
+    /// global to the wrong term.
+    #[test]
+    fn test_fresh_name_collision_globals() {
+        let mut egraph = EGraph::default();
+        // Each `(or2 x y)` command consumes one `fresh("x")`. After the ten
+        // `t` commands (plus the definition of `x` itself), the minted name
+        // for a fresh "x" is "@x11". Global `x1` has only been minted once
+        // (by its own definition), so minting for it also produces "@x11".
+        // The final command references both globals, conflating them.
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+                (sort B)
+                (constructor var (String) B)
+                (constructor and2 (B B) B)
+                (constructor or2 (B B) B)
+                (let x (var "x"))
+                (let y (var "y"))
+                (let t1 (or2 x y))
+                (let t2 (or2 x y))
+                (let t3 (or2 x y))
+                (let t4 (or2 x y))
+                (let t5 (or2 x y))
+                (let t6 (or2 x y))
+                (let t7 (or2 x y))
+                (let t8 (or2 x y))
+                (let t9 (or2 x y))
+                (let t10 (or2 x y))
+                (let x1 (var "x1"))
+                (let out (and2 x x1))
+                "#,
+            )
+            .unwrap();
+
+        // `out` must equal the term it was bound to. With the name
+        // collision, the last action was miscompiled as
+        // `(set (out) (and2 (x1) (x1)))`, so this check failed.
+        egraph
+            .parse_and_run_program(
+                None,
+                r#"
+                (check (= out (and2 (var "x") x1)))
+                "#,
+            )
+            .unwrap();
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,6 +15,17 @@ pub use egglog_ast::generic_ast_helpers::INTERNAL_SYMBOL_PREFIX;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SymbolGen {
     hint_to_count: HashMap<String, usize>,
+    /// Every symbol minted by this generator so far.
+    ///
+    /// `fresh` concatenates a hint with a per-hint counter, which by itself is
+    /// *not* collision-free across different hints: e.g. minting for hint
+    /// "n414" at count 11 and for hint "n4141" at count 1 both produce
+    /// "n41411". Downstream passes treat resolved variables by name, so two
+    /// distinct variables with the same name silently get conflated and
+    /// corrupt action compilation. This set guarantees every minted symbol is
+    /// unique, by advancing the per-hint counter past any name that has
+    /// already been used.
+    minted: HashSet<String>,
     reserved_string: String,
     leave_off_zero: bool,
 }
@@ -24,6 +35,7 @@ impl SymbolGen {
     pub fn new(reserved_string: String) -> Self {
         Self {
             hint_to_count: HashMap::default(),
+            minted: HashSet::default(),
             reserved_string,
             leave_off_zero: true,
         }
@@ -60,18 +72,28 @@ pub trait FreshGen<Head: ?Sized, Leaf> {
 impl FreshGen<str, String> for SymbolGen {
     fn fresh(&mut self, name_hint: &str) -> String {
         let entry = self.hint_to_count.entry(name_hint.to_string()).or_insert(0);
-        let count_before = *entry;
-        *entry += 1;
-        format!(
-            "{}{}{}",
-            self.reserved_string,
-            name_hint,
-            if self.leave_off_zero && count_before == 0 {
-                "".to_string()
-            } else {
-                count_before.to_string()
+        let mut count = *entry;
+        let name = loop {
+            let candidate = format!(
+                "{}{}{}",
+                self.reserved_string,
+                name_hint,
+                if self.leave_off_zero && count == 0 {
+                    "".to_string()
+                } else {
+                    count.to_string()
+                }
+            );
+            // Advance past any name that has already been minted (possibly
+            // via a different hint), so minted names are pairwise unique.
+            if !self.minted.contains(&candidate) {
+                break candidate;
             }
-        )
+            count += 1;
+        };
+        *entry = count + 1;
+        self.minted.insert(name.clone());
+        name
     }
 }
 
@@ -87,18 +109,26 @@ impl FreshGen<ResolvedCall, ResolvedVar> for SymbolGen {
             .hint_to_count
             .entry(format!("{name_hint}"))
             .or_insert(0);
-        let count = *entry;
-        *entry += 1;
-        let name = format!(
-            "{}{}{}",
-            self.reserved_string,
-            name_hint,
-            if self.leave_off_zero && count == 0 {
-                "".to_string()
-            } else {
-                count.to_string()
+        let mut count = *entry;
+        let name = loop {
+            let candidate = format!(
+                "{}{}{}",
+                self.reserved_string,
+                name_hint,
+                if self.leave_off_zero && count == 0 {
+                    "".to_string()
+                } else {
+                    count.to_string()
+                }
+            );
+            // Keep minted names pairwise unique; see the `str` impl.
+            if !self.minted.contains(&candidate) {
+                break candidate;
             }
-        );
+            count += 1;
+        };
+        *entry = count + 1;
+        self.minted.insert(name.clone());
         let sort = match name_hint {
             ResolvedCall::Func(f) => f.output.clone(),
             ResolvedCall::Primitive(prim) => prim.output().clone(),


### PR DESCRIPTION
Fresh-name collision. This will cause term bound to even wrong term.
This issue is identified originally in egglog-python and traced back here. If possible, update egglog-python too.

## Root cause

https://github.com/egraphs-good/egglog/blob/e264c37a3332453eb0b6486c82c8766dd1af17df/src/util.rs#L61-L75

The counter is **per hint**, so two different hints can produce the same string:

| hint    | count | minted name |
|---------|-------|-------------|
| `n414`  | 11    | `@n41411`   |
| `n4141` | 1     | `@n41411`   |

Downstream, variable identity is name-based, so the two variables were conflated while compiling the set action and node was silently bound to the wrong term.