### PR TITLE
Test function-induced database structure and certificates

### DIFF
--- a/egraph-comparison/tests/functions.rs
+++ b/egraph-comparison/tests/functions.rs
@@ -1,0 +1,71 @@
+use egraph_comparison::{Certificate, Database, certificate, compare, verify};
+
+fn db(rows: serde_json::Value) -> Database {
+    serde_json::from_value(serde_json::json!({
+        "version":1,
+        "classes":{"x":{"sort":"E"},"y":{"sort":"E"}},
+        "functions":{
+            "f":{"kind":"function","inputs":["E"],"output":"E"},
+            "g":{"kind":"function","inputs":["E"],"output":"E"}
+        },
+        "rows": rows,
+    }))
+    .unwrap()
+}
+
+#[test]
+fn function_structure_survives_without_constructor_terms() {
+    let left = db(serde_json::json!([
+        {"function":"f","inputs":["x"],"output":"y"},
+        {"function":"g","inputs":["x"],"output":"x"}
+    ]));
+    let right = db(serde_json::json!([
+        {"function":"f","inputs":["x"],"output":"y"},
+        {"function":"g","inputs":["y"],"output":"y"}
+    ]));
+    let result = compare(&left, &right).unwrap();
+    assert!(result.terms_equal);
+    assert!(!result.database_equal);
+    for (a, b) in [(&left, &right), (&right, &left)] {
+        let cert = certificate(a, b).unwrap().unwrap();
+        assert!(matches!(cert, Certificate::Row { .. }));
+        assert!(verify(&cert, a, b).unwrap());
+        assert!(!verify(&cert, a, a).unwrap());
+    }
+}
+
+#[test]
+fn bisimilar_function_cycles_ignore_ids_and_multiplicity() {
+    let left = db(serde_json::json!([
+        {"function":"f","inputs":["x"],"output":"x"}
+    ]));
+    let right = db(serde_json::json!([
+        {"function":"f","inputs":["x"],"output":"y"},
+        {"function":"f","inputs":["y"],"output":"x"}
+    ]));
+    assert!(compare(&left, &right).unwrap().database_equal);
+    assert!(certificate(&left, &right).unwrap().is_none());
+}
+
+#[test]
+fn function_members_change_database_but_never_term_witnesses() {
+    let mut left = db(serde_json::json!([
+        {"function":"f","inputs":["x"],"output":"y"}
+    ]));
+    left.functions.get_mut("g").unwrap().kind = egraph_comparison::FunctionKind::Constructor;
+    left.rows.push(egraph_comparison::Row {
+        function: "g".into(),
+        inputs: vec!["x".into()],
+        output: "x".into(),
+        subsumed: false,
+    });
+    let mut right = left.clone();
+    right.rows[0].output = "x".into();
+    let result = compare(&left, &right).unwrap();
+    assert!(result.terms_equal);
+    assert!(!result.database_equal);
+    assert!(matches!(
+        certificate(&left, &right).unwrap().unwrap(),
+        Certificate::Row { .. }
+    ));
+}


### PR DESCRIPTION
*From Codex:*

Add regression coverage for function-induced structure without constructor terms, bisimilar ordinary-function cycles, function-only changes, and row-certificate verification. Extend the independent relation oracle to function-only graphs.

The semantic implementation is already in #1011 and the certificate handling is in #1012. This layer contains tests only. All comparison tests pass at this layer.

Part of the actual `gh stack` #1023. Non-test diff: 0 added/deleted lines; tests are in separate files.
