### PR TITLE
Fix subsuming rows created in the same action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased] - ReleaseDate
 
 - **The scheduler runner applies each rule's chosen matches immediately.** After a rule's `filter_matches`, its chosen matches are applied before the next rule's `filter_matches` is called, so schedulers observe up-to-date e-node counts within an iteration. The e-graph is still rebuilt at most once per iteration (egglog-bridge gains `run_rules_no_rebuild`, `flush_updates_no_rebuild`, and `rebuild_now` for this). Measured on Herbie's rewriting workload with identical scheduling decisions, the per-rule application costs nothing single-threaded and 0–7 % wall time with 8 threads.
+- Fix subsuming constructor rows created earlier in the same rule or `EGraph::update` action, including executing subsequent rule actions after subsuming a missing row.
 - Egglog-level rule-action errors preserve completed effects without rollback; successful recovery rebuilds leave the e-graph reusable in a canonical partial state. Custom schedulers clear failed decided rows instead of retaining them, though a later query may rediscover the match.
 - `Read::is_sort_unionable` and `Read::is_table_hidden` let read primitives classify visible constructor tables without exposing the e-graph; `EGraph::num_nodes` also handles term/proof constructor views.
 - **Schedulers now receive a `SchedulerContext`.** `Scheduler::filter_matches` and `can_stop` receive read-only access to the e-graph and a runner-cached `num_nodes()` convenience. Add `EGraph::total_size` for all non-hidden function rows and `EGraph::num_nodes` for the constructor-node measure.

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -1674,12 +1674,16 @@ impl TableAction {
         state.stage_remove(self.table, key);
     }
 
-    /// Subsume a row in this table.
+    /// Subsume a row in a table with subsumption enabled. For a constructor,
+    /// the configured default is inserted if the key is absent. Rows predicted
+    /// earlier in the same action are reused.
     pub fn subsume(&self, state: &mut ExecutionState, key: impl Iterator<Item = Value>) {
         let ts = Value::from_usize(state.read_counter(self.timestamp));
         let mut scratch = key.collect::<SmallVec<[_; 8]>>();
 
-        let ret_val = self.lookup(state, &scratch).expect("subsume lookup failed");
+        let ret_val = self
+            .lookup_or_insert(state, &scratch)
+            .expect("subsume lookup failed");
 
         self.table_math.write_table_row(
             &mut scratch,

--- a/egglog-bridge/src/rule.rs
+++ b/egglog-bridge/src/rule.rs
@@ -496,13 +496,7 @@ impl RuleBuilder<'_> {
         let ret: QueryEntry = ret.into();
         self.add_callback(move |inner, rb| {
             // Then, add a tuple subsuming the entry, but only if the entry isn't already subsumed.
-            // Look up the current subsume value.
             let mut dst_entries = inner.convert_all(&entries);
-            let cur_subsume_val = rb.lookup(
-                table,
-                &dst_entries,
-                ColumnId::from_usize(schema_math.subsume_col()),
-            )?;
             schema_math.write_table_row(
                 &mut dst_entries,
                 RowVals {
@@ -511,6 +505,19 @@ impl RuleBuilder<'_> {
                     ret_val: Some(inner.convert(&ret)),
                 },
             );
+            // Look up the current subsume value, including rows predicted by
+            // earlier actions for the same rule match.
+            let default_vals = dst_entries[schema_math.num_keys()..]
+                .iter()
+                .copied()
+                .map(WriteVal::from)
+                .collect::<SmallVec<[_; 4]>>();
+            let cur_subsume_val = rb.lookup_or_insert(
+                table,
+                &dst_entries[..schema_math.num_keys()],
+                &default_vals,
+                ColumnId::from_usize(schema_math.subsume_col()),
+            )?;
             rb.insert_if_eq(
                 table,
                 cur_subsume_val.into(),

--- a/egglog-bridge/src/rule.rs
+++ b/egglog-bridge/src/rule.rs
@@ -495,7 +495,9 @@ impl RuleBuilder<'_> {
 
         let ret: QueryEntry = ret.into();
         self.add_callback(move |inner, rb| {
-            // Then, add a tuple subsuming the entry, but only if the entry isn't already subsumed.
+            // Then add the same row with a subsumed status. The table merge
+            // makes subsumption dominant whether the row was committed or
+            // predicted by an earlier action for this match.
             let mut dst_entries = inner.convert_all(&entries);
             schema_math.write_table_row(
                 &mut dst_entries,
@@ -505,26 +507,7 @@ impl RuleBuilder<'_> {
                     ret_val: Some(inner.convert(&ret)),
                 },
             );
-            // Look up the current subsume value, including rows predicted by
-            // earlier actions for the same rule match.
-            let default_vals = dst_entries[schema_math.num_keys()..]
-                .iter()
-                .copied()
-                .map(WriteVal::from)
-                .collect::<SmallVec<[_; 4]>>();
-            let cur_subsume_val = rb.lookup_or_insert(
-                table,
-                &dst_entries[..schema_math.num_keys()],
-                &default_vals,
-                ColumnId::from_usize(schema_math.subsume_col()),
-            )?;
-            rb.insert_if_eq(
-                table,
-                cur_subsume_val.into(),
-                NOT_SUBSUMED.into(),
-                &dst_entries,
-            )?;
-            Ok(())
+            rb.insert(table, &dst_entries).context("subsume")
         });
     }
 

--- a/src/exec_state.rs
+++ b/src/exec_state.rs
@@ -655,7 +655,10 @@ pub trait Write<'a, 'db: 'a>: Core<'a, 'db> + RegistrySealed<'a, 'db> {
         Ok(())
     }
 
-    /// Subsume a row in the named table.
+    /// Subsume a row in the named table. For a subsumable constructor, a
+    /// missing row is inserted as subsumed. This may be sequenced with
+    /// [`Write::add`] for the same key without an intermediate flush; the
+    /// predicted output is reused and subsumption takes precedence.
     fn subsume<K: IntoValues>(&mut self, name: &str, key: K) -> Result<(), Error> {
         let action = lookup_action(self.registry(), self.es(), name)?;
         let key_values: ValueRow = key.into_values(self.base_values()).collect();

--- a/tests/api_fact_ops.rs
+++ b/tests/api_fact_ops.rs
@@ -140,6 +140,53 @@ fn test_constructor_add_returns_id() -> Result<(), Error> {
 }
 
 #[test]
+fn test_subsume_predicted_constructor_rows() -> Result<(), Error> {
+    let mut eg = EGraph::default();
+    eg.parse_and_run_program(None, "(datatype Math (Num i64))")?;
+
+    // A direct subsume creates a missing constructor row as subsumed.
+    eg.update(|mut fs| fs.subsume("Num", 0_i64))?;
+    let direct = eg
+        .update(|fs| fs.eclass_of("Num", 0_i64))?
+        .expect("subsume should create a missing constructor row");
+
+    // Both action orders work without an intermediate flush. Repeated adds
+    // return the output predicted by the first operation for that key.
+    let (add_then, subsume_then) = eg.update(|mut fs| -> Result<_, Error> {
+        assert_eq!(fs.add("Num", 0_i64)?, direct);
+
+        let add_then = fs.add("Num", 1_i64)?;
+        fs.subsume("Num", 1_i64)?;
+        assert_eq!(fs.add("Num", 1_i64)?, add_then);
+
+        fs.subsume("Num", 2_i64)?;
+        let subsume_then = fs.add("Num", 2_i64)?;
+        assert_eq!(fs.add("Num", 2_i64)?, subsume_then);
+
+        Ok((add_then, subsume_then))
+    })?;
+
+    let mut rows = Vec::new();
+    eg.constructor_enodes("Num", |enode| {
+        rows.push((
+            eg.value_to_base::<i64>(enode.children[0]),
+            enode.eclass,
+            enode.subsumed,
+        ));
+    })?;
+    rows.sort_unstable_by_key(|row| row.0);
+    assert_eq!(
+        rows,
+        vec![
+            (0, direct, true),
+            (1, add_then, true),
+            (2, subsume_then, true)
+        ]
+    );
+    Ok(())
+}
+
+#[test]
 fn test_eclass_of_constructor() -> Result<(), Error> {
     let mut eg = EGraph::default();
     eg.parse_and_run_program(None, "(datatype List (Cons i64 List) (Nil))")?;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1219,6 +1219,70 @@ fn test_subsume_ok() {
 }
 
 #[test]
+fn test_rule_subsume_predicted_rows() {
+    let mut egraph = EGraph::default();
+    egraph
+        .parse_and_run_program(
+            None,
+            r#"
+            (datatype Math (Num i64))
+            (relation fire (i64))
+            (relation after (i64))
+            (relation saw-num (i64))
+            (ruleset mutate)
+            (ruleset observe)
+
+            ;; Subsume a missing row directly.
+            (rule ((fire 0))
+                  ((subsume (Num 0))
+                   (after 0))
+                  :ruleset mutate)
+
+            ;; Add, then subsume, within one rule action.
+            (rule ((fire 1))
+                  ((let n (Num 1))
+                   (subsume (Num 1))
+                   (after 1))
+                  :ruleset mutate)
+
+            ;; Subsumption remains dominant when followed by an add.
+            (rule ((fire 2))
+                  ((subsume (Num 2))
+                   (let n (Num 2))
+                   (after 2))
+                  :ruleset mutate)
+
+            (rule ((= e (Num n)))
+                  ((saw-num n))
+                  :ruleset observe)
+
+            (fire 0)
+            (fire 1)
+            (fire 2)
+            (run mutate 1)
+            (check (after 0) (after 1) (after 2))
+            (run observe 1)
+            (fail (check (saw-num 0)))
+            (fail (check (saw-num 1)))
+            (fail (check (saw-num 2)))
+            "#,
+        )
+        .unwrap();
+
+    let mut nums = Vec::new();
+    egraph
+        .constructor_enodes("Num", |enode| {
+            nums.push((
+                egraph.value_to_base::<i64>(enode.children[0]),
+                enode.subsumed,
+            ));
+        })
+        .unwrap();
+    nums.sort_unstable();
+    assert_eq!(nums, vec![(0, true), (1, true), (2, true)]);
+}
+
+#[test]
 fn test_cant_subsume_merge() {
     // Test that we can't subsume something with a merge function
 


### PR DESCRIPTION
## Summary

Make constructor subsumption work for rows created earlier in the same action, both in compiled egglog rule RHSs and through the `Write`/`FullState` API. Subsumption is dominant regardless of whether an add appears before or after it, and actions following a missing-row `subsume` continue to execute.

This uses the existing table merge and prediction machinery. It adds no public API and makes no `core-relations` changes.

## Bugs fixed

- **Rule RHS ordering could leave a row live and skip later actions.** The first half of rule-level subsumption uses `lookup_or_insert` to supply a constructor output, predicting a subsumed row on a miss. Its second callback nevertheless performed a committed-only status lookup before writing. For a row predicted by a preceding constructor add, that lookup removed the action lane: the row flushed live and every later RHS action was skipped. A direct missing-row `subsume` predicted a hidden row but still skipped later actions. The second callback now writes the same row with `SUBSUMED` directly; the existing table merge makes subsumption dominant for committed and predicted rows without another lookup.
- **The runtime API could not subsume a same-action row.** `FullState::add` followed by `FullState::subsume` panicked because `TableAction::subsume` searched only committed rows. Directly subsuming a missing constructor failed the same way. It now uses `lookup_or_insert`, reusing any predicted output before staging the subsumed row.

Committed live and already-subsumed rows retain their existing explicit-subsume behavior.

## Validation

- `make test` — 1,191 tests plus doctests
- `make nits`
- `cargo test -p egglog-bridge` — 19 tests
- `cargo test --test integration_test` — 59 tests
- `cargo test --test api_fact_ops test_subsume_predicted_constructor_rows`
- focused rule and `FullState` regressions for direct subsume and both action orders
- `cargo check -p egglog --no-default-features --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

An earlier full-suite run hit the known-flaky `core_relations::tests::early_stop`; it passed in isolation and the complete suite passed on rerun.
