### PR TITLE
Make displayed commands replayable and enable output downcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add `Read::eclass_enodes` to scan an e-class across every constructor, rename the single-constructor method to `constructor_enodes_for_eclass`, and add `Enode::name`.
 
+- Allow consumers to safely downcast `UserDefinedCommandOutput` trait objects to known concrete output types.
+
 - Treat tables dropped by `pop` as missing in the name-indexed `Read` and `Write` APIs.
 
 - Escape quotes and backslashes in printed rule names so the generated syntax round-trips through the parser.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - Treat tables dropped by `pop` as missing in the name-indexed `Read` and `Write` APIs.
 
-- Escape quotes and backslashes in printed rule names and panic messages so the generated syntax round-trips through the parser.
+- Escape quotes and backslashes in printed rule names and panic messages, and print command paths as string literals, so the generated syntax round-trips through the parser.
 
 ## [3.0.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Treat tables dropped by `pop` as missing in the name-indexed `Read` and `Write` APIs.
 
+- Escape quotes and backslashes in printed rule names so the generated syntax round-trips through the parser.
+
 ## [3.0.0] - 2026-08-18
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - Add `Read::eclass_enodes` to scan an e-class across every constructor, rename the single-constructor method to `constructor_enodes_for_eclass`, and add `Enode::name`.
 
-- Allow consumers to safely downcast `UserDefinedCommandOutput` trait objects to known concrete output types.
+- Allow consumers to safely downcast `UserDefinedCommandOutput` trait-object
+  references to known concrete output types with `as_any`.
 
 - Treat tables dropped by `pop` as missing in the name-indexed `Read` and `Write` APIs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - Treat tables dropped by `pop` as missing in the name-indexed `Read` and `Write` APIs.
 
-- Escape quotes and backslashes in printed rule names so the generated syntax round-trips through the parser.
+- Escape quotes and backslashes in printed rule names and panic messages so the generated syntax round-trips through the parser.
 
 ## [3.0.0] - 2026-08-18
 

--- a/egglog-ast/src/generic_ast_helpers.rs
+++ b/egglog-ast/src/generic_ast_helpers.rs
@@ -66,7 +66,7 @@ where
             "".into()
         };
         let name = if !self.name.is_empty() {
-            format!(":name \"{}\"", &self.name)
+            format!(":name {}", Literal::String(self.name.clone()))
         } else {
             "".into()
         };
@@ -812,5 +812,21 @@ mod tests {
         assert_eq!(Literal::String("a\\b".into()).to_string(), "\"a\\\\b\"");
         // Newlines and tabs are accepted verbatim by the lexer, so they are not escaped.
         assert_eq!(Literal::String("a\nb".into()).to_string(), "\"a\nb\"");
+    }
+
+    #[test]
+    fn display_rule_name_escapes_special_characters() {
+        let rule = GenericRule::<String, String> {
+            span: Span::Panic,
+            head: GenericActions(vec![]),
+            body: vec![],
+            name: "a\"b\\c".into(),
+            ruleset: String::new(),
+            eval_mode: RuleEvalMode::Seminaive,
+            no_decomp: false,
+            include_subsumed: false,
+        };
+
+        assert!(rule.to_string().contains(r#":name "a\"b\\c""#));
     }
 }

--- a/egglog-ast/src/generic_ast_helpers.rs
+++ b/egglog-ast/src/generic_ast_helpers.rs
@@ -148,7 +148,9 @@ where
                     )
                 }
             }
-            GenericAction::Panic(_, msg) => write!(f, "(panic \"{msg}\")"),
+            GenericAction::Panic(_, msg) => {
+                write!(f, "(panic {})", Literal::String(msg.clone()))
+            }
             GenericAction::Expr(_, e) => write!(f, "{e}"),
         }
     }
@@ -828,5 +830,12 @@ mod tests {
         };
 
         assert!(rule.to_string().contains(r#":name "a\"b\\c""#));
+    }
+
+    #[test]
+    fn display_panic_message_escapes_special_characters() {
+        let action = GenericAction::<String, String>::Panic(Span::Panic, "a\"b\\c".into());
+
+        assert_eq!(action.to_string(), r#"(panic "a\"b\\c")"#);
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1145,7 +1145,7 @@ where
             GenericCommand::Rule { rule } => rule.fmt(f),
             GenericCommand::RunSchedule(sched) => write!(f, "(run-schedule {sched})"),
             GenericCommand::PrintOverallStatistics(_span, file) => match file {
-                Some(file) => write!(f, "(print-stats :file {file})"),
+                Some(file) => write!(f, "(print-stats :file {})", Literal::String(file.clone())),
                 None => write!(f, "(print-stats)"),
             },
             GenericCommand::Check(_ann, facts) => {
@@ -1169,7 +1169,7 @@ where
                     write!(f, " {n}")?;
                 }
                 if let Some(file) = file {
-                    write!(f, " :file {file:?}")?;
+                    write!(f, " :file {}", Literal::String(file.clone()))?;
                 }
                 match mode {
                     PrintFunctionMode::Default => {}
@@ -1185,15 +1185,22 @@ where
                 name,
                 file,
             } => {
-                write!(f, "(input {name} {file:?})")
+                write!(f, "(input {name} {})", Literal::String(file.clone()))
             }
             GenericCommand::Output {
                 span: _,
                 file,
                 exprs,
-            } => write!(f, "(output {file:?} {})", ListDisplay(exprs, " ")),
+            } => write!(
+                f,
+                "(output {} {})",
+                Literal::String(file.clone()),
+                ListDisplay(exprs, " ")
+            ),
             GenericCommand::Fail(_span, cmd) => write!(f, "(fail {cmd})"),
-            GenericCommand::Include(_span, file) => write!(f, "(include {file:?})"),
+            GenericCommand::Include(_span, file) => {
+                write!(f, "(include {})", Literal::String(file.clone()))
+            }
             GenericCommand::Datatypes { span: _, datatypes } => {
                 let datatypes: Vec<_> = datatypes
                     .iter()

--- a/src/ast/parse.rs
+++ b/src/ast/parse.rs
@@ -1313,6 +1313,41 @@ mod tests {
     }
 
     #[test]
+    fn test_file_command_display_roundtrip() {
+        let file = "quoted\"-backslash\\-combining\u{300}";
+        let commands = [
+            Command::PrintOverallStatistics(Span::Panic, Some(file.into())),
+            Command::PrintFunction(
+                Span::Panic,
+                "f".into(),
+                None,
+                Some(file.into()),
+                PrintFunctionMode::Default,
+            ),
+            Command::Input {
+                span: Span::Panic,
+                name: "f".into(),
+                file: file.into(),
+            },
+            Command::Output {
+                span: Span::Panic,
+                file: file.into(),
+                exprs: vec![],
+            },
+            Command::Include(Span::Panic, file.into()),
+        ];
+
+        for command in commands {
+            let displayed = command.to_string();
+            let reparsed = Parser::default()
+                .get_program_from_string(None, &displayed)
+                .unwrap();
+            assert_eq!(reparsed.len(), 1);
+            assert_eq!(reparsed[0].to_string(), displayed);
+        }
+    }
+
+    #[test]
     #[rustfmt::skip]
     fn rust_span_display() {
         let actual = format!("{}", span!()).replace('\\', "/");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,10 @@ pub trait FullPrim: Primitive {
 pub trait UserDefinedCommandOutput: Debug + std::fmt::Display + Send + Sync {
     /// Views a stored output as [`Any`] so consumers can safely downcast it.
     ///
+    /// Call this on a `&dyn UserDefinedCommandOutput`; smart pointers that
+    /// themselves satisfy this trait should first be dereferenced with
+    /// `as_ref()`.
+    ///
     /// [`CommandOutput::UserDefined`] owns its output, so values stored there
     /// satisfy the required `'static` bound. Keeping the bound on this method
     /// lets borrowed values continue to implement `UserDefinedCommandOutput`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,11 +130,27 @@ pub trait FullPrim: Primitive {
 }
 
 /// A type-erased output from a user-defined command.
-///
-/// The [`Any`] supertrait lets consumers safely downcast a trait object to a
-/// known concrete output type.
-pub trait UserDefinedCommandOutput: Any + Debug + std::fmt::Display + Send + Sync {}
-impl<T> UserDefinedCommandOutput for T where T: Any + Debug + std::fmt::Display + Send + Sync {}
+pub trait UserDefinedCommandOutput: Debug + std::fmt::Display + Send + Sync {
+    /// Views a stored output as [`Any`] so consumers can safely downcast it.
+    ///
+    /// [`CommandOutput::UserDefined`] owns its output, so values stored there
+    /// satisfy the required `'static` bound. Keeping the bound on this method
+    /// lets borrowed values continue to implement `UserDefinedCommandOutput`.
+    fn as_any(&self) -> &dyn Any
+    where
+        Self: 'static;
+}
+impl<T> UserDefinedCommandOutput for T
+where
+    T: Debug + std::fmt::Display + Send + Sync,
+{
+    fn as_any(&self) -> &dyn Any
+    where
+        Self: 'static,
+    {
+        self
+    }
+}
 
 /// Output from a command.
 #[derive(Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,9 +129,12 @@ pub trait FullPrim: Primitive {
     fn apply<'a, 'db>(&self, state: FullState<'a, 'db>, args: &[Value]) -> Option<Value>;
 }
 
-/// A user-defined command output trait.
-pub trait UserDefinedCommandOutput: Debug + std::fmt::Display + Send + Sync {}
-impl<T> UserDefinedCommandOutput for T where T: Debug + std::fmt::Display + Send + Sync {}
+/// A type-erased output from a user-defined command.
+///
+/// The [`Any`] supertrait lets consumers safely downcast a trait object to a
+/// known concrete output type.
+pub trait UserDefinedCommandOutput: Any + Debug + std::fmt::Display + Send + Sync {}
+impl<T> UserDefinedCommandOutput for T where T: Any + Debug + std::fmt::Display + Send + Sync {}
 
 /// Output from a command.
 #[derive(Clone, Debug)]

--- a/tests/user_defined_command_output.rs
+++ b/tests/user_defined_command_output.rs
@@ -1,0 +1,15 @@
+use std::{any::Any, sync::Arc};
+
+use egglog::UserDefinedCommandOutput;
+
+#[test]
+fn user_defined_command_output_can_be_downcast() {
+    let output: Arc<dyn UserDefinedCommandOutput> = Arc::new(String::from("structured output"));
+    let output: &dyn Any = output.as_ref();
+
+    assert_eq!(
+        output.downcast_ref::<String>().map(String::as_str),
+        Some("structured output")
+    );
+    assert!(output.downcast_ref::<usize>().is_none());
+}

--- a/tests/user_defined_command_output.rs
+++ b/tests/user_defined_command_output.rs
@@ -1,15 +1,32 @@
-use std::{any::Any, sync::Arc};
+use std::{fmt::Display, sync::Arc};
 
 use egglog::UserDefinedCommandOutput;
 
 #[test]
 fn user_defined_command_output_can_be_downcast() {
     let output: Arc<dyn UserDefinedCommandOutput> = Arc::new(String::from("structured output"));
-    let output: &dyn Any = output.as_ref();
+    let output = output.as_ref().as_any();
 
     assert_eq!(
         output.downcast_ref::<String>().map(String::as_str),
         Some("structured output")
     );
     assert!(output.downcast_ref::<usize>().is_none());
+}
+
+#[derive(Debug)]
+struct BorrowedOutput<'a>(&'a str);
+
+impl Display for BorrowedOutput<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+#[test]
+fn borrowed_values_still_implement_user_defined_command_output() {
+    fn accepts_user_defined_output<T: UserDefinedCommandOutput>(_: &T) {}
+
+    let text = String::from("borrowed output");
+    accepts_user_defined_output(&BorrowedOutput(&text));
 }


### PR DESCRIPTION
## Summary

- Render rule names and panic messages through Egglog's string-literal formatter, preserving quotes and backslashes as valid Egglog syntax.
- Render file paths as string literals for `print-stats`, `print-function`, `input`, `output`, and `include`, so displayed commands can be parsed and replayed.
- Add `UserDefinedCommandOutput::as_any()`, allowing a consumer that knows an extension's concrete output type to downcast safely.
- Keep borrowed values eligible for `UserDefinedCommandOutput` by placing the required `'static` bound on `as_any`, rather than on the trait itself.

The replayable display changes are needed by clients that record successful commands and later reconstruct an e-graph. The downcast supports typed extension outputs without adding extension-specific variants to core; egglog-experimental #67 uses it for `MultiExtractOutput`, and egglog-python #414 exposes that result to Python.

## Validation

- `cargo test -p egglog-ast display_ --locked`
- `cargo test -p egglog test_file_command_display_roundtrip --locked`
- `cargo test --test user_defined_command_output --locked`
- `cargo test --test user_defined_command_output --no-default-features --locked`
- `cargo check -p egglog --no-default-features --lib --locked`
- `cargo test --doc -p egglog --locked`
- `cargo fmt --all --check`
- `cargo clippy --tests --locked -- -D warnings`

The current head is `1eea60a14f214505741d22bdd6c9b501b21c04ee`. All GitHub checks are green; the PR is mergeable and awaits non-author approval.

## Stack

This is the first PR in:

1. egraphs-good/egglog#1008
2. egraphs-good/egglog-experimental#67
3. egraphs-good/egglog-python#414
