### PR TITLE
Pilot semantic database snapshots and document migration options

### DIFF
--- a/egraph-comparison/README.md
+++ b/egraph-comparison/README.md
@@ -180,3 +180,8 @@ Container support needs variable-arity observations with element sorts and
 container kind in the label. Ordered sequences, unordered sets, multiplicities,
 and map key/value pairing must be preserved when comparing child blocks. The
 current fixed-arity ordered `Function` schema cannot express all these cases.
+
+## Snapshot infrastructure
+
+[The snapshot evaluation](SNAPSHOTS.md) describes the saved-database pilot,
+verified failure certificates, and the requirements for broader adoption.

--- a/egraph-comparison/SNAPSHOTS.md
+++ b/egraph-comparison/SNAPSHOTS.md
@@ -1,0 +1,115 @@
+# Semantic snapshot evaluation
+
+The comparison tool can already add useful database regression coverage. Adopt
+stored semantic database snapshots incrementally, alongside the current
+command-output tests. The pilot in `tests/comparison_snapshots.rs` deliberately
+leaves the existing harness and `.snap` files in place.
+
+## What the current harness checks
+
+`tests/files.rs` runs normal, parallel, desugared, term-encoded, and proof
+variants. Its shared snapshots use
+`CommandOutput::snapshot_stable_under_proof_encoding` in `src/lib.rs`:
+
+* `PrintFunction` contents and extraction variants are dropped.
+* Best-term extraction is reduced to its cost.
+* A final `(print-size)` adds table counts to every program.
+* Snapshots are skipped for parallel runs and several known nondeterministic
+  cases. Error strings and proof-support lists have separate snapshots.
+
+Counts can stay unchanged when a function result changes, a constructor term is
+replaced, or the same number of unions produces different equalities. The pilot
+has three executable regressions demonstrating this: the existing snapshot
+strings match, but database comparison fails and produces a valid certificate.
+
+## Options
+
+| Option | Coverage | Tradeoff |
+| --- | --- | --- |
+| Stored JSON database + semantic comparison | Changes across commits and thread counts; certificates explain failures | Larger baselines and explicit format/version maintenance |
+| Compare a fresh sequential run with parallel/desugared runs | Differences between execution treatments, without stored state | Both treatments can regress identically; extra program execution |
+| Snapshot a deterministic minimized serialization | Potentially smaller, text-reviewable snapshots | Needs a separate canonical labeling/serialization design; joint partition block numbers are not stable labels |
+| Keep command-output snapshots | Errors, formatting, extraction costs, command order, intermediate outputs | Does not establish database equality |
+
+Use stored JSON for accepted database contents, differential checks to broaden
+threading coverage, and focused output tests for observable command behavior.
+Final-state equality cannot replace intermediate-state checks, extraction-cost
+checks, or error snapshots.
+
+## Working pilot
+
+Three checked-in JSON baselines cover constructor equalities (`eqsat-basic`),
+relations (`path`), and ordinary functions (`fibonacci`). The test compares each
+baseline against fresh runs with 1, 4, and 32 threads. It never relies on the
+baseline's raw IDs or row ordering. On failure it writes the actual database and
+a verified certificate under `target/comparison-snapshots/` and prints the paths.
+
+```sh
+cargo test -p egglog --test comparison_snapshots
+# Explicitly accept new databases after reviewing an intentional behavior change:
+EGGLOG_UPDATE_COMPARISON_SNAPSHOTS=1 cargo test -p egglog --test comparison_snapshots golden_databases_match_sequential_and_parallel_runs
+```
+
+Updates run the sequential program once per baseline. They are never triggered
+by ordinary test execution. Review a proposed baseline semantically with the
+comparison binary as well as inspecting its JSON diff. The three baselines total
+about 7.4 KB, versus very small existing count-only snapshots.
+
+## Bounded survey
+
+Reproduce the 12-program, five-treatment feasibility survey with:
+
+```sh
+EGGLOG_COMPARISON_SURVEY_OUTPUT=/tmp/egraph-comparison-survey.json cargo test -p egglog --test comparison_snapshots survey_snapshot_candidates -- --ignored --nocapture
+```
+
+The survey reports unsupported cases rather than silently skipping them. Export
+success alone does not establish coverage: a database can be empty when values
+are held only in global bindings. Compare nonempty user-table exports and inspect
+the projection requirements below before expanding the pilot.
+
+## Requirements before broader adoption
+
+1. **Container values as variable-arity tables.** The exporter rejects encountered container values.
+   `set` and `unstable-fn` fail in the survey. Some other container programs export
+   only their remaining scalar/constructor tables, so successful export does not
+   establish container coverage. Add typed container observations: sequences for
+   vectors/pairs, unordered elements for sets, multiplicities for multisets,
+   key/value associations for maps, and target function identity for closures.
+   Normalize unordered observations after substituting partition blocks, not by
+   raw ID order. A container observation can be a variable-arity table row:
+   its label identifies the container kind and element sorts, while its children
+   are the elements (or map key/value pairs). The current `Function` schema has
+   fixed arity and ordered arguments, so it cannot directly express this for all
+   container kinds. Add the appropriate ordered/unordered observation form and
+   validation rather than encoding container runtime IDs or arbitrary iteration
+   order. Extend certificate syntax/evaluation for those value forms.
+2. **Term/proof projection.** Encoded tables are not the same schema as the user
+   database; blindly dropping hidden tables is insufficient. Project constructor
+   views and analysis functions back to their original signatures and canonical
+   values, then compare that projection. The exporter currently rejects these
+   modes. Several surveyed examples also fail earlier in encoded execution.
+3. **Desugared relations.** `path` and `points-to` compare unequal after the
+   harness-style resolve/print/reparse round trip. Relation desugaring marks its
+   generated output sort non-unionable, but the printed sort does not preserve
+   that metadata. The reparsed relation becomes a constructor to the exporter.
+   Preserve this metadata in the round trip or export through an explicit schema
+   projection before enabling comparisons across those treatments. Other eight
+   successful normal exports compare equal to their desugared runs.
+4. **Global-only values and custom sorts.** Global bindings and hidden tables
+   are excluded. `map` demonstrates why this must remain explicit: an empty user
+   database says nothing about values retained only by globals. Decide which
+   user roots to expose as stable named observations. Custom base sorts need an
+   injective, stable encoding; arbitrary `Debug` output is insufficient.
+5. **Snapshot boundaries and policy.** Start at final program state, then add
+   explicit checkpoints where intermediate changes matter. Keep full database
+   equality for regression tests; use `terms_equal` to diagnose whether a change
+   is confined to functions/activity. Costs are intentionally outside database
+   equality and need their own assertions. Bisimulation ignores multiplicities
+   of equivalent cycles; table-size assertions may intentionally remain stricter.
+
+After those requirements are addressed, add semantic snapshots to selected
+`Run::test_program` cases and remove their parallel snapshot skip. Expand coverage
+only when their schemas and projections are supported; retain textual diagnostics
+and extraction checks. This pilot provides a migration path without weakening
+existing coverage or accepting unsupported exports as equal.

--- a/tests/comparison/baselines/eqsat-basic.json
+++ b/tests/comparison/baselines/eqsat-basic.json
@@ -1,0 +1,171 @@
+{
+  "version": 1,
+  "classes": {
+    "Math-0": {
+      "sort": "Math"
+    },
+    "Math-1": {
+      "sort": "Math"
+    },
+    "Math-2": {
+      "sort": "Math"
+    },
+    "Math-3": {
+      "sort": "Math"
+    },
+    "Math-4": {
+      "sort": "Math"
+    },
+    "Math-5": {
+      "sort": "Math"
+    },
+    "Math-6": {
+      "sort": "Math"
+    },
+    "String-0": {
+      "sort": "String",
+      "literal": "\"x\""
+    },
+    "i64-2": {
+      "sort": "i64",
+      "literal": "2"
+    },
+    "i64-3": {
+      "sort": "i64",
+      "literal": "3"
+    },
+    "i64-6": {
+      "sort": "i64",
+      "literal": "6"
+    }
+  },
+  "functions": {
+    "Add": {
+      "kind": "constructor",
+      "inputs": [
+        "Math",
+        "Math"
+      ],
+      "output": "Math"
+    },
+    "Mul": {
+      "kind": "constructor",
+      "inputs": [
+        "Math",
+        "Math"
+      ],
+      "output": "Math"
+    },
+    "Num": {
+      "kind": "constructor",
+      "inputs": [
+        "i64"
+      ],
+      "output": "Math"
+    },
+    "Var": {
+      "kind": "constructor",
+      "inputs": [
+        "String"
+      ],
+      "output": "Math"
+    }
+  },
+  "rows": [
+    {
+      "function": "Num",
+      "inputs": [
+        "i64-2"
+      ],
+      "output": "Math-0",
+      "subsumed": false
+    },
+    {
+      "function": "Num",
+      "inputs": [
+        "i64-3"
+      ],
+      "output": "Math-2",
+      "subsumed": false
+    },
+    {
+      "function": "Num",
+      "inputs": [
+        "i64-6"
+      ],
+      "output": "Math-5",
+      "subsumed": false
+    },
+    {
+      "function": "Var",
+      "inputs": [
+        "String-0"
+      ],
+      "output": "Math-1",
+      "subsumed": false
+    },
+    {
+      "function": "Add",
+      "inputs": [
+        "Math-1",
+        "Math-2"
+      ],
+      "output": "Math-3",
+      "subsumed": false
+    },
+    {
+      "function": "Add",
+      "inputs": [
+        "Math-2",
+        "Math-1"
+      ],
+      "output": "Math-3",
+      "subsumed": false
+    },
+    {
+      "function": "Add",
+      "inputs": [
+        "Math-6",
+        "Math-5"
+      ],
+      "output": "Math-4",
+      "subsumed": false
+    },
+    {
+      "function": "Add",
+      "inputs": [
+        "Math-5",
+        "Math-6"
+      ],
+      "output": "Math-4",
+      "subsumed": false
+    },
+    {
+      "function": "Mul",
+      "inputs": [
+        "Math-0",
+        "Math-3"
+      ],
+      "output": "Math-4",
+      "subsumed": false
+    },
+    {
+      "function": "Mul",
+      "inputs": [
+        "Math-0",
+        "Math-1"
+      ],
+      "output": "Math-6",
+      "subsumed": false
+    },
+    {
+      "function": "Mul",
+      "inputs": [
+        "Math-0",
+        "Math-2"
+      ],
+      "output": "Math-5",
+      "subsumed": false
+    }
+  ]
+}

--- a/tests/comparison/baselines/fibonacci.json
+++ b/tests/comparison/baselines/fibonacci.json
@@ -1,0 +1,132 @@
+{
+  "version": 1,
+  "classes": {
+    "i64-0": {
+      "sort": "i64",
+      "literal": "0"
+    },
+    "i64-1": {
+      "sort": "i64",
+      "literal": "1"
+    },
+    "i64-13": {
+      "sort": "i64",
+      "literal": "13"
+    },
+    "i64-2": {
+      "sort": "i64",
+      "literal": "2"
+    },
+    "i64-21": {
+      "sort": "i64",
+      "literal": "21"
+    },
+    "i64-3": {
+      "sort": "i64",
+      "literal": "3"
+    },
+    "i64-4": {
+      "sort": "i64",
+      "literal": "4"
+    },
+    "i64-5": {
+      "sort": "i64",
+      "literal": "5"
+    },
+    "i64-6": {
+      "sort": "i64",
+      "literal": "6"
+    },
+    "i64-7": {
+      "sort": "i64",
+      "literal": "7"
+    },
+    "i64-8": {
+      "sort": "i64",
+      "literal": "8"
+    }
+  },
+  "functions": {
+    "fib": {
+      "kind": "function",
+      "inputs": [
+        "i64"
+      ],
+      "output": "i64"
+    }
+  },
+  "rows": [
+    {
+      "function": "fib",
+      "inputs": [
+        "i64-0"
+      ],
+      "output": "i64-0",
+      "subsumed": false
+    },
+    {
+      "function": "fib",
+      "inputs": [
+        "i64-1"
+      ],
+      "output": "i64-1",
+      "subsumed": false
+    },
+    {
+      "function": "fib",
+      "inputs": [
+        "i64-2"
+      ],
+      "output": "i64-1",
+      "subsumed": false
+    },
+    {
+      "function": "fib",
+      "inputs": [
+        "i64-3"
+      ],
+      "output": "i64-2",
+      "subsumed": false
+    },
+    {
+      "function": "fib",
+      "inputs": [
+        "i64-4"
+      ],
+      "output": "i64-3",
+      "subsumed": false
+    },
+    {
+      "function": "fib",
+      "inputs": [
+        "i64-5"
+      ],
+      "output": "i64-5",
+      "subsumed": false
+    },
+    {
+      "function": "fib",
+      "inputs": [
+        "i64-6"
+      ],
+      "output": "i64-8",
+      "subsumed": false
+    },
+    {
+      "function": "fib",
+      "inputs": [
+        "i64-7"
+      ],
+      "output": "i64-13",
+      "subsumed": false
+    },
+    {
+      "function": "fib",
+      "inputs": [
+        "i64-8"
+      ],
+      "output": "i64-21",
+      "subsumed": false
+    }
+  ]
+}

--- a/tests/comparison/baselines/path.json
+++ b/tests/comparison/baselines/path.json
@@ -1,0 +1,149 @@
+{
+  "version": 1,
+  "classes": {
+    "@edgeSort-0": {
+      "sort": "@relation:[\"edge\"]"
+    },
+    "@edgeSort-1": {
+      "sort": "@relation:[\"edge\"]"
+    },
+    "@edgeSort-2": {
+      "sort": "@relation:[\"edge\"]"
+    },
+    "@pathSort-3": {
+      "sort": "@relation:[\"path\"]"
+    },
+    "@pathSort-4": {
+      "sort": "@relation:[\"path\"]"
+    },
+    "@pathSort-5": {
+      "sort": "@relation:[\"path\"]"
+    },
+    "@pathSort-6": {
+      "sort": "@relation:[\"path\"]"
+    },
+    "@pathSort-7": {
+      "sort": "@relation:[\"path\"]"
+    },
+    "@pathSort-8": {
+      "sort": "@relation:[\"path\"]"
+    },
+    "i64-1": {
+      "sort": "i64",
+      "literal": "1"
+    },
+    "i64-2": {
+      "sort": "i64",
+      "literal": "2"
+    },
+    "i64-3": {
+      "sort": "i64",
+      "literal": "3"
+    },
+    "i64-4": {
+      "sort": "i64",
+      "literal": "4"
+    }
+  },
+  "functions": {
+    "edge": {
+      "kind": "function",
+      "inputs": [
+        "i64",
+        "i64"
+      ],
+      "output": "@relation:[\"edge\"]"
+    },
+    "path": {
+      "kind": "function",
+      "inputs": [
+        "i64",
+        "i64"
+      ],
+      "output": "@relation:[\"path\"]"
+    }
+  },
+  "rows": [
+    {
+      "function": "path",
+      "inputs": [
+        "i64-1",
+        "i64-2"
+      ],
+      "output": "@pathSort-3",
+      "subsumed": false
+    },
+    {
+      "function": "path",
+      "inputs": [
+        "i64-2",
+        "i64-3"
+      ],
+      "output": "@pathSort-4",
+      "subsumed": false
+    },
+    {
+      "function": "path",
+      "inputs": [
+        "i64-3",
+        "i64-4"
+      ],
+      "output": "@pathSort-5",
+      "subsumed": false
+    },
+    {
+      "function": "path",
+      "inputs": [
+        "i64-1",
+        "i64-3"
+      ],
+      "output": "@pathSort-6",
+      "subsumed": false
+    },
+    {
+      "function": "path",
+      "inputs": [
+        "i64-2",
+        "i64-4"
+      ],
+      "output": "@pathSort-7",
+      "subsumed": false
+    },
+    {
+      "function": "path",
+      "inputs": [
+        "i64-1",
+        "i64-4"
+      ],
+      "output": "@pathSort-8",
+      "subsumed": false
+    },
+    {
+      "function": "edge",
+      "inputs": [
+        "i64-1",
+        "i64-2"
+      ],
+      "output": "@edgeSort-0",
+      "subsumed": false
+    },
+    {
+      "function": "edge",
+      "inputs": [
+        "i64-2",
+        "i64-3"
+      ],
+      "output": "@edgeSort-1",
+      "subsumed": false
+    },
+    {
+      "function": "edge",
+      "inputs": [
+        "i64-3",
+        "i64-4"
+      ],
+      "output": "@edgeSort-2",
+      "subsumed": false
+    }
+  ]
+}

--- a/tests/comparison_snapshots.rs
+++ b/tests/comparison_snapshots.rs
@@ -1,0 +1,165 @@
+#![cfg(feature = "comparison")]
+use egglog::{CommandOutput, EGraph};
+use egraph_comparison::{Database, certificate, compare, verify};
+use std::{fs, path::Path, time::Instant};
+
+const GOLDENS: &[&str] = &["eqsat-basic", "path", "fibonacci"];
+
+fn run(program: &str, threads: usize) -> (Database, Vec<CommandOutput>) {
+    let mut graph = EGraph::default().with_num_threads(threads);
+    let outputs = graph.parse_and_run_program(None, program).unwrap();
+    (graph.serialize_for_comparison().unwrap(), outputs)
+}
+
+// An explicit update mode, separate from comparison: ordinary test runs never
+// rewrite accepted databases. Each threading treatment uses the same baseline.
+#[test]
+fn golden_databases_match_sequential_and_parallel_runs() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let baseline_dir = root.join("tests/comparison/baselines");
+    for name in GOLDENS {
+        let program = fs::read_to_string(root.join(format!("tests/web-demo/{name}.egg"))).unwrap();
+        let baseline_path = baseline_dir.join(format!("{name}.json"));
+        if std::env::var("EGGLOG_UPDATE_COMPARISON_SNAPSHOTS").as_deref() == Ok("1") {
+            let (database, _) = run(&program, 1);
+            fs::write(
+                &baseline_path,
+                serde_json::to_string_pretty(&database).unwrap() + "\n",
+            )
+            .unwrap();
+        }
+        let expected: Database =
+            serde_json::from_slice(&fs::read(&baseline_path).unwrap()).unwrap();
+        for threads in [1, 4, 32] {
+            let (actual, _) = run(&program, threads);
+            let result = compare(&expected, &actual).unwrap();
+            if !result.database_equal {
+                let witness = certificate(&expected, &actual).unwrap().unwrap();
+                assert!(verify(&witness, &expected, &actual).unwrap());
+                let output = root.join("target/comparison-snapshots");
+                fs::create_dir_all(&output).unwrap();
+                let stem = format!("{name}-{threads}threads");
+                let actual_path = output.join(format!("{stem}.actual.json"));
+                let witness_path = output.join(format!("{stem}.certificate.json"));
+                fs::write(&actual_path, serde_json::to_vec_pretty(&actual).unwrap()).unwrap();
+                fs::write(&witness_path, serde_json::to_vec_pretty(&witness).unwrap()).unwrap();
+                panic!(
+                    "{name} ({threads} threads): {result:?}\nbaseline: {}\nactual: {}\ncertificate: {}",
+                    baseline_path.display(),
+                    actual_path.display(),
+                    witness_path.display()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn database_snapshots_find_changes_that_keep_output_snapshots_identical() {
+    let cases = [
+        (
+            "(function f (i64) i64 :no-merge)",
+            "(set (f 0) 1)",
+            "(set (f 0) 2)",
+        ),
+        ("(datatype E (Num i64))", "(Num 1)", "(Num 2)"),
+        (
+            "(datatype E (A) (B) (C)) (A) (B) (C)",
+            "(union (A) (B))",
+            "(union (A) (C))",
+        ),
+    ];
+    for (header, a, b) in cases {
+        let (left, a) = run(&format!("{header} {a} (print-size)"), 1);
+        let (right, b) = run(&format!("{header} {b} (print-size)"), 4);
+        assert_eq!(
+            CommandOutput::snapshot_stable_under_proof_encoding(&a),
+            CommandOutput::snapshot_stable_under_proof_encoding(&b)
+        );
+        assert!(!compare(&left, &right).unwrap().database_equal);
+        let witness = certificate(&left, &right).unwrap().unwrap();
+        assert!(verify(&witness, &left, &right).unwrap());
+    }
+}
+
+// A bounded, reproducible feasibility survey, not a performance benchmark or a
+// silent skip list. Unsupported cases are reported for the migration design.
+#[test]
+#[ignore = "manual snapshot migration survey; reports supported and blocked cases"]
+fn survey_snapshot_candidates() {
+    use std::io::Write;
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let paths = [
+        "web-demo/eqsat-basic",
+        "web-demo/path",
+        "web-demo/fibonacci",
+        "web-demo/points-to",
+        "web-demo/bignum",
+        "web-demo/subsume",
+        "web-demo/set",
+        "web-demo/multiset",
+        "vec",
+        "map",
+        "pair",
+        "web-demo/unstable-fn",
+    ];
+    let mut report = Vec::new();
+    for path in paths {
+        let program = fs::read_to_string(root.join(format!("tests/{path}.egg"))).unwrap();
+        let mut baseline = None;
+        for mode in ["normal", "32threads", "desugar", "term_encoding", "proofs"] {
+            let start = Instant::now();
+            let result = (|| -> Result<Database, String> {
+                let mut graph = match mode {
+                    "term_encoding" => EGraph::new_with_term_encoding(),
+                    "proofs" => EGraph::new_with_proofs(),
+                    "32threads" => EGraph::default().with_num_threads(32),
+                    _ => EGraph::default(),
+                };
+                let program = if mode == "desugar" {
+                    let commands = graph
+                        .resolve_program(None, &program)
+                        .map_err(|e| e.to_string())?;
+                    let result = commands
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    graph = EGraph::default();
+                    graph.ensure_no_reserved_symbols(false);
+                    result
+                } else {
+                    program.clone()
+                };
+                graph
+                    .parse_and_run_program(None, &program)
+                    .map_err(|e| e.to_string())?;
+                graph.serialize_for_comparison().map_err(|e| e.to_string())
+            })();
+            let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+            let row = match result {
+                Ok(database) => {
+                    let compare_start = Instant::now();
+                    let comparison = baseline
+                        .as_ref()
+                        .map(|expected| compare(expected, &database).unwrap());
+                    let compare_ms = compare_start.elapsed().as_secs_f64() * 1000.0;
+                    let row = serde_json::json!({"case":path,"mode":mode,"classes":database.classes.len(),"rows":database.rows.len(),"bytes":serde_json::to_vec_pretty(&database).unwrap().len(),"run_export_ms":elapsed_ms,"compare_ms":compare_ms,"comparison":comparison});
+                    if mode == "normal" {
+                        baseline = Some(database);
+                    }
+                    row
+                }
+                Err(error) => {
+                    serde_json::json!({"case":path,"mode":mode,"error":error,"run_export_ms":elapsed_ms})
+                }
+            };
+            report.push(row);
+        }
+    }
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    if let Ok(path) = std::env::var("EGGLOG_COMPARISON_SURVEY_OUTPUT") {
+        fs::write(path, &json).unwrap();
+    }
+    writeln!(std::io::stdout().lock(), "{json}").unwrap();
+}


### PR DESCRIPTION
*From Codex:*

Pilot accepted full-database snapshots for three egglog programs, checked against 1/4/32-thread runs. Failures produce verified disequality certificates; explicit updates regenerate baselines. Keep existing output/error/extraction snapshots intact.

Document the remaining migration requirements, including variable-arity container observations, term/proof projection, desugared relation metadata, and global roots. Keep the bounded survey available as an ignored test without checking in local timing reports.

Validation: both pilot tests pass independently at this layer. The manual survey remains ignored.

Part of the actual `gh stack` #1023. Non-test diff: 120 added/deleted lines; tests are in separate files.
