### PR TITLE
Add standalone e-graph comparison by partition refinement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "egraph-comparison"
+version = "3.0.0"
+dependencies = [
+ "clap",
+ "egglog-numeric-id",
+ "hashbrown 0.16.0",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "egraph-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
   "concurrency",
   "core-relations",
+  "egraph-comparison",
   "egglog-ast",
   "egglog-bridge",
   "numeric-id",

--- a/egraph-comparison/Cargo.toml
+++ b/egraph-comparison/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "egraph-comparison"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Compare serialized e-graphs modulo bisimulation"
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+egglog-numeric-id.workspace = true
+hashbrown.workspace = true
+rustc-hash.workspace = true

--- a/egraph-comparison/README.md
+++ b/egraph-comparison/README.md
@@ -1,0 +1,87 @@
+# egraph-comparison
+
+```sh
+cargo run -p egraph-comparison -- left.json right.json
+cargo run -p egraph-comparison -- --terms-only left.json right.json
+```
+
+The binary reads two complete, rebuilt databases and emits JSON with
+`terms_equal`, `database_equal`, `refinement_rounds`, and
+`database_refinement_rounds`. Exit status is 0 for
+equality, 1 for disequality, and 2 for invalid input or I/O failure. `--terms-only`
+selects term equality for the exit status; both results are always reported.
+
+## Semantics
+
+Partition refinement starts with a coarse grouping of e-classes and repeatedly
+splits groups whose members have different observations. Initially, classes are
+grouped by sort. A class's observation is the set of its e-node labels together
+with the current groups of each node's ordered children. Refinement stops when
+no group can split. Comparing two inputs refines their disjoint union and checks
+that the same groups contain observable roots on both sides.
+
+This is the idea behind [DFA minimization](https://en.wikipedia.org/wiki/DFA_minimization).
+For its generalization to other transition structures, see Jacobs and Wißmann,
+[Fast Coalgebraic Bisimilarity Minimization](https://arxiv.org/abs/2204.12368).
+The implementation here uses whole-graph rounds; it does **not** implement
+Hopcroft's smaller-half splitter worklist or the fast algorithm in that paper.
+
+This is conservative e-graph partition refinement: cycles merge only when the
+complete sets of e-nodes in their e-classes are identical modulo the refined
+child groups. Merely overlapping sets do not suffice. A self-loop and two
+mutually recursive classes compare equal when they have the same complete
+observations, as do duplicated copies of a cycle. Adding an unmatched member to
+one class can distinguish it even when both classes still contain a common term.
+
+`terms_equal` compares constructor-output classes by bisimulation. Node labels
+include function name and signature; children are ordered, e-class members are
+sets, and sorts and primitive literal values are exact. Literals are allowed as
+constructor arguments, but primitive values occurring only in function tables
+do not add constructor terms. Empty classes are observable through constructor
+arguments. Bisimulation includes ungrounded cycles and is deliberately stronger
+than equality of finite ground-term languages. This is not graph isomorphism.
+
+`database_equal` additionally compares function declarations and all rows,
+including constructor rows and subsumption flags. Its full-database refinement
+includes ordinary function calls in class observations. This preserves
+structure carried only by function tables, even when values have no constructor
+terms. Values in the rows are compared using this full-database partition.
+Non-constructor functions never become term operators or enter finite term
+certificates. All comparisons are of sets, so multiplicities of duplicate rows
+or bisimilar values are ignored. Unused classes are ignored. This still compares
+bisimulation quotients, not bijective identities or graph isomorphism: empty
+classes of the same sort remain indistinguishable if no incoming rows give them
+different observations.
+Costs, roots, extraction preferences, and runtime implementation details are
+outside this database format.
+
+The implementation recomputes exact signatures each round. It has at most a
+linear number of splitting rounds and can take quadratic time (plus signature
+sorting). There is no probabilistic equality or depth limit. Performance
+improvements preserve exact signature equality.
+
+## Version 1 JSON
+
+```json
+{
+  "version": 1,
+  "classes": {"a": {"sort": "Expr"}, "n": {"sort": "i64", "literal": "1"}},
+  "functions": {
+    "Num": {"kind": "constructor", "inputs": ["i64"], "output": "Expr"},
+    "cost": {"kind": "function", "inputs": ["Expr"], "output": "i64"}
+  },
+  "rows": [
+    {"function": "Num", "inputs": ["n"], "output": "a"},
+    {"function": "cost", "inputs": ["a"], "output": "n"}
+  ]
+}
+```
+
+Class IDs are arbitrary strings scoped to one file. The numeric `version` field
+is a `FormatVersion` identifying the wire format, not an e-class identifier.
+Setup resolves class names to distinct typed class and partition IDs.
+`literal` is an opaque, stable encoding qualified by its sort. `subsumed` defaults to false. Declarations
+are explicit even for empty tables. Unknown fields, unsupported versions,
+dangling IDs, wrong sorts/arity, duplicate literal identities, and conflicting
+function rows are errors. Producers must canonicalize IDs and rebuild first.
+This format is separate from visualization-oriented `egraph-serialize` JSON.

--- a/egraph-comparison/src/ids.rs
+++ b/egraph-comparison/src/ids.rs
@@ -1,0 +1,35 @@
+use egglog_numeric_id::{NumericId, define_id};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+// Preserve scalar JSON encodings while giving each numeric namespace a type.
+macro_rules! serial_id {
+    ($name:ident, $repr:tt, $doc:literal) => {
+        define_id!(pub $name, $repr, $doc);
+        impl Serialize for $name {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                self.rep().serialize(serializer)
+            }
+        }
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                <$repr>::deserialize(deserializer).map(Self::new)
+            }
+        }
+    };
+}
+
+serial_id!(
+    FormatVersion,
+    u32,
+    "Version of the surrounding JSON format, not an e-class or partition ID. Version 1 is currently supported."
+);
+impl FormatVersion {
+    pub const V1: Self = Self::new_const(1);
+}
+define_id!(pub(crate) ClassId, usize, "Dense e-class index in a comparison graph. In joint refinement, right-side IDs follow all left-side IDs. Unrelated to serialized class names.");
+serial_id!(
+    BlockId,
+    usize,
+    "Equivalence block in one refinement partition. IDs are local to that partition and round, not stable e-class identities."
+);
+define_id!(pub RowId, usize, "Index in one input database's rows, used by the representative worklist.");

--- a/egraph-comparison/src/lib.rs
+++ b/egraph-comparison/src/lib.rs
@@ -1,0 +1,9 @@
+//! Compare complete serialized databases by conservative partition refinement.
+mod ids;
+mod model;
+mod refine;
+pub use ids::{FormatVersion, RowId};
+pub use model::{Class, Database, Error, Function, FunctionKind, Row};
+pub use refine::{Comparison, compare};
+pub(crate) type HashMap<K, V> =
+    hashbrown::HashMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;

--- a/egraph-comparison/src/main.rs
+++ b/egraph-comparison/src/main.rs
@@ -1,0 +1,41 @@
+use clap::Parser;
+use egraph_comparison::{Database, compare};
+use std::{fs::File, io::BufReader, path::PathBuf, process::ExitCode};
+
+#[derive(Parser)]
+#[command(about = "Compare two serialized e-graphs modulo constructor bisimulation")]
+struct Args {
+    left: PathBuf,
+    right: PathBuf,
+    /// Compare constructor-built terms and their e-class equalities, including
+    /// cyclic structure. Ignore ordinary function tables and subsumption for
+    /// the exit status; comparison still reports both equality results.
+    /// See egraph-comparison/README.md, Semantics, for the bisimulation definition.
+    #[arg(long)]
+    terms_only: bool,
+}
+
+fn run(args: &Args) -> Result<bool, Box<dyn std::error::Error>> {
+    let read = |path: &PathBuf| -> Result<Database, Box<dyn std::error::Error>> {
+        Ok(serde_json::from_reader(BufReader::new(File::open(path)?))?)
+    };
+    let result = compare(&read(&args.left)?, &read(&args.right)?)?;
+    serde_json::to_writer_pretty(std::io::stdout().lock(), &result)?;
+    Ok(if args.terms_only {
+        result.terms_equal
+    } else {
+        result.database_equal
+    })
+}
+
+#[allow(clippy::disallowed_macros)]
+fn main() -> ExitCode {
+    match run(&Args::parse()) {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::from(1),
+        Err(error) => {
+            eprintln!("egraph-comparison: {error}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/egraph-comparison/src/model.rs
+++ b/egraph-comparison/src/model.rs
@@ -1,0 +1,186 @@
+use crate::{FormatVersion, HashMap, RowId};
+use egglog_numeric_id::NumericId;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A complete rebuilt database without visualization limits. Class names are
+/// arbitrary input-local strings; they are resolved to typed dense IDs at setup.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Database {
+    /// Wire-format version; unrelated to database contents or e-class identity.
+    pub version: FormatVersion,
+    pub classes: BTreeMap<String, Class>,
+    pub functions: BTreeMap<String, Function>,
+    pub rows: Vec<Row>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Class {
+    pub sort: String,
+    /// A stable, exact encoding of a primitive value, qualified by `sort`.
+    /// Equality-sort classes have no literal, including empty classes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub literal: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Function {
+    pub kind: FunctionKind,
+    pub inputs: Vec<String>,
+    pub output: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FunctionKind {
+    Constructor,
+    Function,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Row {
+    pub function: String,
+    pub inputs: Vec<String>,
+    pub output: String,
+    /// Subsumed constructors still denote terms; activity affects database equality.
+    #[serde(default)]
+    pub subsumed: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("unsupported database version {version:?}")]
+    UnsupportedVersion { version: FormatVersion },
+    #[error("duplicate literal classes {first} and {second}")]
+    DuplicateLiteral { first: String, second: String },
+    #[error("row {row:?}: undeclared function {function}")]
+    UndeclaredFunction { row: RowId, function: String },
+    #[error("row {row:?}: wrong arity for {function}: expected {expected}, got {actual}")]
+    Arity {
+        row: RowId,
+        function: String,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("row {row:?}: unknown class {class}")]
+    UnknownClass { row: RowId, class: String },
+    #[error("row {row:?}: class {class} has sort {actual}, expected {expected}")]
+    SortMismatch {
+        row: RowId,
+        class: String,
+        expected: String,
+        actual: String,
+    },
+    #[error("row {row:?}: constructor output {class} cannot be a literal")]
+    ConstructorLiteral { row: RowId, class: String },
+    #[error(
+        "row {row:?}: conflicting rows for the same inputs to {function}; rebuild before exporting"
+    )]
+    ConflictingRows { row: RowId, function: String },
+    #[error("disequality without a witness (internal error)")]
+    MissingWitness,
+    #[error("cannot serialize canonical graph: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+impl Default for Database {
+    fn default() -> Self {
+        Self {
+            version: FormatVersion::V1,
+            classes: BTreeMap::new(),
+            functions: BTreeMap::new(),
+            rows: Vec::new(),
+        }
+    }
+}
+
+impl Database {
+    /// Reject malformed or non-canonical input rather than silently repairing it.
+    pub fn validate(&self) -> Result<(), Error> {
+        if self.version != FormatVersion::V1 {
+            return Err(Error::UnsupportedVersion {
+                version: self.version,
+            });
+        }
+        let mut literals = HashMap::default();
+        for (id, class) in &self.classes {
+            if let Some(value) = &class.literal
+                && let Some(previous) = literals.insert((&class.sort, value), id)
+            {
+                return Err(Error::DuplicateLiteral {
+                    first: previous.clone(),
+                    second: id.clone(),
+                });
+            }
+        }
+        // Borrow the serialized names; repeated row lookups should not traverse
+        // a string-keyed tree. The public, ordered serialization stays unchanged.
+        let classes: HashMap<_, _> = self
+            .classes
+            .iter()
+            .map(|(id, c)| (id.as_str(), c))
+            .collect();
+        let mut calls = HashMap::default();
+        calls.reserve(self.rows.len());
+        for (index, row) in self.rows.iter().enumerate() {
+            let function =
+                self.functions
+                    .get(&row.function)
+                    .ok_or_else(|| Error::UndeclaredFunction {
+                        row: RowId::from_usize(index),
+                        function: row.function.clone(),
+                    })?;
+            if row.inputs.len() != function.inputs.len() {
+                return Err(Error::Arity {
+                    row: RowId::from_usize(index),
+                    function: row.function.clone(),
+                    expected: function.inputs.len(),
+                    actual: row.inputs.len(),
+                });
+            }
+            for (id, sort) in row
+                .inputs
+                .iter()
+                .zip(&function.inputs)
+                .chain(std::iter::once((&row.output, &function.output)))
+            {
+                let class = classes
+                    .get(id.as_str())
+                    .ok_or_else(|| Error::UnknownClass {
+                        row: RowId::from_usize(index),
+                        class: id.clone(),
+                    })?;
+                if &class.sort != sort {
+                    return Err(Error::SortMismatch {
+                        row: RowId::from_usize(index),
+                        class: id.clone(),
+                        expected: sort.clone(),
+                        actual: class.sort.clone(),
+                    });
+                }
+            }
+            if function.kind == FunctionKind::Constructor
+                && classes[row.output.as_str()].literal.is_some()
+            {
+                return Err(Error::ConstructorLiteral {
+                    row: RowId::from_usize(index),
+                    class: row.output.clone(),
+                });
+            }
+            if let Some(previous) =
+                calls.insert((&row.function, &row.inputs), (&row.output, row.subsumed))
+                && previous != (&row.output, row.subsumed)
+            {
+                return Err(Error::ConflictingRows {
+                    row: RowId::from_usize(index),
+                    function: row.function.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+}

--- a/egraph-comparison/src/refine.rs
+++ b/egraph-comparison/src/refine.rs
@@ -1,0 +1,201 @@
+use crate::ids::{BlockId, ClassId};
+use crate::{Database, Error, Function, FunctionKind};
+use egglog_numeric_id::NumericId;
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct Comparison {
+    /// Constructor e-classes have the same sets of bisimulation behaviors.
+    pub terms_equal: bool,
+    /// Additionally, declarations and the full database coalgebra agree.
+    pub database_equal: bool,
+    /// Rounds in constructor-only refinement.
+    pub refinement_rounds: usize,
+    /// Rounds in refinement including ordinary functions and subsumption.
+    pub database_refinement_rounds: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Node<I = ClassId> {
+    Literal(String),
+    Call(String, Function, Vec<I>, bool),
+}
+
+pub(crate) struct Graph {
+    pub sorts: Vec<String>,
+    pub nodes: Vec<Vec<Node>>,
+    pub roots: BTreeSet<ClassId>,
+    pub index: BTreeMap<String, ClassId>,
+}
+
+impl Graph {
+    fn new(db: &Database, offset: usize, include_functions: bool) -> Self {
+        let ids: Vec<_> = db.classes.keys().cloned().collect();
+        let index: BTreeMap<_, _> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| (id.clone(), ClassId::from_usize(i + offset)))
+            .collect();
+        let sorts = db.classes.values().map(|c| c.sort.clone()).collect();
+        let mut nodes = vec![Vec::new(); ids.len()];
+        for (id, class) in &db.classes {
+            if let Some(literal) = &class.literal {
+                nodes[index[id].index() - offset].push(Node::Literal(literal.clone()));
+            }
+        }
+        let mut roots = BTreeSet::new();
+        for row in &db.rows {
+            let function = &db.functions[&row.function];
+            if include_functions || function.kind == FunctionKind::Constructor {
+                roots.insert(index[&row.output]);
+                nodes[index[&row.output].index() - offset].push(Node::Call(
+                    row.function.clone(),
+                    function.clone(),
+                    row.inputs.iter().map(|id| index[id]).collect(),
+                    include_functions && row.subsumed,
+                ));
+            }
+        }
+        Self {
+            sorts,
+            nodes,
+            roots,
+            index,
+        }
+    }
+}
+
+pub(crate) struct Partition {
+    pub left: Graph,
+    pub right: Graph,
+    pub blocks: Vec<BlockId>,
+    pub rounds: usize,
+}
+
+impl Partition {
+    pub fn new(left: &Database, right: &Database) -> Self {
+        Self::with_functions(left, right, false)
+    }
+
+    pub fn database(left: &Database, right: &Database) -> Self {
+        Self::with_functions(left, right, true)
+    }
+
+    fn with_functions(left: &Database, right: &Database, include_functions: bool) -> Self {
+        let left = Graph::new(left, 0, include_functions);
+        let right = Graph::new(right, left.nodes.len(), include_functions);
+        // Sorts must never become equivalent, even for empty e-classes.
+        let mut sorts = BTreeMap::new();
+        let blocks = left
+            .sorts
+            .iter()
+            .chain(&right.sorts)
+            .map(|sort| {
+                let next = BlockId::from_usize(sorts.len());
+                *sorts.entry(sort).or_insert(next)
+            })
+            .collect();
+        Self {
+            left,
+            right,
+            blocks,
+            rounds: 0,
+        }
+    }
+
+    pub fn step(&mut self) -> bool {
+        let mut signatures = BTreeMap::new();
+        let mut next_blocks = Vec::with_capacity(self.blocks.len());
+        for (i, nodes) in self.left.nodes.iter().chain(&self.right.nodes).enumerate() {
+            let signature: BTreeSet<_> = nodes
+                .iter()
+                .map(|node| match node {
+                    Node::Literal(value) => Node::Literal(value.clone()),
+                    Node::Call(op, schema, children, subsumed) => Node::Call(
+                        op.clone(),
+                        schema.clone(),
+                        children
+                            .iter()
+                            .map(|&child| self.blocks[child.index()])
+                            .collect(),
+                        *subsumed,
+                    ),
+                })
+                .collect();
+            // Retain the old block: every round is a refinement, never a merge.
+            let next = BlockId::from_usize(signatures.len());
+            next_blocks.push(
+                *signatures
+                    .entry((self.blocks[i], signature))
+                    .or_insert(next),
+            );
+        }
+        self.rounds += 1;
+        let changed = next_blocks != self.blocks;
+        self.blocks = next_blocks;
+        changed
+    }
+
+    pub fn finish(&mut self) {
+        while self.step() {}
+    }
+
+    pub fn root_blocks(&self, graph: &Graph) -> BTreeSet<BlockId> {
+        graph
+            .roots
+            .iter()
+            .map(|&id| self.blocks[id.index()])
+            .collect()
+    }
+
+    pub fn terms_equal(&self) -> bool {
+        self.root_blocks(&self.left) == self.root_blocks(&self.right)
+    }
+}
+
+/// Exact whole-graph refinement; no iteration/depth cutoff. This does not use
+/// Hopcroft's smaller-half splitter worklist.
+///
+/// This intentionally starts with the straightforward whole-graph algorithm.
+/// A round scans all nodes and edges and sorts signatures; there are at most
+/// O(classes) splitting rounds. The result ignores row order and duplicate rows
+/// or bisimilar cyclic classes. Function rows do not participate in term syntax.
+pub fn compare(left: &Database, right: &Database) -> Result<Comparison, Error> {
+    left.validate()?;
+    right.validate()?;
+    let mut partition = Partition::new(left, right);
+    partition.finish();
+    let terms_equal = partition.terms_equal();
+    let refinement_rounds = partition.rounds;
+    // Constructor-only blocks can erase structure carried by ordinary functions.
+    // Refine again with all rows to preserve those observations, while keeping
+    // the term result and finite certificates strictly constructor-only.
+    let mut partition = Partition::database(left, right);
+    partition.finish();
+    let rows = |db: &Database, graph: &Graph| -> BTreeSet<_> {
+        db.rows
+            .iter()
+            .map(|row| {
+                (
+                    row.function.clone(),
+                    row.inputs
+                        .iter()
+                        .map(|id| partition.blocks[graph.index[id].index()])
+                        .collect::<Vec<_>>(),
+                    partition.blocks[graph.index[&row.output].index()],
+                    row.subsumed,
+                )
+            })
+            .collect()
+    };
+    let database_equal = terms_equal
+        && left.functions == right.functions
+        && rows(left, &partition.left) == rows(right, &partition.right);
+    Ok(Comparison {
+        terms_equal,
+        database_equal,
+        refinement_rounds,
+        database_refinement_rounds: partition.rounds,
+    })
+}

--- a/egraph-comparison/tests/cli.rs
+++ b/egraph-comparison/tests/cli.rs
@@ -1,0 +1,37 @@
+use std::{fs, process::Command};
+
+#[test]
+fn exit_status_and_json_output() {
+    let dir = std::env::temp_dir().join(format!("egraph-comparison-cli-{}", std::process::id()));
+    fs::create_dir_all(&dir).unwrap();
+    let empty = dir.join("empty.json");
+    let different = dir.join("different.json");
+    let invalid = dir.join("invalid.json");
+    fs::write(
+        &empty,
+        r#"{"version":1,"classes":{},"functions":{},"rows":[]}"#,
+    )
+    .unwrap();
+    fs::write(&different, r#"{"version":1,"classes":{},"functions":{"f":{"kind":"function","inputs":[],"output":"E"}},"rows":[]}"#).unwrap();
+    fs::write(&invalid, "{").unwrap();
+    let run = |a: &std::path::Path, b: &std::path::Path, terms: bool| {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_egraph-comparison"));
+        cmd.arg(a).arg(b);
+        if terms {
+            cmd.arg("--terms-only");
+        }
+        cmd.output().unwrap()
+    };
+    let same = run(&empty, &empty, false);
+    assert!(same.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&same.stdout).unwrap();
+    assert_eq!(json["database_equal"], true);
+    assert_eq!(run(&empty, &different, false).status.code(), Some(1));
+    assert!(run(&empty, &different, true).status.success());
+    assert_eq!(run(&empty, &invalid, false).status.code(), Some(2));
+    assert_eq!(
+        run(&empty, &dir.join("missing"), false).status.code(),
+        Some(2)
+    );
+    fs::remove_dir_all(dir).unwrap();
+}

--- a/egraph-comparison/tests/comparison.rs
+++ b/egraph-comparison/tests/comparison.rs
@@ -1,0 +1,286 @@
+use egraph_comparison::{Class, Database, Function, FunctionKind, Row, compare};
+use std::collections::BTreeSet;
+
+fn graph(rows: &[(&str, &[&str], &str)]) -> Database {
+    let mut db = Database::default();
+    for &(op, inputs, output) in rows {
+        for id in inputs.iter().copied().chain([output]) {
+            db.classes.insert(
+                id.into(),
+                Class {
+                    sort: "E".into(),
+                    literal: None,
+                },
+            );
+        }
+        db.functions.insert(
+            op.into(),
+            Function {
+                kind: FunctionKind::Constructor,
+                inputs: vec!["E".into(); inputs.len()],
+                output: "E".into(),
+            },
+        );
+        db.rows.push(Row {
+            function: op.into(),
+            inputs: inputs.iter().map(|s| (*s).into()).collect(),
+            output: output.into(),
+            subsumed: false,
+        });
+    }
+    db
+}
+
+#[test]
+fn renaming_order_duplicates_and_cycles() {
+    let left = graph(&[("f", &["x"], "x")]);
+    let mut right = graph(&[("f", &["b"], "a"), ("f", &["a"], "b"), ("f", &["c"], "c")]);
+    right.rows.reverse();
+    right.rows.push(right.rows[0].clone());
+    assert!(compare(&left, &right).unwrap().database_equal);
+}
+
+#[test]
+fn missing_terms_and_different_equalities() {
+    let left = graph(&[("a", &[], "x"), ("b", &[], "x")]);
+    let split = graph(&[("a", &[], "x"), ("b", &[], "y")]);
+    let absent = graph(&[("a", &[], "x")]);
+    assert!(!compare(&left, &split).unwrap().terms_equal);
+    assert!(!compare(&left, &absent).unwrap().terms_equal);
+    assert!(
+        compare(&Database::default(), &Database::default())
+            .unwrap()
+            .database_equal
+    );
+}
+
+#[test]
+fn ordered_children_sorts_and_empty_classes() {
+    let left = graph(&[("a", &[], "x"), ("b", &[], "y"), ("p", &["x", "y"], "z")]);
+    let mut right = left.clone();
+    right.rows[2].inputs.reverse();
+    assert!(!compare(&left, &right).unwrap().terms_equal);
+    let left = graph(&[("f", &["hole"], "root")]);
+    let right = graph(&[("f", &["root"], "root")]);
+    assert!(!compare(&left, &right).unwrap().terms_equal);
+    let mut right = left.clone();
+    right.classes.get_mut("hole").unwrap().sort = "Other".into();
+    right.functions.get_mut("f").unwrap().inputs = vec!["Other".into()];
+    assert!(!compare(&left, &right).unwrap().terms_equal);
+}
+
+#[test]
+fn function_values_and_subsumption_do_not_create_terms() {
+    let mut left = graph(&[("a", &[], "x"), ("cost", &["x"], "one")]);
+    left.functions.get_mut("cost").unwrap().kind = FunctionKind::Function;
+    left.functions.get_mut("cost").unwrap().output = "i64".into();
+    left.classes.insert(
+        "one".into(),
+        Class {
+            sort: "i64".into(),
+            literal: Some("1".into()),
+        },
+    );
+    let mut right = left.clone();
+    right.classes.get_mut("one").unwrap().literal = Some("2".into());
+    let result = compare(&left, &right).unwrap();
+    assert!(result.terms_equal);
+    assert!(!result.database_equal);
+    right = left.clone();
+    right.rows[0].subsumed = true;
+    let result = compare(&left, &right).unwrap();
+    assert!(result.terms_equal);
+    assert!(!result.database_equal);
+    right = left.clone();
+    right.functions.insert(
+        "empty".into(),
+        Function {
+            kind: FunctionKind::Function,
+            inputs: vec![],
+            output: "E".into(),
+        },
+    );
+    assert!(compare(&left, &right).unwrap().terms_equal);
+    assert!(!compare(&left, &right).unwrap().database_equal);
+}
+
+#[test]
+fn validation_errors() {
+    let db = graph(&[("a", &[], "x"), ("f", &["x"], "y")]);
+    let mut bad = db.clone();
+    bad.version = egraph_comparison::FormatVersion::new_const(9);
+    assert!(bad.validate().unwrap_err().to_string().contains("version"));
+    bad = db.clone();
+    bad.rows[1].inputs[0] = "missing".into();
+    assert!(
+        bad.validate()
+            .unwrap_err()
+            .to_string()
+            .contains("unknown class")
+    );
+    bad = db.clone();
+    bad.rows[1].inputs.clear();
+    assert!(bad.validate().unwrap_err().to_string().contains("arity"));
+    bad = db.clone();
+    bad.rows.push(Row {
+        output: "y".into(),
+        ..bad.rows[0].clone()
+    });
+    assert!(
+        bad.validate()
+            .unwrap_err()
+            .to_string()
+            .contains("conflicting")
+    );
+    bad = db.clone();
+    bad.classes.get_mut("x").unwrap().sort = "other".into();
+    assert!(bad.validate().unwrap_err().to_string().contains("sort"));
+    bad = db.clone();
+    bad.functions.clear();
+    assert!(
+        bad.validate()
+            .unwrap_err()
+            .to_string()
+            .contains("undeclared")
+    );
+    bad = db.clone();
+    bad.classes.get_mut("x").unwrap().literal = Some("0".into());
+    assert!(bad.validate().unwrap_err().to_string().contains("literal"));
+    bad.classes.get_mut("y").unwrap().literal = Some("0".into());
+    assert!(
+        bad.validate()
+            .unwrap_err()
+            .to_string()
+            .contains("duplicate literal")
+    );
+    let mut json = serde_json::to_value(&db).unwrap();
+    json["typo"] = true.into();
+    assert!(serde_json::from_value::<Database>(json).is_err());
+    let roundtrip: Database = serde_json::from_str(&serde_json::to_string(&db).unwrap()).unwrap();
+    assert!(compare(&db, &roundtrip).unwrap().database_equal);
+}
+
+// Independent greatest-fixed-point relation elimination, without partition IDs.
+fn oracle(left: &Database, right: &Database) -> bool {
+    let mut relation: BTreeSet<_> = left
+        .classes
+        .keys()
+        .flat_map(|l| right.classes.keys().map(move |r| (l.clone(), r.clone())))
+        .collect();
+    loop {
+        let previous = relation.clone();
+        relation.retain(|(l, r)| {
+            let lc = &left.classes[l];
+            let rc = &right.classes[r];
+            if lc.sort != rc.sort || lc.literal != rc.literal {
+                return false;
+            }
+            let lr: Vec<_> = left.rows.iter().filter(|row| &row.output == l).collect();
+            let rr: Vec<_> = right.rows.iter().filter(|row| &row.output == r).collect();
+            let matches = |a: &&Row, b: &&Row| {
+                a.function == b.function
+                    && a.inputs.len() == b.inputs.len()
+                    && a.inputs
+                        .iter()
+                        .zip(&b.inputs)
+                        .all(|(x, y)| previous.contains(&(x.clone(), y.clone())))
+            };
+            lr.iter().all(|a| rr.iter().any(|b| matches(a, b)))
+                && rr.iter().all(|b| lr.iter().any(|a| matches(a, b)))
+        });
+        if previous == relation {
+            break;
+        }
+    }
+    left.rows.iter().all(|a| {
+        right
+            .rows
+            .iter()
+            .any(|b| relation.contains(&(a.output.clone(), b.output.clone())))
+    }) && right.rows.iter().all(|b| {
+        left.rows
+            .iter()
+            .any(|a| relation.contains(&(a.output.clone(), b.output.clone())))
+    })
+}
+
+#[test]
+fn agrees_with_relation_oracle_on_small_cyclic_graphs() {
+    fn generated(mut seed: usize) -> Database {
+        let mut db = Database::default();
+        for i in 0..4 {
+            db.classes.insert(
+                i.to_string(),
+                Class {
+                    sort: "E".into(),
+                    literal: None,
+                },
+            );
+        }
+        for op in ["f", "g"] {
+            db.functions.insert(
+                op.into(),
+                Function {
+                    kind: FunctionKind::Constructor,
+                    inputs: vec!["E".into()],
+                    output: "E".into(),
+                },
+            );
+            for input in 0..4 {
+                seed = seed.wrapping_mul(1664525).wrapping_add(1013904223);
+                if seed.is_multiple_of(7) {
+                    continue;
+                }
+                db.rows.push(Row {
+                    function: op.into(),
+                    inputs: vec![input.to_string()],
+                    output: ((seed >> 8) % 4).to_string(),
+                    subsumed: false,
+                });
+            }
+        }
+        db
+    }
+    for seed in 0..100 {
+        let left = generated(seed);
+        let right = generated(seed / 2);
+        assert_eq!(
+            compare(&left, &right).unwrap().terms_equal,
+            oracle(&left, &right),
+            "seed {seed}"
+        );
+        assert!(compare(&left, &left).unwrap().database_equal);
+    }
+}
+
+#[test]
+fn propagates_a_difference_through_a_long_chain() {
+    let mut left = graph(&[("a", &[], "0")]);
+    left.functions.insert(
+        "f".into(),
+        Function {
+            kind: FunctionKind::Constructor,
+            inputs: vec!["E".into()],
+            output: "E".into(),
+        },
+    );
+    for i in 1..80 {
+        left.classes.insert(
+            i.to_string(),
+            Class {
+                sort: "E".into(),
+                literal: None,
+            },
+        );
+        left.rows.push(Row {
+            function: "f".into(),
+            inputs: vec![(i - 1).to_string()],
+            output: i.to_string(),
+            subsumed: false,
+        });
+    }
+    let mut right = left.clone();
+    right.rows.last_mut().unwrap().output = "78".into();
+    assert!(!compare(&left, &right).unwrap().terms_equal);
+    assert!(compare(&left, &left).unwrap().refinement_rounds >= 79);
+}

--- a/egraph-comparison/tests/errors.rs
+++ b/egraph-comparison/tests/errors.rs
@@ -1,0 +1,33 @@
+use egraph_comparison::{Database, Error, FormatVersion, RowId};
+
+#[test]
+fn validation_errors_expose_context_without_parsing_messages() {
+    let mut db: Database = serde_json::from_value(serde_json::json!({
+        "version":1, "classes":{"x":{"sort":"E"}},
+        "functions":{"f":{"kind":"constructor","inputs":["E"],"output":"E"}},
+        "rows":[{"function":"f","inputs":[],"output":"x"}]
+    }))
+    .unwrap();
+    assert!(
+        matches!(db.validate(), Err(Error::Arity { row, function, expected: 1, actual: 0 })
+        if row == RowId::new_const(0) && function == "f")
+    );
+    db.rows[0].inputs.push("missing".into());
+    assert!(
+        matches!(db.validate(), Err(Error::UnknownClass { row, class })
+        if row == RowId::new_const(0) && class == "missing")
+    );
+    db.version = FormatVersion::new_const(99);
+    assert!(
+        matches!(db.validate(), Err(Error::UnsupportedVersion { version })
+        if version == FormatVersion::new_const(99))
+    );
+}
+
+#[test]
+fn typed_format_version_preserves_scalar_wire_encoding() {
+    let db = Database::default();
+    assert_eq!(serde_json::to_value(&db).unwrap()["version"], 1);
+    let parsed: Database = serde_json::from_value(serde_json::to_value(&db).unwrap()).unwrap();
+    assert_eq!(parsed.version, FormatVersion::V1);
+}

--- a/egraph-comparison/tests/function_core.rs
+++ b/egraph-comparison/tests/function_core.rs
@@ -1,0 +1,15 @@
+use egraph_comparison::{Database, compare};
+#[test]
+fn function_only_structure_is_observable_at_the_core_layer() {
+    let mut left: Database = serde_json::from_value(serde_json::json!({
+        "version":1,"classes":{"x":{"sort":"E"},"y":{"sort":"E"}},
+        "functions":{"f":{"kind":"function","inputs":["E"],"output":"E"},"g":{"kind":"function","inputs":["E"],"output":"E"}},
+        "rows":[{"function":"f","inputs":["x"],"output":"y"},{"function":"g","inputs":["x"],"output":"x"}]
+    })).unwrap();
+    let right = left.clone();
+    left.rows[1].inputs[0] = "y".into();
+    left.rows[1].output = "y".into();
+    let result = compare(&left, &right).unwrap();
+    assert!(result.terms_equal);
+    assert!(!result.database_equal);
+}


### PR DESCRIPTION
*From Codex:*

Add a standalone `egraph-comparison` library and binary that compare rebuilt JSON databases by conservative partition refinement. Report constructor-term equality separately from full database equality, including ordinary-function structure and subsumption from this first layer.

Use documented numeric-id types for wire versions, classes, partitions, and rows, with structured validation errors. The README explains the algorithm independently, links DFA minimization and generic coalgebraic minimization, and explicitly notes that this implementation scans the whole graph rather than using Hopcroft’s smaller-half worklist.

Validation: comparison/oracle, cyclic/renaming, CLI, typed-error, and function-only counterexample tests pass independently at this layer; Clippy passes.

Part of the actual `gh stack` #1023. Non-test diff: 589 added/deleted lines; tests are in separate files.
