### PR TITLE
Export complete egglog databases for semantic comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "egglog-core-relations",
  "egglog-numeric-id",
  "egglog-reports",
+ "egraph-comparison",
  "egraph-serialize",
  "enum-map",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ required-features = ["bin"]
 default = ["bin"]
 
 bin = [
+  "comparison",
   "serde",
   "graphviz",
   "dep:clap",
@@ -130,9 +131,11 @@ bin = [
   "dep:mimalloc",
 ]
 serde = ["egraph-serialize/serde"]
+comparison = ["dep:egraph-comparison"]
 graphviz = ["egraph-serialize/graphviz"]
 
 [dependencies]
+egraph-comparison = { path = "egraph-comparison", version = "3.0.0", optional = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 egraph-serialize = { workspace = true}
 env_logger = { workspace = true, optional = true }

--- a/egraph-comparison/README.md
+++ b/egraph-comparison/README.md
@@ -128,3 +128,55 @@ refinement algorithm. Certificates are valid witnesses, not guaranteed minimal.
 Structural and row verification use exact refinement. Certificate generation
 currently repeats comparison/refinement and row-witness search can be quadratic;
 it is opt-in so equality checks do not pay this diagnostic cost.
+
+For a concrete example, save these as `left.egg` and `right.egg`:
+
+```lisp
+; left.egg
+(datatype Expr (Num i64))
+(Num 1)
+```
+
+```lisp
+; right.egg
+(datatype Expr (Num i64))
+(Num 2)
+```
+
+Export both using `egglog --to-comparison-json`, then compare their JSON files
+with `--certificate`. The certificate field is:
+
+```json
+{"kind":"missing_term","side":"left","terms":[{"kind":"literal","sort":"i64","value":"1"},{"kind":"apply","function":"Num","inputs":[0]}],"term":1}
+```
+
+Entry 0 is the literal `1`; entry 1 builds `Num(1)` from it. Root 1 exists in the
+left database and has no interpretation in the right. Certificate term IDs are
+local indices in this topologically ordered DAG, so the same literal need only
+be stored once even if many applications use it.
+
+## Exporting egglog databases
+
+```sh
+cargo run -p egglog -- --to-comparison-json before.egg
+cargo run -p egglog -- --to-comparison-json after.egg
+cargo run -p egraph-comparison -- before.comparison.json after.comparison.json --certificate
+```
+
+`EGraph::serialize_for_comparison` is available with egglog's `comparison`
+feature (included by the default `bin` feature). It rebuilds before exporting
+all visible user tables, empty declarations, and subsumed rows. Relations are
+ordinary database tables. Global bindings and hidden helper tables are excluded.
+Visualization limits, splitting, and inlining do not affect this export.
+
+The initial exporter handles equality sorts and the built-in scalar types,
+including normalized floating-point zeros/NaNs. It rejects encountered container
+and custom base values, and rejects term/proof encoding. These cases require
+explicit value semantics or a projection to user-visible tables; treating their
+raw IDs or debug strings as values would give misleading equality results.
+
+
+Container support needs variable-arity observations with element sorts and
+container kind in the label. Ordered sequences, unordered sets, multiplicities,
+and map key/value pairing must be preserved when comparing child blocks. The
+current fixed-arity ordered `Function` schema cannot express all these cases.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,9 @@ struct Args {
     /// Serializes the egraph for each egglog file as JSON
     #[clap(long)]
     to_json: bool,
+    /// Write a complete database for egraph-comparison to INPUT.comparison.json
+    #[clap(long)]
+    to_comparison_json: bool,
     /// Serializes the egraph for each egglog file as a dot file
     #[clap(long)]
     to_dot: bool,
@@ -141,6 +144,22 @@ pub fn cli(mut egraph: EGraph) {
             ) {
                 Ok(None) => {}
                 _ => std::process::exit(1),
+            }
+
+            if args.to_comparison_json {
+                let path = input.with_extension("comparison.json");
+                let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+                    let database = egraph.serialize_for_comparison()?;
+                    let file = std::fs::File::create(&path)?;
+                    let mut writer = std::io::BufWriter::new(file);
+                    serde_json::to_writer_pretty(&mut writer, &database)?;
+                    writer.flush()?;
+                    Ok(())
+                })();
+                if let Err(error) = result {
+                    log::error!("Failed to export comparison database to {path:?}: {error}");
+                    std::process::exit(1);
+                }
             }
 
             if args.to_json || args.to_dot || args.to_svg {

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -1,0 +1,192 @@
+use crate::{core_relations::BaseValuePrinter, *};
+use egraph_comparison::{Class, Database, FunctionKind, Row};
+use std::any::TypeId;
+
+/// Errors exporting an egglog database for semantic comparison.
+#[derive(Debug, thiserror::Error)]
+pub enum ComparisonExportError {
+    #[error("comparison export does not yet project term/proof encoding to user tables")]
+    EncodedDatabase,
+    #[error("comparison export does not support sort {sort} yet")]
+    UnsupportedSort { sort: String },
+    #[error("cannot rebuild database for comparison: {0}")]
+    Rebuild(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error(transparent)]
+    InvalidDatabase(#[from] egraph_comparison::Error),
+}
+
+impl EGraph {
+    /// Export a complete database for `egraph-comparison`, rebuilding first.
+    ///
+    /// Includes every visible constructor/function/relation, including empty
+    /// tables and subsumed rows. Global bindings and hidden implementation tables
+    /// are excluded. Costs and extraction preferences are not database contents.
+    /// The initial exporter supports equality sorts and built-in scalar sorts.
+    /// Unsupported containers/custom base types and term/proof encoding return
+    /// an error, never a silently incomplete comparison database.
+    #[cfg_attr(docsrs, doc(cfg(feature = "comparison")))]
+    pub fn serialize_for_comparison(&mut self) -> Result<Database, ComparisonExportError> {
+        if self.proof_state.original_typechecking.is_some() {
+            return Err(ComparisonExportError::EncodedDatabase);
+        }
+        self.backend.flush_updates_no_rebuild();
+        self.backend
+            .rebuild_now()
+            .map_err(|error| ComparisonExportError::Rebuild(error.into()))?;
+        let mut database = Database::default();
+        for (name, function) in &self.functions {
+            if function.is_hidden() || function.is_let_binding() {
+                continue;
+            }
+            let signature = function.func_type();
+            // Relations use constructor tables internally, with a generated
+            // non-unionable output sort. They do not build e-graph terms.
+            let kind = if signature.subtype == FunctionSubtype::Constructor
+                && !self.comparison_relation_sort(&signature.output)
+            {
+                FunctionKind::Constructor
+            } else {
+                FunctionKind::Function
+            };
+            database.functions.insert(
+                name.clone(),
+                egraph_comparison::Function {
+                    kind,
+                    inputs: signature
+                        .input
+                        .iter()
+                        .map(|s| self.comparison_sort_name(s))
+                        .collect(),
+                    output: self.comparison_sort_name(&signature.output),
+                },
+            );
+            let mut error = None;
+            self.backend.for_each_while(function.backend_id, |row| {
+                let result = (|| {
+                    let (output, inputs) = row.vals.split_last().unwrap();
+                    let inputs = inputs
+                        .iter()
+                        .zip(&signature.input)
+                        .map(|(&value, sort)| self.comparison_value(&mut database, sort, value))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    let output =
+                        self.comparison_value(&mut database, &signature.output, *output)?;
+                    database.rows.push(Row {
+                        function: name.clone(),
+                        inputs,
+                        output,
+                        subsumed: row.subsumed,
+                    });
+                    Ok::<_, ComparisonExportError>(())
+                })();
+                match result {
+                    Ok(()) => true,
+                    Err(e) => {
+                        error = Some(e);
+                        false
+                    }
+                }
+            });
+            if let Some(error) = error {
+                return Err(error);
+            }
+        }
+        database.validate()?;
+        Ok(database)
+    }
+
+    fn comparison_value(
+        &self,
+        database: &mut Database,
+        sort: &ArcSort,
+        value: Value,
+    ) -> Result<String, ComparisonExportError> {
+        let id = self.value_to_class_id(sort, value).to_string();
+        if database.classes.contains_key(&id) {
+            return Ok(id);
+        }
+        let literal = if sort.is_eq_sort() {
+            None
+        } else {
+            let ty = sort.value_type();
+            let supported = [
+                TypeId::of::<i64>(),
+                TypeId::of::<bool>(),
+                TypeId::of::<()>(),
+                TypeId::of::<S>(),
+                TypeId::of::<F>(),
+                TypeId::of::<Z>(),
+                TypeId::of::<Q>(),
+            ];
+            if sort.is_container_sort() || !ty.is_some_and(|ty| supported.contains(&ty)) {
+                return Err(ComparisonExportError::UnsupportedSort {
+                    sort: sort.name().to_owned(),
+                });
+            }
+            let value = if ty == Some(TypeId::of::<F>()) {
+                let float = self.value_to_base::<F>(value).0.0;
+                // OrderedFloat equates both zeros and all NaNs. The interned
+                // representative may otherwise depend on insertion order.
+                if float == 0.0 {
+                    "0.0".into()
+                } else if float.is_nan() {
+                    "NaN".into()
+                } else {
+                    format!("{float:?}")
+                }
+            } else {
+                format!(
+                    "{:?}",
+                    BaseValuePrinter {
+                        base: self.backend.base_values(),
+                        ty: self.backend.base_values().get_ty_by_id(ty.unwrap()),
+                        val: value
+                    }
+                )
+            };
+            Some(value)
+        };
+        database.classes.insert(
+            id.clone(),
+            Class {
+                sort: self.comparison_sort_name(sort),
+                literal,
+            },
+        );
+        Ok(id)
+    }
+
+    fn comparison_relation_sort(&self, sort: &ArcSort) -> bool {
+        // Normal desugaring creates reserved, non-unionable relation sorts.
+        // User-declared :no-union sorts still have ordinary constructors.
+        !self.type_info.is_sort_unionable(sort)
+            && sort.is_eq_sort()
+            && sort.name().starts_with(util::INTERNAL_SYMBOL_PREFIX)
+    }
+
+    fn comparison_sort_name(&self, sort: &ArcSort) -> String {
+        if self.comparison_relation_sort(sort) {
+            // Generated names can depend on declaration order (notably when
+            // relation names differ only by dashes). Use their table names.
+            let mut names: Vec<_> = self
+                .functions
+                .values()
+                .filter(|f| {
+                    !f.is_hidden()
+                        && !f.is_let_binding()
+                        && f.func_type().subtype == FunctionSubtype::Constructor
+                        && f.func_type().output.name() == sort.name()
+                })
+                .map(Function::name)
+                .collect();
+            names.sort_unstable();
+            format!(
+                "{}relation:{}",
+                util::INTERNAL_SYMBOL_PREFIX,
+                serde_json::to_string(&names).unwrap()
+            )
+        } else {
+            sort.name().to_owned()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,10 @@ pub mod extract;
 pub mod prelude;
 mod proofs;
 
+#[cfg(feature = "comparison")]
+mod comparison;
+#[cfg(feature = "comparison")]
+pub use comparison::ComparisonExportError;
 pub mod scheduler;
 mod serialize;
 pub mod sort;

--- a/tests/comparison_export.rs
+++ b/tests/comparison_export.rs
@@ -1,0 +1,173 @@
+#![cfg(feature = "comparison")]
+use egglog::EGraph;
+use egraph_comparison::{Certificate, Database, FunctionKind, certificate, compare, verify};
+
+fn export(program: &str) -> Database {
+    let mut graph = EGraph::default();
+    graph.parse_and_run_program(None, program).unwrap();
+    graph.serialize_for_comparison().unwrap()
+}
+
+#[test]
+fn exports_constructor_function_relation_and_empty_declarations() {
+    let db = export(
+        r#"
+        (datatype E (A) (B) (F E))
+        (function cost (E) i64 :merge (max old new))
+        (relation seen (E))
+        (A)
+        (set (cost (A)) 7)
+        (seen (A))
+        (let $global (A))
+    "#,
+    );
+    assert_eq!(db.functions["A"].kind, FunctionKind::Constructor);
+    assert_eq!(db.functions["cost"].kind, FunctionKind::Function);
+    assert_eq!(db.functions["seen"].kind, FunctionKind::Function);
+    assert!(db.functions.contains_key("B"));
+    assert!(!db.functions.contains_key("$global"));
+    assert_eq!(db.functions.len(), 5);
+    assert!(db.rows.iter().any(|row| row.function == "cost"));
+    assert!(db.rows.iter().any(|row| row.function == "seen"));
+    let decoded = serde_json::from_str(&serde_json::to_string(&db).unwrap()).unwrap();
+    assert!(compare(&db, &decoded).unwrap().database_equal);
+}
+
+#[test]
+fn compares_reordered_insertions_and_union_representatives() {
+    let header = "(datatype E (A) (B) (F E))";
+    let left = export(&format!("{header} (F (A)) (B) (union (A) (B))"));
+    let right = export(&format!("{header} (B) (F (B)) (A) (union (B) (A))"));
+    assert!(compare(&left, &right).unwrap().database_equal);
+}
+
+#[test]
+fn compares_real_cyclic_egraphs() {
+    let header = "(datatype E (Placeholder) (X E))";
+    let cycle = "(let $c (X (Placeholder))) (union (Placeholder) $c) (delete (Placeholder))";
+    let left = export(&format!("{header} {cycle}"));
+    let second = cycle.replace("$c", "$d");
+    let right = export(&format!("{header} {cycle} {second}"));
+    assert!(compare(&left, &right).unwrap().database_equal);
+}
+
+#[test]
+fn term_witnesses_and_function_only_differences() {
+    let header = "(datatype E (A) (B)) (function cost (E) i64 :merge (max old new))";
+    let left = export(&format!("{header} (set (cost (A)) 1)"));
+    let right = export(&format!("{header} (set (cost (A)) 2)"));
+    let result = compare(&left, &right).unwrap();
+    assert!(result.terms_equal);
+    assert!(!result.database_equal);
+    let witness = certificate(&left, &right).unwrap().unwrap();
+    assert!(matches!(witness, Certificate::Row { .. }));
+    assert!(verify(&witness, &left, &right).unwrap());
+    let right = export(&format!("{header} (set (cost (A)) 1) (B)"));
+    assert!(matches!(
+        certificate(&left, &right).unwrap().unwrap(),
+        Certificate::MissingTerm { .. }
+    ));
+}
+
+#[test]
+fn subsumed_rows_remain_in_the_export() {
+    let left = export("(datatype E (A) (B)) (A) (B)");
+    let right = export("(datatype E (A) (B)) (A) (B) (subsume (A))");
+    assert!(right.rows.iter().any(|r| r.function == "A" && r.subsumed));
+    let result = compare(&left, &right).unwrap();
+    assert!(result.terms_equal);
+    assert!(!result.database_equal);
+}
+
+#[test]
+fn scalar_values_are_exact_and_zeros_are_normalized() {
+    let header = "(datatype E (Float f64) (Str String) (Int i64))";
+    let left = export(&format!(
+        r#"{header} (Float -0.0) (Str "a\n\"b") (Int 9223372036854775807)"#
+    ));
+    let right = export(&format!(
+        r#"{header} (Int 9223372036854775807) (Str "a\n\"b") (Float 0.0)"#
+    ));
+    assert!(compare(&left, &right).unwrap().database_equal);
+    let right = export(&format!(
+        r#"{header} (Int 9223372036854775806) (Str "a\n\"b") (Float 0.0)"#
+    ));
+    assert!(!compare(&left, &right).unwrap().terms_equal);
+}
+
+#[test]
+fn unsupported_exports_fail_instead_of_truncating() {
+    let mut graph = EGraph::default();
+    graph
+        .parse_and_run_program(
+            None,
+            "(sort V (Vec i64)) (datatype E (C V)) (C (vec-of 1 2))",
+        )
+        .unwrap();
+    assert!(matches!(graph.serialize_for_comparison(),
+        Err(egglog::ComparisonExportError::UnsupportedSort { sort }) if sort == "V"));
+    let mut graph = EGraph::new_with_term_encoding();
+    graph
+        .parse_and_run_program(None, "(datatype E (A)) (A)")
+        .unwrap();
+    assert!(matches!(
+        graph.serialize_for_comparison(),
+        Err(egglog::ComparisonExportError::EncodedDatabase)
+    ));
+}
+
+#[cfg(feature = "bin")]
+#[test]
+fn cli_exports_complete_database_even_with_visualization_limits() {
+    use std::{fs, process::Command};
+    let dir = std::env::temp_dir().join(format!("egglog-comparison-export-{}", std::process::id()));
+    fs::create_dir_all(&dir).unwrap();
+    let input = dir.join("input.egg");
+    fs::write(&input, "(datatype E (A) (B)) (A) (B)").unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_egglog"))
+        .args([
+            "--to-comparison-json",
+            "--max-functions",
+            "0",
+            "--max-calls-per-function",
+            "0",
+        ])
+        .arg(&input)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let db: Database =
+        serde_json::from_slice(&fs::read(input.with_extension("comparison.json")).unwrap())
+            .unwrap();
+    assert_eq!(db.rows.len(), 2);
+    fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
+fn relation_names_are_independent_of_desugaring_order() {
+    let left = export("(relation a-b (i64)) (relation ab (i64)) (a-b 1) (ab 2)");
+    let right = export("(relation ab (i64)) (relation a-b (i64)) (ab 2) (a-b 1)");
+    assert!(compare(&left, &right).unwrap().database_equal);
+    let missing = export("(relation a-b (i64)) (relation ab (i64)) (a-b 1)");
+    assert!(compare(&left, &missing).unwrap().terms_equal);
+    assert!(!compare(&left, &missing).unwrap().database_equal);
+}
+
+#[test]
+fn user_nonunionable_constructors_still_build_terms() {
+    let mut graph = EGraph::default();
+    let mut program = graph
+        .parse_program(None, "(sort E) (constructor A () E) (A)")
+        .unwrap();
+    let egglog::ast::Command::Sort { unionable, .. } = &mut program[0] else {
+        unreachable!()
+    };
+    *unionable = false;
+    graph.run_program(program).unwrap();
+    let db = graph.serialize_for_comparison().unwrap();
+    assert_eq!(db.functions["A"].kind, FunctionKind::Constructor);
+}


### PR DESCRIPTION
*From Codex:*

Add `EGraph::serialize_for_comparison` and `--to-comparison-json`, exporting complete visible constructor/function/relation tables after rebuild. Structured `ComparisonExportError` variants distinguish unsupported values/projections, rebuild failures, and invalid exported databases.

Support equality sorts and built-in scalars; unsupported containers/custom base values and term/proof projections fail explicitly. Document the variable-arity observation design needed for containers, and show two egglog programs with their actual missing-term certificate.

Validation: all 10 exporter tests pass. The README certificate was checked against real CLI output.

Part of the actual `gh stack` #1023. Non-test diff: 271 added/deleted lines; tests are in separate files.
