### PR TITLE
Add canonical serialization of e-graph comparison quotients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "statrs"

--- a/egraph-comparison/CANONICAL.md
+++ b/egraph-comparison/CANONICAL.md
@@ -1,0 +1,72 @@
+# Canonical comparison graphs
+
+```sh
+cargo run -p egraph-comparison -- --canonical input.json > canonical.json
+cargo run -p egraph-comparison -- --canonical --terms-only input.json > terms.json
+```
+
+The Rust API is `canonicalize(&Database, CanonicalMode) -> Result<Vec<u8>, Error>`.
+For valid inputs and the same mode, byte equality is equivalent to the
+corresponding `compare` result: `terms_equal` for `Terms`, `database_equal` for
+`Database`. This includes ungrounded cycles, holes, and duplicate bisimilar
+classes. It does not identify graphs solely by their finite term languages.
+The full mode includes unused declarations and subsumption; term mode ignores
+ordinary functions and subsumption. Input validation applies in both modes.
+
+## How numbering becomes canonical
+
+Start from row-output roots in the selected projection and retain their reachable
+classes. Sort the observed sorts and complete node labels; these define the
+initial block and symbol IDs. Each refinement round builds exact signatures
+`(previous block, sorted unique node signatures)`. Intern signatures with full
+key equality, sort the unique signatures lexicographically, and assign IDs in
+that order. Each node signature is `[symbol ID, ordered child block IDs...]`.
+Retaining the previous block allows only splits. Stop when no block splits.
+
+Equivalent rooted graphs have the same reachable behaviors, the same initial
+ordered partition, and inductively the same ordered signatures at every round.
+At the fixed point, emit one class per block and the sorted set of root block
+IDs. Conversely, identical serialized quotients supply a bisimulation between
+the roots. Full-mode bisimulation also preserves the constructor projection:
+matching constructor nodes identify matching constructor roots. Thus the full
+encoding does not need a second copy of the term quotient.
+
+Input IDs, row order, duplicate rows, multiplicities of equivalent classes, and
+unreachable classes cannot affect bytes. Sorting unused labels or sorts would
+break this property, so they are removed before numbering. Hash values are never
+used as semantic identities. The algorithm is iterative and has no depth cutoff.
+In addition to the pairwise algorithm's signature work, this implementation sorts
+all unique block signatures on every round and serializes the quotient.
+
+## Version 1 encoding
+
+The output is compact UTF-8 JSON with one trailing newline, in this field order:
+
+- `format`: `"egraph-comparison-canonical"`.
+- `version`: `1`.
+- `mode`: `"terms"` or `"database"`.
+- `declarations`: the input declaration map, only in database mode.
+- `sorts`: sorted observed sort names.
+- `labels`: sorted complete labels. Literals encode as `{"Literal":"value"}`;
+  calls as `{"Call":["name",function_schema,subsumed]}`. Literal labels precede
+  calls; within each variant the fields follow Rust lexicographic ordering.
+  Schemas order by kind (constructor before function), input sorts, output sort.
+- `roots`: sorted unique class IDs.
+- `classes`: records in class-ID order, each with `sort` (sort ID), then `nodes`
+  (sorted unique node-signature arrays).
+
+String and map-key ordering follows Rust `str` ordering. Schemas encode fields
+in `kind`, `inputs`, `output` order. Changing canonical ordering, semantics, or
+JSON encoding requires a format-version change and baseline regeneration.
+Compare bytes only within the same format version and mode; cross-version
+inequality is not a certificate of semantic disequality.
+
+This is a **comparison quotient**, not version 1 input `Database` JSON. For
+example, `x=f(x)` and `y=f(y)` can merge even when `g(x)` and `g(y)` have different
+additional members. Their quotient contains one input tuple for `g` with two
+distinct output blocks, which input validation would reject. Keep original
+inputs when generating or verifying existing disequality certificates. The
+format records enough structure to compare exactly, but has no certificate
+reader yet. Canonical byte equality also leaves exporter coverage unchanged;
+containers, custom base values, and term/proof projections still need explicit
+semantics before broad snapshot migration.

--- a/egraph-comparison/Cargo.toml
+++ b/egraph-comparison/Cargo.toml
@@ -11,8 +11,8 @@ clap = { workspace = true, features = ["derive"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-egglog-numeric-id.workspace = true
 hashbrown.workspace = true
 rustc-hash.workspace = true
-smallvec.workspace = true
+smallvec = { workspace = true, features = ["serde"] }
+egglog-numeric-id.workspace = true
 fixedbitset.workspace = true

--- a/egraph-comparison/README.md
+++ b/egraph-comparison/README.md
@@ -181,7 +181,15 @@ container kind in the label. Ordered sequences, unordered sets, multiplicities,
 and map key/value pairing must be preserved when comparing child blocks. The
 current fixed-arity ordered `Function` schema cannot express all these cases.
 
+## Canonical representation
+
+Use `--canonical input.json` (optionally `--terms-only`) to write a versioned
+canonical quotient that can be compared using byte equality. The
+[format and algorithm](CANONICAL.md) explain deterministic numbering, cycles,
+and the relationship to pairwise comparison and certificates.
+
 ## Snapshot infrastructure
 
-[The snapshot evaluation](SNAPSHOTS.md) describes the saved-database pilot,
-verified failure certificates, and the requirements for broader adoption.
+[The snapshot evaluation](SNAPSHOTS.md) compares adoption options and records a
+working pilot with saved databases, 1/4/32-thread checks, verified failure
+certificates, and a reproducible survey of the remaining migration requirements.

--- a/egraph-comparison/src/canonical.rs
+++ b/egraph-comparison/src/canonical.rs
@@ -1,0 +1,172 @@
+use crate::ids::{BlockId, ClassId, FormatVersion, SortId, SymbolId};
+use crate::{
+    Database, Error, Function, HashMap,
+    refine::{Graph, Label},
+};
+use egglog_numeric_id::NumericId;
+use serde::Serialize;
+use smallvec::SmallVec;
+use std::collections::BTreeMap;
+
+/// Which observations participate in the canonical representation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CanonicalMode {
+    Terms,
+    Database,
+}
+
+// Packed wire words: SymbolId followed by ordered BlockIds, converted only at
+// this encoding boundary. The typed graph and partition retain separate IDs.
+type NodeSignature = SmallVec<[usize; 3]>;
+type Signature = (BlockId, Vec<NodeSignature>);
+
+#[derive(Serialize)]
+struct CanonicalClass {
+    sort: SortId,
+    nodes: Vec<NodeSignature>,
+}
+
+#[derive(Serialize)]
+struct Encoding<'a> {
+    format: &'static str,
+    version: FormatVersion,
+    mode: CanonicalMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    declarations: Option<&'a BTreeMap<String, Function>>,
+    sorts: Vec<&'a str>,
+    labels: Vec<Label<'a>>,
+    roots: Vec<BlockId>,
+    classes: Vec<CanonicalClass>,
+}
+
+/// Produce versioned canonical JSON bytes (with a trailing newline).
+///
+/// For valid inputs in the same mode, byte equality is equivalent to `compare`'s
+/// corresponding equality result, including cycles and duplicate behaviors.
+/// The output is a bisimulation quotient, not an input `Database`. Canonical
+/// ordering requires sorting unique block signatures on every refinement round.
+pub fn canonicalize(db: &Database, mode: CanonicalMode) -> Result<Vec<u8>, Error> {
+    db.validate()?;
+    let mut labels = HashMap::default();
+    let graph = Graph::new(db, 0, mode == CanonicalMode::Database, &mut labels);
+
+    // Unobserved classes must not affect numbering, even indirectly through
+    // unused sorts/literals. Reachability is iterative to support deep cycles.
+    let mut active = vec![false; graph.nodes.len()];
+    let mut pending = graph.roots.clone();
+    while let Some(id) = pending.pop() {
+        if std::mem::replace(&mut active[id.index()], true) {
+            continue;
+        }
+        pending.extend(graph.nodes[id.index()].iter().flat_map(|n| &n.children));
+    }
+    let mut used_labels = vec![false; labels.len()];
+    let mut sorts = Vec::new();
+    let ids: Vec<_> = active
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &used)| used.then_some(ClassId::from_usize(i)))
+        .collect();
+    for &id in &ids {
+        sorts.push(graph.sorts[id.index()]);
+        for node in &graph.nodes[id.index()] {
+            used_labels[node.symbol.index()] = true;
+        }
+    }
+    sorts.sort_unstable();
+    sorts.dedup();
+    let mut labels: Vec<_> = labels
+        .into_iter()
+        .filter(|(_, id)| used_labels[id.index()])
+        .collect();
+    labels.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    let mut symbols = vec![SymbolId::from_usize(0); used_labels.len()];
+    for (canonical, (_, original)) in labels.iter().enumerate() {
+        symbols[original.index()] = SymbolId::from_usize(canonical);
+    }
+    let labels = labels.into_iter().map(|(label, _)| label).collect();
+    let mut blocks = vec![BlockId::from_usize(0); graph.nodes.len()];
+    for &id in &ids {
+        blocks[id.index()] =
+            BlockId::from_usize(sorts.binary_search(&graph.sorts[id.index()]).unwrap());
+    }
+    let mut block_count = sorts.len();
+
+    let final_signatures = loop {
+        let mut signatures = HashMap::default();
+        let mut next = Vec::with_capacity(ids.len());
+        let mut key: Signature = (BlockId::from_usize(0), Vec::new());
+        for &id in &ids {
+            key.0 = blocks[id.index()]; // Split existing blocks; never merge them.
+            key.1.clear();
+            key.1.extend(graph.nodes[id.index()].iter().map(|node| {
+                let mut signature = SmallVec::new();
+                signature.push(symbols[node.symbol.index()].index());
+                signature.extend(
+                    node.children
+                        .iter()
+                        .map(|&child| blocks[child.index()].index()),
+                );
+                signature
+            }));
+            key.1.sort_unstable();
+            key.1.dedup();
+            let block = if let Some(&block) = signatures.get(&key) {
+                block
+            } else {
+                let block = BlockId::from_usize(signatures.len());
+                signatures.insert((key.0, std::mem::take(&mut key.1)), block);
+                block
+            };
+            next.push(block);
+        }
+        // Hashing only interns exact signatures. Sorting them gives IDs that
+        // depend on observations, never hash iteration or input class order.
+        let mut ordered: Vec<_> = signatures.into_iter().collect();
+        ordered.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let mut ranks = vec![BlockId::from_usize(0); ordered.len()];
+        for (rank, (_, discovered)) in ordered.iter().enumerate() {
+            ranks[discovered.index()] = BlockId::from_usize(rank);
+        }
+        for (&id, discovered) in ids.iter().zip(next) {
+            blocks[id.index()] = ranks[discovered.index()];
+        }
+        if ordered.len() == block_count {
+            // Old block is the leading key, so a round without splits preserves
+            // IDs. These node signatures already reference the final numbering.
+            break ordered;
+        }
+        block_count = ordered.len();
+    };
+    let mut class_sorts = vec![SortId::from_usize(0); block_count];
+    for &id in &ids {
+        class_sorts[blocks[id.index()].index()] =
+            SortId::from_usize(sorts.binary_search(&graph.sorts[id.index()]).unwrap());
+    }
+    let classes = final_signatures
+        .into_iter()
+        .enumerate()
+        .map(|(id, ((_, nodes), _))| CanonicalClass {
+            sort: class_sorts[id],
+            nodes,
+        })
+        .collect();
+    let mut roots: Vec<_> = graph.roots.iter().map(|&id| blocks[id.index()]).collect();
+    roots.sort_unstable();
+    roots.dedup();
+    drop(graph);
+    let encoding = Encoding {
+        format: "egraph-comparison-canonical",
+        version: FormatVersion::V1,
+        mode,
+        declarations: (mode == CanonicalMode::Database).then_some(&db.functions),
+        sorts,
+        labels,
+        roots,
+        classes,
+    };
+    let mut bytes = serde_json::to_vec(&encoding)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}

--- a/egraph-comparison/src/ids.rs
+++ b/egraph-comparison/src/ids.rs
@@ -39,3 +39,8 @@ serial_id!(
 );
 define_id!(pub RowId, usize, "Index in one input database's rows, used by the representative worklist.");
 define_id!(pub(crate) SymbolId, usize, "Interned complete node label, shared by both inputs during joint refinement.");
+serial_id!(
+    SortId,
+    usize,
+    "Index in a canonical encoding's sorted sort-name table."
+);

--- a/egraph-comparison/src/lib.rs
+++ b/egraph-comparison/src/lib.rs
@@ -1,13 +1,21 @@
-//! Compare complete serialized databases by conservative partition refinement.
+//! Equality of serialized e-graphs modulo constructor bisimulation.
+//!
+//! Input IDs are local names, never semantic identities. Comparison refines the
+//! disjoint union of both inputs, including cycles, until no block can split.
+
+mod canonical;
 mod certificate;
 mod hopcroft;
 mod ids;
 mod model;
 mod refine;
 mod signatures;
+
+pub use canonical::{CanonicalMode, canonicalize};
 pub use certificate::{Certificate, Side, Term, certificate, verify};
 pub use ids::{FormatVersion, RowId, TermId};
 pub use model::{Class, Database, Error, Function, FunctionKind, Row};
 pub use refine::{Comparison, compare};
+
 pub(crate) type HashMap<K, V> =
     hashbrown::HashMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;

--- a/egraph-comparison/src/main.rs
+++ b/egraph-comparison/src/main.rs
@@ -1,12 +1,23 @@
 use clap::Parser;
-use egraph_comparison::{Certificate, Database, certificate, compare, verify};
-use std::{fs::File, io::BufReader, path::PathBuf, process::ExitCode};
+use egraph_comparison::{
+    CanonicalMode, Certificate, Database, canonicalize, certificate, compare, verify,
+};
+use std::{
+    fs::File,
+    io::{BufReader, Write},
+    path::PathBuf,
+    process::ExitCode,
+};
 
 #[derive(Parser)]
 #[command(about = "Compare two serialized e-graphs modulo constructor bisimulation")]
 struct Args {
     left: PathBuf,
-    right: PathBuf,
+    #[arg(required_unless_present = "canonical", conflicts_with = "canonical")]
+    right: Option<PathBuf>,
+    /// Write canonical JSON for one input; --terms-only selects the projection.
+    #[arg(long, conflicts_with_all = ["certificate", "verify_certificate"])]
+    canonical: bool,
     /// Compare constructor-built terms and their e-class equalities, including
     /// cyclic structure. Ignore ordinary function tables and subsumption for
     /// the exit status; comparison still reports both equality results.
@@ -23,12 +34,24 @@ struct Args {
 
 fn run(args: &Args) -> Result<bool, Box<dyn std::error::Error>> {
     let read = |path: &PathBuf| -> Result<Database, Box<dyn std::error::Error>> {
-        // Parse each byte slice and release it before reading the next input.
+        // Parsing a slice avoids the per-byte reader adapter. Drop each input
+        // buffer before loading the next graph to bound the extra memory.
         let bytes = std::fs::read(path)?;
         Ok(serde_json::from_slice(&bytes)?)
     };
     let left = read(&args.left)?;
-    let right = read(&args.right)?;
+    if args.canonical {
+        let mode = if args.terms_only {
+            CanonicalMode::Terms
+        } else {
+            CanonicalMode::Database
+        };
+        std::io::stdout()
+            .lock()
+            .write_all(&canonicalize(&left, mode)?)?;
+        return Ok(true);
+    }
+    let right = read(args.right.as_ref().ok_or("missing right input")?)?;
     if let Some(path) = &args.verify_certificate {
         let witness: Certificate = serde_json::from_reader(BufReader::new(File::open(path)?))?;
         let valid = verify(&witness, &left, &right)?;

--- a/egraph-comparison/src/refine.rs
+++ b/egraph-comparison/src/refine.rs
@@ -19,7 +19,7 @@ pub struct Comparison {
 
 // Intern complete labels jointly across the inputs. Neither names nor schemas
 // are copied per node or per refinement round; hash collisions still use Eq.
-#[derive(PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub(crate) enum Label<'a> {
     Literal(&'a str),
     Call(&'a str, &'a Function, bool),

--- a/egraph-comparison/tests/canonical.rs
+++ b/egraph-comparison/tests/canonical.rs
@@ -1,0 +1,323 @@
+use egraph_comparison::{
+    CanonicalMode, Class, Database, Function, FunctionKind, Row, canonicalize, compare,
+};
+use std::collections::BTreeMap;
+
+fn graph(rows: &[(&str, &[&str], &str)]) -> Database {
+    let mut db = Database::default();
+    for &(op, inputs, output) in rows {
+        for id in inputs.iter().copied().chain([output]) {
+            db.classes.insert(
+                id.into(),
+                Class {
+                    sort: "E".into(),
+                    literal: None,
+                },
+            );
+        }
+        db.functions.insert(
+            op.into(),
+            Function {
+                kind: FunctionKind::Constructor,
+                inputs: vec!["E".into(); inputs.len()],
+                output: "E".into(),
+            },
+        );
+        db.rows.push(Row {
+            function: op.into(),
+            inputs: inputs.iter().map(|s| (*s).into()).collect(),
+            output: output.into(),
+            subsumed: false,
+        });
+    }
+    db
+}
+
+fn agrees(left: &Database, right: &Database) {
+    let result = compare(left, right).unwrap();
+    for (mode, expected) in [
+        (CanonicalMode::Terms, result.terms_equal),
+        (CanonicalMode::Database, result.database_equal),
+    ] {
+        assert_eq!(
+            canonicalize(left, mode).unwrap() == canonicalize(right, mode).unwrap(),
+            expected,
+            "{mode:?}: {left:?} vs {right:?}"
+        );
+    }
+}
+
+fn renamed(db: &Database) -> Database {
+    let names: BTreeMap<_, _> = db
+        .classes
+        .keys()
+        .enumerate()
+        .map(|(i, id)| (id.clone(), format!("renamed-{:06}", db.classes.len() - i)))
+        .collect();
+    let mut result = db.clone();
+    result.classes = db
+        .classes
+        .iter()
+        .map(|(id, class)| (names[id].clone(), class.clone()))
+        .collect();
+    for row in &mut result.rows {
+        row.output = names[&row.output].clone();
+        for input in &mut row.inputs {
+            *input = names[input].clone();
+        }
+    }
+    result.rows.reverse();
+    result.rows.extend(result.rows.clone());
+    result
+}
+
+#[test]
+fn canonical_format_is_versioned_and_byte_stable() {
+    let db = graph(&[("f", &["x"], "x")]);
+    assert_eq!(
+        String::from_utf8(canonicalize(&db, CanonicalMode::Terms).unwrap()).unwrap(),
+        "{\"format\":\"egraph-comparison-canonical\",\"version\":1,\"mode\":\"terms\",\"sorts\":[\"E\"],\"labels\":[{\"Call\":[\"f\",{\"kind\":\"constructor\",\"inputs\":[\"E\"],\"output\":\"E\"},false]}],\"roots\":[0],\"classes\":[{\"sort\":0,\"nodes\":[[0,0]]}]}\n"
+    );
+    let empty = canonicalize(&Database::default(), CanonicalMode::Database).unwrap();
+    assert_eq!(
+        String::from_utf8(empty).unwrap(),
+        "{\"format\":\"egraph-comparison-canonical\",\"version\":1,\"mode\":\"database\",\"declarations\":{},\"sorts\":[],\"labels\":[],\"roots\":[],\"classes\":[]}\n"
+    );
+}
+
+#[test]
+fn quotients_cycles_and_ignores_unobserved_classes() {
+    let left = graph(&[("f", &["x"], "x")]);
+    let mut right = graph(&[("f", &["b"], "a"), ("f", &["a"], "b"), ("f", &["c"], "c")]);
+    right.classes.insert(
+        "unused".into(),
+        Class {
+            sort: "AAA".into(),
+            literal: Some("zzz".into()),
+        },
+    );
+    agrees(&left, &right);
+    assert_eq!(
+        canonicalize(&left, CanonicalMode::Database).unwrap(),
+        canonicalize(&right, CanonicalMode::Database).unwrap()
+    );
+    agrees(&right, &renamed(&right));
+    right.functions.insert(
+        "AAA".into(),
+        Function {
+            kind: FunctionKind::Constructor,
+            inputs: vec![],
+            output: "Unused".into(),
+        },
+    );
+    agrees(&left, &right);
+    assert_eq!(
+        canonicalize(&left, CanonicalMode::Terms).unwrap(),
+        canonicalize(&right, CanonicalMode::Terms).unwrap()
+    );
+    let empty = Database {
+        classes: right.classes,
+        ..Database::default()
+    };
+    agrees(&Database::default(), &empty);
+}
+
+#[test]
+fn terms_functions_subsumption_literals_and_schemas() {
+    let mut left = graph(&[("a", &[], "x"), ("cost", &["x"], "n")]);
+    left.functions.get_mut("cost").unwrap().kind = FunctionKind::Function;
+    left.functions.get_mut("cost").unwrap().output = "i64".into();
+    left.classes.insert(
+        "n".into(),
+        Class {
+            sort: "i64".into(),
+            literal: Some("1".into()),
+        },
+    );
+    agrees(&left, &renamed(&left));
+    let mut right = left.clone();
+    right.classes.get_mut("n").unwrap().literal = Some("2".into());
+    agrees(&left, &right);
+    right = left.clone();
+    right.rows[0].subsumed = true;
+    agrees(&left, &right);
+    right = left.clone();
+    right.rows[1].subsumed = true;
+    agrees(&left, &right);
+    right = left.clone();
+    right.functions.insert(
+        "empty".into(),
+        Function {
+            kind: FunctionKind::Function,
+            inputs: vec![],
+            output: "E".into(),
+        },
+    );
+    agrees(&left, &right);
+    right = left.clone();
+    right.functions.get_mut("a").unwrap().kind = FunctionKind::Function;
+    agrees(&left, &right);
+    assert_ne!(
+        canonicalize(&left, CanonicalMode::Terms).unwrap(),
+        canonicalize(&left, CanonicalMode::Database).unwrap()
+    );
+}
+
+#[test]
+fn preserves_equalities_ordered_children_and_holes() {
+    let left = graph(&[("a", &[], "x"), ("b", &[], "x")]);
+    agrees(&left, &graph(&[("a", &[], "x"), ("b", &[], "y")]));
+    let left = graph(&[
+        ("a", &[], "x"),
+        ("b", &[], "y"),
+        ("p", &["x", "y", "x", "y"], "z"),
+    ]);
+    let mut right = left.clone();
+    right.rows[2].inputs.reverse();
+    agrees(&left, &right);
+    agrees(&left, &renamed(&left));
+    let left = graph(&[("f", &["hole"], "root")]);
+    agrees(&left, &graph(&[("f", &["root"], "root")]));
+    let mut right = left.clone();
+    right.classes.get_mut("hole").unwrap().sort = "Other".into();
+    right.functions.get_mut("f").unwrap().inputs = vec!["Other".into()];
+    agrees(&left, &right);
+}
+
+#[test]
+fn quotient_can_have_multiple_outputs_for_the_same_quotient_inputs() {
+    // x and y collapse, but g(x) and g(y) do not: only g(x) also contains a.
+    let left = graph(&[
+        ("f", &["x"], "x"),
+        ("f", &["y"], "y"),
+        ("g", &["x"], "u"),
+        ("g", &["y"], "v"),
+        ("a", &[], "u"),
+    ]);
+    agrees(&left, &renamed(&left));
+    let bytes = canonicalize(&left, CanonicalMode::Database).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["classes"].as_array().unwrap().len(), 3);
+    assert!(serde_json::from_slice::<Database>(&bytes).is_err());
+}
+
+#[test]
+fn rejects_invalid_inputs() {
+    let mut db = graph(&[("a", &[], "x")]);
+    db.version = egraph_comparison::FormatVersion::new_const(99);
+    for mode in [CanonicalMode::Terms, CanonicalMode::Database] {
+        assert!(canonicalize(&db, mode).is_err());
+    }
+    db.version = egraph_comparison::FormatVersion::new_const(1);
+    db.rows[0].output = "missing".into();
+    assert!(canonicalize(&db, CanonicalMode::Database).is_err());
+}
+
+#[test]
+fn independent_canonicalizations_agree_with_joint_refinement() {
+    fn generated(mut seed: usize) -> Database {
+        let mut db = graph(&[("a", &[], "0")]);
+        for i in 1..6 {
+            db.classes.insert(
+                i.to_string(),
+                Class {
+                    sort: "E".into(),
+                    literal: None,
+                },
+            );
+        }
+        for (op, kind) in [
+            ("f", FunctionKind::Constructor),
+            ("g", FunctionKind::Function),
+        ] {
+            db.functions.insert(
+                op.into(),
+                Function {
+                    kind,
+                    inputs: vec!["E".into()],
+                    output: "E".into(),
+                },
+            );
+            for input in 0..6 {
+                seed = seed.wrapping_mul(1664525).wrapping_add(1013904223);
+                if seed.is_multiple_of(7) {
+                    continue;
+                }
+                db.rows.push(Row {
+                    function: op.into(),
+                    inputs: vec![input.to_string()],
+                    output: ((seed >> 8) % 6).to_string(),
+                    subsumed: seed.is_multiple_of(11),
+                });
+            }
+        }
+        db
+    }
+    for seed in 0..200 {
+        let left = generated(seed);
+        agrees(&left, &renamed(&left));
+        agrees(&left, &generated(seed / 2));
+    }
+    let mut chain = graph(&[("a", &[], "0")]);
+    chain.functions.insert(
+        "f".into(),
+        Function {
+            kind: FunctionKind::Constructor,
+            inputs: vec!["E".into()],
+            output: "E".into(),
+        },
+    );
+    for i in 1..100 {
+        chain.classes.insert(
+            i.to_string(),
+            Class {
+                sort: "E".into(),
+                literal: None,
+            },
+        );
+        chain.rows.push(Row {
+            function: "f".into(),
+            inputs: vec![(i - 1).to_string()],
+            output: i.to_string(),
+            subsumed: false,
+        });
+    }
+    agrees(&chain, &renamed(&chain));
+    let mut other = chain.clone();
+    other.rows.last_mut().unwrap().output = "98".into();
+    agrees(&chain, &other);
+}
+
+#[test]
+fn cli_canonical_modes_and_argument_errors() {
+    use std::{fs, process::Command};
+    let dir = std::env::temp_dir().join(format!("canonical-cli-{}", std::process::id()));
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("graph.json");
+    let db = graph(&[("a", &[], "x")]);
+    fs::write(&path, serde_json::to_vec(&db).unwrap()).unwrap();
+    let run = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_egraph-comparison"))
+            .arg(&path)
+            .args(args)
+            .output()
+            .unwrap()
+    };
+    for (args, mode) in [
+        (vec!["--canonical"], CanonicalMode::Database),
+        (vec!["--canonical", "--terms-only"], CanonicalMode::Terms),
+    ] {
+        let output = run(&args);
+        assert!(output.status.success());
+        assert_eq!(output.stdout, canonicalize(&db, mode).unwrap());
+    }
+    for args in [
+        vec![],
+        vec!["--canonical", "--certificate"],
+        vec!["--canonical", "--verify-certificate", "witness.json"],
+        vec!["--canonical", path.to_str().unwrap()],
+    ] {
+        assert_eq!(run(&args).status.code(), Some(2));
+    }
+    fs::remove_dir_all(dir).unwrap();
+}


### PR DESCRIPTION
*From Codex:*

Add `canonicalize(&Database, CanonicalMode)` and `--canonical` with an optional `--terms-only` projection. Independently serialized equivalent databases produce identical versioned bytes, including bisimilar cycles and renamed/reordered inputs.

Prune unobserved classes, order semantic labels and sorts, and assign canonical block ranks from sorted exact signatures. Typed IDs distinguish class, symbol, sort, and partition namespaces. The separate quotient format is necessary because minimizing a valid input need not produce another valid input Database.

Validation: canonical goldens, CLI modes, unused observations, cycles, functions, invalid input, long chains, and 200 generated cyclic pairs pass; existing comparison/certificate tests and the doctest also pass.

Canonical rank assignment remains ordered synchronous refinement; the earlier comparison worklist uses internal IDs that are not canonical.

Part of the actual `gh stack` #1023. Non-test diff: 313 added/deleted lines; tests are in separate files.
