### PR TITLE
Extract and verify e-graph disequality certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ version = "3.0.0"
 dependencies = [
  "clap",
  "egglog-numeric-id",
+ "fixedbitset",
  "hashbrown 0.16.0",
  "rustc-hash",
  "serde",

--- a/egraph-comparison/Cargo.toml
+++ b/egraph-comparison/Cargo.toml
@@ -15,3 +15,4 @@ egglog-numeric-id.workspace = true
 hashbrown.workspace = true
 rustc-hash.workspace = true
 smallvec.workspace = true
+fixedbitset.workspace = true

--- a/egraph-comparison/README.md
+++ b/egraph-comparison/README.md
@@ -93,3 +93,38 @@ are explicit even for empty tables. Unknown fields, unsupported versions,
 dangling IDs, wrong sorts/arity, duplicate literal identities, and conflicting
 function rows are errors. Producers must canonicalize IDs and rebuild first.
 This format is separate from visualization-oriented `egraph-serialize` JSON.
+
+## Disequality certificates
+
+Pass `--certificate` to include a `certificate` field (`null` for equal
+inputs). Save that field alone to `witness.json` and verify it with:
+
+```sh
+cargo run -p egraph-comparison -- left.json right.json --verify-certificate witness.json
+```
+
+Verification emits `{"valid": true}` or `{"valid": false}` with status 0 or 1.
+Malformed JSON/input still exits 2. The Rust API exposes `certificate` and
+`verify` for the same operations.
+
+* `missing_term`: a constructor term exists on only the indicated side.
+* `unequal_terms`: both terms exist in both inputs, and are equal only on the
+  indicated side.
+* `structure`: a constructor class has a bounded bisimulation observation absent
+  from all constructor classes in the other input. The class ID and refinement
+  round count let the verifier replay that observation using synchronous refinement;
+  comparison worklist steps are not certificate depths. This is needed for
+  ungrounded cycles/holes, which may have no finite ground-term witness.
+* `declaration` / `row`: a schema or table row differs. Row IDs are interpreted
+  in the indicated input and compared modulo the joint full-database partition.
+
+Finite terms use a topologically ordered DAG: each application references earlier
+entries, and the certificate identifies its root(s). This avoids exponential
+expansion and recursive evaluation. Functions never appear in these terms.
+The extractor finds one ground representative per productive class, then checks
+constructor rows against their output representatives in both directions.
+Ground-term verification uses direct constructor lookup, independently of the
+refinement algorithm. Certificates are valid witnesses, not guaranteed minimal.
+Structural and row verification use exact refinement. Certificate generation
+currently repeats comparison/refinement and row-witness search can be quadratic;
+it is opt-in so equality checks do not pay this diagnostic cost.

--- a/egraph-comparison/src/certificate.rs
+++ b/egraph-comparison/src/certificate.rs
@@ -1,0 +1,480 @@
+use crate::ids::{RowId, TermId};
+use crate::{Database, Error, FunctionKind, Row, compare, refine::Partition};
+use egglog_numeric_id::NumericId;
+use fixedbitset::FixedBitSet;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, VecDeque};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Side {
+    Left,
+    Right,
+}
+
+/// A finite term DAG. Children refer to earlier entries in the same vector,
+/// preventing exponential expansion (and recursion on deeply nested terms).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Term {
+    Literal {
+        sort: String,
+        value: String,
+    },
+    Apply {
+        function: String,
+        inputs: Vec<TermId>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Certificate {
+    /// `term` exists in `side`, but has no interpretation in the other input.
+    MissingTerm {
+        side: Side,
+        terms: Vec<Term>,
+        term: TermId,
+    },
+    /// Both terms exist on both sides, but are equal only in `side`.
+    UnequalTerms {
+        side: Side,
+        terms: Vec<Term>,
+        first: TermId,
+        second: TermId,
+    },
+    /// A constructor class's depth-bounded bisimulation observation occurs on
+    /// only one side. This also covers cycles that have no finite ground terms.
+    /// The verifier rebuilds the disjoint union of the two constructor graphs,
+    /// initially groups classes by sort, and computes exactly `rounds` successive
+    /// partitions from node labels and child blocks. It then checks that `class`
+    /// is a constructor root whose block has no constructor root on the other
+    /// side. The certificate stores an input-local class name, not a block ID;
+    /// verification recomputes every block and trusts no serialized partition.
+    Structure {
+        side: Side,
+        class: String,
+        rounds: usize,
+    },
+    /// A declaration is absent or has a different signature/kind.
+    Declaration { function: String },
+    /// This row exists only on `side`, modulo full-database bisimulation.
+    Row { side: Side, row: Row },
+}
+
+fn sides<'a>(side: Side, left: &'a Database, right: &'a Database) -> (&'a Database, &'a Database) {
+    match side {
+        Side::Left => (left, right),
+        Side::Right => (right, left),
+    }
+}
+
+/// Return a certificate for any difference, preferring finite term witnesses.
+/// The fallback is a finite structural observation, never a fabricated ground
+/// term for an ungrounded cycle. Equal databases return `None`.
+#[doc = include_str!("../tests/support/representatives.md")]
+pub fn certificate(left: &Database, right: &Database) -> Result<Option<Certificate>, Error> {
+    let result = compare(left, right)?;
+    if result.database_equal {
+        return Ok(None);
+    }
+    // Prefer an explicit constructor term or equality that a user can inspect.
+    // Search both directions: a term can be absent from either database.
+    if !result.terms_equal {
+        for side in [Side::Left, Side::Right] {
+            let (source, target) = sides(side, left, right);
+            if let Some(witness) = ground_certificate(source, target, side) {
+                return Ok(Some(witness));
+            }
+        }
+    }
+    // A pure cycle or an empty class may have no finite representative. Use a
+    // finite-depth structural observation when ground-term search cannot explain
+    // the constructor mismatch; refinement reaches a fixed point in finite time.
+    let mut partition = Partition::new(left, right);
+    partition.finish();
+    if !result.terms_equal {
+        for (side, source, target) in [
+            (Side::Left, &partition.left, &partition.right),
+            (Side::Right, &partition.right, &partition.left),
+        ] {
+            let other = partition.root_blocks(target);
+            for (class, id) in &source.index {
+                if source.roots.binary_search(id).is_ok()
+                    && !other.contains(&partition.blocks[id.index()])
+                {
+                    return Ok(Some(Certificate::Structure {
+                        side,
+                        class: (*class).to_owned(),
+                        rounds: partition.rounds,
+                    }));
+                }
+            }
+        }
+    }
+    // With constructor behavior matched (or no structural witness found),
+    // declarations and full-database rows account for the remaining differences.
+    for function in left.functions.keys().chain(right.functions.keys()) {
+        if left.functions.get(function) != right.functions.get(function) {
+            return Ok(Some(Certificate::Declaration {
+                function: function.clone(),
+            }));
+        }
+    }
+    let mut partition = Partition::database(left, right);
+    partition.finish();
+    for side in [Side::Left, Side::Right] {
+        let (source, _) = sides(side, left, right);
+        for row in &source.rows {
+            let witness = Certificate::Row {
+                side,
+                row: row.clone(),
+            };
+            if verify_with_partition(&witness, left, right, &partition) {
+                return Ok(Some(witness));
+            }
+        }
+    }
+    Err(Error::MissingWitness)
+}
+
+// Here "productive" means that a class contains a finite ground constructor
+// term (the grammar/inductive sense, not coinductive productivity). Literals and
+// nullary constructors seed the worklist; an application becomes ready once all
+// arguments have representatives. A pure x=f(x) cycle never becomes ready, while
+// a class containing both A() and f(x) gets the representative A(). See the
+// executable example on `certificate` above. Each row becomes ready once;
+// repeated arguments are counted separately so one notification satisfies each
+// occurrence. The result supplies reusable source terms to `ground_certificate`.
+fn representatives(db: &Database) -> (Vec<Term>, BTreeMap<String, TermId>) {
+    let mut terms = Vec::new();
+    let mut reps = BTreeMap::new();
+    let mut ready = VecDeque::new();
+    for (id, class) in &db.classes {
+        if let Some(value) = &class.literal {
+            reps.insert(id.clone(), TermId::from_usize(terms.len()));
+            terms.push(Term::Literal {
+                sort: class.sort.clone(),
+                value: value.clone(),
+            });
+        }
+    }
+    let mut waiting: BTreeMap<&str, Vec<RowId>> = BTreeMap::new();
+    let mut remaining = vec![0; db.rows.len()];
+    for (i, row) in db.rows.iter().enumerate() {
+        if db.functions[&row.function].kind != FunctionKind::Constructor {
+            continue;
+        }
+        for input in &row.inputs {
+            if !reps.contains_key(input) {
+                remaining[i] += 1;
+                waiting.entry(input).or_default().push(RowId::from_usize(i));
+            }
+        }
+        if remaining[i] == 0 {
+            ready.push_back(RowId::from_usize(i));
+        }
+    }
+    while let Some(i) = ready.pop_front() {
+        let row = &db.rows[i.index()];
+        if reps.contains_key(&row.output) {
+            continue;
+        }
+        let term = Term::Apply {
+            function: row.function.clone(),
+            inputs: row.inputs.iter().map(|id| reps[id]).collect(),
+        };
+        reps.insert(row.output.clone(), TermId::from_usize(terms.len()));
+        terms.push(term);
+        if let Some(rows) = waiting.remove(row.output.as_str()) {
+            for i in rows {
+                remaining[i.index()] -= 1;
+                if remaining[i.index()] == 0 {
+                    ready.push_back(i);
+                }
+            }
+        }
+    }
+    (terms, reps)
+}
+
+// Interpret a certificate's finite term DAG in a particular input database.
+// Ground witness extraction uses this to test source representatives in the
+// target; verification evaluates the supplied terms independently in both inputs.
+// Lookup uses only literals and constructors, never ordinary function rows or
+// refinement blocks. A missing argument/application yields no interpretation.
+struct Evaluator<'a> {
+    db: &'a Database,
+    literals: BTreeMap<(&'a str, &'a str), &'a str>,
+    calls: BTreeMap<(&'a str, Vec<&'a str>), &'a str>,
+}
+
+impl<'a> Evaluator<'a> {
+    fn new(db: &'a Database) -> Self {
+        let literals = db
+            .classes
+            .iter()
+            .filter_map(|(id, c)| {
+                c.literal
+                    .as_ref()
+                    .map(|v| ((c.sort.as_str(), v.as_str()), id.as_str()))
+            })
+            .collect();
+        let calls = db
+            .rows
+            .iter()
+            .filter(|r| db.functions[&r.function].kind == FunctionKind::Constructor)
+            .map(|r| {
+                (
+                    (
+                        r.function.as_str(),
+                        r.inputs.iter().map(String::as_str).collect(),
+                    ),
+                    r.output.as_str(),
+                )
+            })
+            .collect();
+        Self {
+            db,
+            literals,
+            calls,
+        }
+    }
+
+    fn term(&self, term: &Term, values: &[Option<&'a str>]) -> Option<&'a str> {
+        match term {
+            Term::Literal { sort, value } => {
+                self.literals.get(&(sort.as_str(), value.as_str())).copied()
+            }
+            Term::Apply { function, inputs } => {
+                let schema = self.db.functions.get(function)?;
+                if schema.kind != FunctionKind::Constructor {
+                    return None;
+                }
+                let args = inputs
+                    .iter()
+                    .map(|&i| values.get(i.index()).copied().flatten())
+                    .collect::<Option<Vec<_>>>()?;
+                self.calls.get(&(function.as_str(), args)).copied()
+            }
+        }
+    }
+
+    fn all(&self, terms: &[Term]) -> Vec<Option<&'a str>> {
+        let mut values = Vec::with_capacity(terms.len());
+        for term in terms {
+            values.push(self.term(term, &values));
+        }
+        values
+    }
+}
+
+fn ground_certificate(source: &Database, target: &Database, side: Side) -> Option<Certificate> {
+    let (mut terms, reps) = representatives(source);
+    let evaluator = Evaluator::new(target);
+    let mut values = evaluator.all(&terms);
+    for row in &source.rows {
+        if source.functions[&row.function].kind != FunctionKind::Constructor {
+            continue;
+        }
+        let Some(inputs) = row
+            .inputs
+            .iter()
+            .map(|id| reps.get(id).copied())
+            .collect::<Option<Vec<_>>>()
+        else {
+            continue;
+        };
+        let term = Term::Apply {
+            function: row.function.clone(),
+            inputs,
+        };
+        let value = evaluator.term(&term, &values);
+        let term_id = TermId::from_usize(terms.len());
+        terms.push(term);
+        values.push(value);
+        let representative = reps[&row.output];
+        if value.is_none() {
+            let (terms, roots) = compact(terms, &[term_id]);
+            return Some(Certificate::MissingTerm {
+                side,
+                terms,
+                term: roots[0],
+            });
+        }
+        if values[representative.index()].is_none() {
+            let (terms, roots) = compact(terms, &[representative]);
+            return Some(Certificate::MissingTerm {
+                side,
+                terms,
+                term: roots[0],
+            });
+        }
+        if value != values[representative.index()] {
+            let (terms, roots) = compact(terms, &[representative, term_id]);
+            return Some(Certificate::UnequalTerms {
+                side,
+                terms,
+                first: roots[0],
+                second: roots[1],
+            });
+        }
+    }
+    None
+}
+
+// Keep only the sub-DAG reachable from the witness roots. Source extraction
+// creates representatives for many unrelated classes; including them would make
+// certificates unnecessarily large. Backward marking works because every child
+// precedes its parent. A forward pass removes unused entries and remaps children
+// and roots to dense TermIds while preserving this topological order.
+fn compact(terms: Vec<Term>, roots: &[TermId]) -> (Vec<Term>, Vec<TermId>) {
+    let mut used = FixedBitSet::with_capacity(terms.len());
+    for &root in roots {
+        used.insert(root.index());
+    }
+    for i in (0..terms.len()).rev() {
+        if used.contains(i)
+            && let Term::Apply { inputs, .. } = &terms[i]
+        {
+            for &child in inputs {
+                used.insert(child.index());
+            }
+        }
+    }
+    let mut mapping = vec![TermId::from_usize(0); terms.len()];
+    let mut result = Vec::new();
+    for (i, mut term) in terms.into_iter().enumerate() {
+        if !used.contains(i) {
+            continue;
+        }
+        if let Term::Apply { inputs, .. } = &mut term {
+            for child in inputs {
+                *child = mapping[child.index()];
+            }
+        }
+        mapping[i] = TermId::from_usize(result.len());
+        result.push(term);
+    }
+    (result, roots.iter().map(|&i| mapping[i.index()]).collect())
+}
+
+/// Verify an untrusted certificate using the inputs. Ground certificates are
+/// checked by ordinary constructor lookup, independently of partition refinement.
+pub fn verify(certificate: &Certificate, left: &Database, right: &Database) -> Result<bool, Error> {
+    left.validate()?;
+    right.validate()?;
+    match certificate {
+        Certificate::MissingTerm { side, terms, term } => {
+            if !valid_dag(terms) {
+                return Ok(false);
+            }
+            let (source, target) = sides(*side, left, right);
+            let a = Evaluator::new(source).all(terms);
+            let b = Evaluator::new(target).all(terms);
+            Ok(matches!(terms.get(term.index()), Some(Term::Apply { .. }))
+                && a.get(term.index()).is_some_and(Option::is_some)
+                && b.get(term.index()) == Some(&None))
+        }
+        Certificate::UnequalTerms {
+            side,
+            terms,
+            first,
+            second,
+        } => {
+            if !valid_dag(terms) {
+                return Ok(false);
+            }
+            let (source, target) = sides(*side, left, right);
+            let a = Evaluator::new(source).all(terms);
+            let b = Evaluator::new(target).all(terms);
+            let ids = (
+                a.get(first.index()),
+                a.get(second.index()),
+                b.get(first.index()),
+                b.get(second.index()),
+            );
+            Ok(
+                matches!(ids, (Some(Some(x)), Some(Some(y)), Some(Some(u)), Some(Some(v))) if x == y && u != v),
+            )
+        }
+        Certificate::Declaration { function } => {
+            Ok(left.functions.get(function) != right.functions.get(function))
+        }
+        _ => {
+            let mut partition = if matches!(certificate, Certificate::Structure { .. }) {
+                Partition::new(left, right)
+            } else {
+                Partition::database(left, right)
+            };
+            if let Certificate::Structure { rounds, .. } = certificate {
+                if *rounds > partition.blocks.len() + 1 {
+                    return Ok(false);
+                }
+                for _ in 0..*rounds {
+                    partition.step();
+                }
+            } else {
+                partition.finish();
+            }
+            Ok(verify_with_partition(certificate, left, right, &partition))
+        }
+    }
+}
+
+// Validate the untrusted DAG's topological-order invariant before evaluation:
+// each child index must be strictly less than its parent's index. This rejects
+// self-cycles, forward/out-of-bounds references, and all longer cycles without
+// recursion. Certificate root bounds are checked separately by `verify`.
+fn valid_dag(terms: &[Term]) -> bool {
+    terms.iter().enumerate().all(|(i, term)| match term {
+        Term::Literal { .. } => true,
+        Term::Apply { inputs, .. } => inputs.iter().all(|&child| child.index() < i),
+    })
+}
+
+fn verify_with_partition(
+    witness: &Certificate,
+    left: &Database,
+    right: &Database,
+    partition: &Partition,
+) -> bool {
+    let (side, row) = match witness {
+        Certificate::Structure { side, class, .. } => {
+            let (source, target) = match side {
+                Side::Left => (&partition.left, &partition.right),
+                Side::Right => (&partition.right, &partition.left),
+            };
+            return source.index.get(class.as_str()).is_some_and(|id| {
+                source.roots.binary_search(id).is_ok()
+                    && !partition
+                        .root_blocks(target)
+                        .contains(&partition.blocks[id.index()])
+            });
+        }
+        Certificate::Row { side, row } => (*side, row),
+        _ => return false,
+    };
+    let (source, target) = sides(side, left, right);
+    if !source.rows.contains(row) {
+        return false;
+    }
+    let (a, b) = match side {
+        Side::Left => (&partition.left, &partition.right),
+        Side::Right => (&partition.right, &partition.left),
+    };
+    !target.rows.iter().any(|other| {
+        row.function == other.function
+            && row.subsumed == other.subsumed
+            && row.inputs.len() == other.inputs.len()
+            && row
+                .inputs
+                .iter()
+                .chain([&row.output])
+                .zip(other.inputs.iter().chain([&other.output]))
+                .all(|(x, y)| {
+                    partition.blocks[a.index[x.as_str()].index()]
+                        == partition.blocks[b.index[y.as_str()].index()]
+                })
+    })
+}

--- a/egraph-comparison/src/ids.rs
+++ b/egraph-comparison/src/ids.rs
@@ -32,5 +32,10 @@ serial_id!(
     usize,
     "Equivalence block in one refinement partition. IDs are local to that partition and round, not stable e-class identities."
 );
+serial_id!(
+    TermId,
+    usize,
+    "Index of a term in a certificate's DAG. Application children must refer to earlier entries in that same DAG."
+);
 define_id!(pub RowId, usize, "Index in one input database's rows, used by the representative worklist.");
 define_id!(pub(crate) SymbolId, usize, "Interned complete node label, shared by both inputs during joint refinement.");

--- a/egraph-comparison/src/lib.rs
+++ b/egraph-comparison/src/lib.rs
@@ -1,10 +1,12 @@
 //! Compare complete serialized databases by conservative partition refinement.
+mod certificate;
 mod hopcroft;
 mod ids;
 mod model;
 mod refine;
 mod signatures;
-pub use ids::{FormatVersion, RowId};
+pub use certificate::{Certificate, Side, Term, certificate, verify};
+pub use ids::{FormatVersion, RowId, TermId};
 pub use model::{Class, Database, Error, Function, FunctionKind, Row};
 pub use refine::{Comparison, compare};
 pub(crate) type HashMap<K, V> =

--- a/egraph-comparison/src/main.rs
+++ b/egraph-comparison/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use egraph_comparison::{Database, compare};
-use std::{path::PathBuf, process::ExitCode};
+use egraph_comparison::{Certificate, Database, certificate, compare, verify};
+use std::{fs::File, io::BufReader, path::PathBuf, process::ExitCode};
 
 #[derive(Parser)]
 #[command(about = "Compare two serialized e-graphs modulo constructor bisimulation")]
@@ -13,6 +13,12 @@ struct Args {
     /// See egraph-comparison/README.md, Semantics, for the bisimulation definition.
     #[arg(long)]
     terms_only: bool,
+    /// Include a verifiable explanation of disequality in the JSON result.
+    #[arg(long, conflicts_with = "verify_certificate")]
+    certificate: bool,
+    /// Verify a certificate JSON file (0 = valid, 1 = invalid, 2 = input error).
+    #[arg(long)]
+    verify_certificate: Option<PathBuf>,
 }
 
 fn run(args: &Args) -> Result<bool, Box<dyn std::error::Error>> {
@@ -21,8 +27,23 @@ fn run(args: &Args) -> Result<bool, Box<dyn std::error::Error>> {
         let bytes = std::fs::read(path)?;
         Ok(serde_json::from_slice(&bytes)?)
     };
-    let result = compare(&read(&args.left)?, &read(&args.right)?)?;
-    serde_json::to_writer_pretty(std::io::stdout().lock(), &result)?;
+    let left = read(&args.left)?;
+    let right = read(&args.right)?;
+    if let Some(path) = &args.verify_certificate {
+        let witness: Certificate = serde_json::from_reader(BufReader::new(File::open(path)?))?;
+        let valid = verify(&witness, &left, &right)?;
+        serde_json::to_writer_pretty(
+            std::io::stdout().lock(),
+            &serde_json::json!({"valid": valid}),
+        )?;
+        return Ok(valid);
+    }
+    let result = compare(&left, &right)?;
+    let mut output = serde_json::to_value(&result)?;
+    if args.certificate {
+        output["certificate"] = serde_json::to_value(certificate(&left, &right)?)?;
+    }
+    serde_json::to_writer_pretty(std::io::stdout().lock(), &output)?;
     Ok(if args.terms_only {
         result.terms_equal
     } else {

--- a/egraph-comparison/src/refine.rs
+++ b/egraph-comparison/src/refine.rs
@@ -3,6 +3,7 @@ use crate::{Database, Error, Function, FunctionKind, HashMap};
 use egglog_numeric_id::NumericId;
 use serde::Serialize;
 use smallvec::SmallVec;
+use std::collections::BTreeSet;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Comparison {
@@ -40,6 +41,7 @@ pub(crate) struct Graph<'a> {
     pub nodes: Vec<Vec<Node>>,
     /// Sorted, unique output IDs. Mark once per row instead of tree insertion.
     pub roots: Vec<ClassId>,
+    pub index: HashMap<&'a str, ClassId>,
 }
 
 impl<'a> Graph<'a> {
@@ -98,6 +100,7 @@ impl<'a> Graph<'a> {
                 .enumerate()
                 .filter_map(|(i, root)| root.then_some(ClassId::from_usize(i + offset)))
                 .collect(),
+            index,
         }
     }
 }
@@ -106,7 +109,6 @@ pub(crate) struct Partition<'a> {
     pub left: Graph<'a>,
     pub right: Graph<'a>,
     pub blocks: Vec<BlockId>,
-    #[cfg(test)]
     pub rounds: usize,
 }
 
@@ -137,7 +139,6 @@ impl<'a> Partition<'a> {
             left,
             right,
             blocks,
-            #[cfg(test)]
             rounds: 0,
         }
     }
@@ -169,9 +170,7 @@ impl<'a> Partition<'a> {
         signatures.intern(self.blocks[id.index()], nodes)
     }
 
-    // The synchronous reference also supplies depth-bounded certificate replay
-    // in the subsequent certificate layer. Worklist steps are not term depths.
-    #[cfg(test)]
+    // Certificates use synchronous depth, independently of comparison worklist steps.
     pub fn step(&mut self) -> bool {
         let mut signatures = crate::signatures::Signatures::default();
         let mut nodes = Vec::new();
@@ -184,9 +183,16 @@ impl<'a> Partition<'a> {
         changed
     }
 
-    #[cfg(test)]
     pub fn finish(&mut self) {
         while self.step() {}
+    }
+
+    pub fn root_blocks(&self, graph: &Graph<'_>) -> BTreeSet<BlockId> {
+        graph
+            .roots
+            .iter()
+            .map(|&id| self.blocks[id.index()])
+            .collect()
     }
 
     pub fn terms_equal(&self) -> bool {

--- a/egraph-comparison/tests/certificates.rs
+++ b/egraph-comparison/tests/certificates.rs
@@ -1,0 +1,214 @@
+use egraph_comparison::{
+    Certificate, Class, Database, Function, FunctionKind, Row, Side, Term, certificate, verify,
+};
+
+fn graph(rows: &[(&str, &[&str], &str)]) -> Database {
+    let mut db = Database::default();
+    for &(op, inputs, output) in rows {
+        for id in inputs.iter().copied().chain([output]) {
+            db.classes.insert(
+                id.into(),
+                Class {
+                    sort: "E".into(),
+                    literal: None,
+                },
+            );
+        }
+        db.functions.insert(
+            op.into(),
+            Function {
+                kind: FunctionKind::Constructor,
+                inputs: vec!["E".into(); inputs.len()],
+                output: "E".into(),
+            },
+        );
+        db.rows.push(Row {
+            function: op.into(),
+            inputs: inputs.iter().map(|s| (*s).into()).collect(),
+            output: output.into(),
+            subsumed: false,
+        });
+    }
+    db
+}
+
+fn witness(left: &Database, right: &Database) -> Certificate {
+    let cert = certificate(left, right).unwrap().unwrap();
+    assert!(verify(&cert, left, right).unwrap());
+    let json = serde_json::to_string(&cert).unwrap();
+    let cert: Certificate = serde_json::from_str(&json).unwrap();
+    assert!(verify(&cert, left, right).unwrap());
+    assert!(!verify(&cert, left, left).unwrap());
+    cert
+}
+
+#[test]
+fn missing_terms_in_either_direction() {
+    let left = graph(&[("a", &[], "x"), ("f", &["x"], "y")]);
+    let right = graph(&[("a", &[], "renamed")]);
+    assert!(matches!(
+        witness(&left, &right),
+        Certificate::MissingTerm {
+            side: Side::Left,
+            ..
+        }
+    ));
+    assert!(matches!(
+        witness(&right, &left),
+        Certificate::MissingTerm {
+            side: Side::Right,
+            ..
+        }
+    ));
+    assert!(certificate(&left, &left).unwrap().is_none());
+}
+
+#[test]
+fn equality_witnesses_in_both_directions() {
+    let left = graph(&[("a", &[], "x"), ("b", &[], "x"), ("f", &["x"], "y")]);
+    let right = graph(&[
+        ("a", &[], "x"),
+        ("b", &[], "z"),
+        ("f", &["x"], "y"),
+        ("f", &["z"], "y"),
+    ]);
+    assert!(matches!(
+        witness(&left, &right),
+        Certificate::UnequalTerms { .. }
+    ));
+    assert!(matches!(
+        witness(&right, &left),
+        Certificate::UnequalTerms { .. }
+    ));
+}
+
+#[test]
+fn productive_cycles_have_finite_witnesses() {
+    let left = graph(&[("a", &[], "x"), ("f", &["x"], "x")]);
+    let right = graph(&[("a", &[], "x"), ("f", &["x"], "y")]);
+    assert!(matches!(
+        witness(&left, &right),
+        Certificate::UnequalTerms { .. }
+    ));
+}
+
+#[test]
+fn pure_cycles_and_holes_have_structural_certificates() {
+    let left = graph(&[("f", &["x"], "x")]);
+    let right = graph(&[("g", &["x"], "x")]);
+    assert!(matches!(
+        witness(&left, &right),
+        Certificate::Structure { .. }
+    ));
+    let right = graph(&[("f", &["hole"], "x")]);
+    assert!(matches!(
+        witness(&left, &right),
+        Certificate::Structure { .. }
+    ));
+}
+
+#[test]
+fn declarations_rows_and_subsumption_have_certificates() {
+    let left = graph(&[("a", &[], "x")]);
+    let mut right = left.clone();
+    right.functions.insert(
+        "empty".into(),
+        Function {
+            kind: FunctionKind::Function,
+            inputs: vec![],
+            output: "E".into(),
+        },
+    );
+    assert!(matches!(
+        witness(&left, &right),
+        Certificate::Declaration { .. }
+    ));
+    let mut left = right.clone();
+    left.rows.push(Row {
+        function: "empty".into(),
+        inputs: vec![],
+        output: "x".into(),
+        subsumed: false,
+    });
+    assert!(matches!(witness(&left, &right), Certificate::Row { .. }));
+    let mut right = left.clone();
+    right.rows[0].subsumed = true;
+    assert!(matches!(witness(&left, &right), Certificate::Row { .. }));
+}
+
+#[test]
+fn rejects_invalid_dags_roots_and_structural_claims() {
+    let left = graph(&[("a", &[], "x")]);
+    let right = Database::default();
+    for terms in [
+        vec![Term::Apply {
+            function: "f".into(),
+            inputs: vec![egraph_comparison::TermId::new_const(0)],
+        }],
+        vec![Term::Apply {
+            function: "a".into(),
+            inputs: vec![],
+        }],
+    ] {
+        let cert = Certificate::MissingTerm {
+            side: Side::Left,
+            terms,
+            term: egraph_comparison::TermId::new_const(99),
+        };
+        assert!(!verify(&cert, &left, &right).unwrap());
+    }
+    for class in ["x", "unknown"] {
+        let cert = Certificate::Structure {
+            side: Side::Left,
+            class: class.into(),
+            rounds: usize::MAX,
+        };
+        assert!(!verify(&cert, &left, &right).unwrap());
+    }
+    let mut db = graph(&[("a", &[], "x")]);
+    db.functions.get_mut("a").unwrap().kind = FunctionKind::Function;
+    let cert = Certificate::MissingTerm {
+        side: Side::Left,
+        terms: vec![Term::Apply {
+            function: "a".into(),
+            inputs: vec![],
+        }],
+        term: egraph_comparison::TermId::new_const(0),
+    };
+    assert!(!verify(&cert, &db, &right).unwrap());
+}
+
+#[test]
+fn shared_subterms_stay_linear_in_certificate_size() {
+    let mut left = graph(&[("a", &[], "0")]);
+    left.functions.insert(
+        "pair".into(),
+        Function {
+            kind: FunctionKind::Constructor,
+            inputs: vec!["E".into(); 2],
+            output: "E".into(),
+        },
+    );
+    for i in 1..60 {
+        left.classes.insert(
+            i.to_string(),
+            Class {
+                sort: "E".into(),
+                literal: None,
+            },
+        );
+        left.rows.push(Row {
+            function: "pair".into(),
+            inputs: vec![(i - 1).to_string(); 2],
+            output: i.to_string(),
+            subsumed: false,
+        });
+    }
+    let mut right = left.clone();
+    right.rows.pop();
+    let cert = witness(&left, &right);
+    let Certificate::MissingTerm { terms, .. } = cert else {
+        panic!("expected a finite term");
+    };
+    assert_eq!(terms.len(), 60); // Expanded tree would contain 2^60 - 1 nodes.
+}

--- a/egraph-comparison/tests/cli.rs
+++ b/egraph-comparison/tests/cli.rs
@@ -28,6 +28,26 @@ fn exit_status_and_json_output() {
     assert_eq!(json["database_equal"], true);
     assert_eq!(run(&empty, &different, false).status.code(), Some(1));
     assert!(run(&empty, &different, true).status.success());
+    let output = Command::new(env!("CARGO_BIN_EXE_egraph-comparison"))
+        .args([&empty, &different])
+        .arg("--certificate")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let witness = dir.join("witness.json");
+    fs::write(&witness, serde_json::to_vec(&json["certificate"]).unwrap()).unwrap();
+    let verify = |right: &std::path::Path| {
+        Command::new(env!("CARGO_BIN_EXE_egraph-comparison"))
+            .arg(&empty)
+            .arg(right)
+            .arg("--verify-certificate")
+            .arg(&witness)
+            .output()
+            .unwrap()
+    };
+    assert!(verify(&different).status.success());
+    assert_eq!(verify(&empty).status.code(), Some(1));
     assert_eq!(run(&empty, &invalid, false).status.code(), Some(2));
     assert_eq!(
         run(&empty, &dir.join("missing"), false).status.code(),

--- a/egraph-comparison/tests/comparison.rs
+++ b/egraph-comparison/tests/comparison.rs
@@ -250,6 +250,10 @@ fn agrees_with_relation_oracle_on_small_cyclic_graphs() {
             "seed {seed}"
         );
         assert!(compare(&left, &left).unwrap().database_equal);
+        if let Some(cert) = egraph_comparison::certificate(&left, &right).unwrap() {
+            assert!(egraph_comparison::verify(&cert, &left, &right).unwrap());
+            assert!(!egraph_comparison::verify(&cert, &left, &left).unwrap());
+        }
         // An unused ordinary declaration forces the full-database path without
         // changing either graph's observations. Check the reuse optimization
         // against that path on every generated cyclic pair.
@@ -281,6 +285,10 @@ fn agrees_with_relation_oracle_on_small_cyclic_graphs() {
             oracle(&left, &right),
             "function seed {seed}"
         );
+        if let Some(cert) = egraph_comparison::certificate(&left, &right).unwrap() {
+            assert!(egraph_comparison::verify(&cert, &left, &right).unwrap());
+            assert!(!egraph_comparison::verify(&cert, &left, &left).unwrap());
+        }
     }
 }
 

--- a/egraph-comparison/tests/performance.rs
+++ b/egraph-comparison/tests/performance.rs
@@ -1,4 +1,6 @@
-use egraph_comparison::{Class, Database, Function, FunctionKind, Row, compare};
+use egraph_comparison::{
+    Class, Database, Function, FunctionKind, Row, certificate, compare, verify,
+};
 
 fn wide() -> Database {
     let mut db = Database::default();
@@ -36,11 +38,14 @@ fn wide() -> Database {
 }
 
 #[test]
-fn spilled_signatures_preserve_argument_order() {
+fn spilled_signatures_preserve_argument_order_and_certificates() {
     let left = wide();
     let mut right = left.clone();
     right.rows[0].inputs.swap(6, 7);
     assert!(!compare(&left, &right).unwrap().terms_equal);
+    let witness = certificate(&left, &right).unwrap().unwrap();
+    assert!(verify(&witness, &left, &right).unwrap());
+    assert!(!verify(&witness, &left, &left).unwrap());
 }
 
 #[test]

--- a/egraph-comparison/tests/support/representatives.md
+++ b/egraph-comparison/tests/support/representatives.md
@@ -1,0 +1,26 @@
+
+A class is productive here when it contains a **finite ground constructor term**.
+For example, `x = f(x)` has no such representative; adding `A()` to `x` supplies
+one. This example uses the JSON input API so it also works without egglog:
+
+```
+use egraph_comparison::{Database, Certificate, certificate, verify};
+let cyclic: Database = serde_json::from_value(serde_json::json!({
+    "version": 1,
+    "classes": {"x": {"sort": "E"}},
+    "functions": {
+        "A": {"kind": "constructor", "inputs": [], "output": "E"},
+        "f": {"kind": "constructor", "inputs": ["E"], "output": "E"}
+    },
+    "rows": [{"function": "f", "inputs": ["x"], "output": "x"}]
+}))?;
+let mut grounded = cyclic.clone();
+grounded.rows.push(egraph_comparison::Row {
+    function: "A".into(), inputs: vec![], output: "x".into(), subsumed: false,
+});
+let witness = certificate(&grounded, &cyclic)?.unwrap();
+assert!(matches!(witness, Certificate::MissingTerm { .. }));
+assert!(verify(&witness, &grounded, &cyclic)?);
+assert!(certificate(&cyclic, &cyclic)?.is_none());
+# Ok::<(), Box<dyn std::error::Error>>(())
+```


### PR DESCRIPTION
*From Codex:*

Extract and verify missing-constructor-term, unequal-term, structural, declaration, and full-database row certificates. Term references use typed IDs in a topologically ordered DAG; `FixedBitSet` compaction keeps only the witness sub-DAG. Full-function certificate handling is included here rather than deferred to #1014.

Document the extraction pipeline, finite-ground productivity, independent evaluator, structural replay, compaction, and DAG validation. An included doctest contrasts an ungrounded cycle with one containing a finite constructor representative.

Validation: certificate extraction/verification, malformed DAGs, shared subterms, cycles, CLI verification, and the doctest pass at this layer; Clippy passes.

This layer follows the comparison optimizations. Structural certificates retain synchronous refinement and depth-based replay; comparison worklist step counts are not certificate depths.

Part of the actual `gh stack` #1023. Non-test diff: 573 added/deleted lines; tests are in separate files.
