### PR TITLE
Use smaller-half worklists for e-graph comparison

### DIFF
--- a/egraph-comparison/README.md
+++ b/egraph-comparison/README.md
@@ -6,10 +6,11 @@ cargo run -p egraph-comparison -- --terms-only left.json right.json
 ```
 
 The binary reads two complete, rebuilt databases and emits JSON with
-`terms_equal`, `database_equal`, `refinement_rounds`, and
-`database_refinement_rounds`. Exit status is 0 for
+`terms_equal`, `database_equal`, `refinement_steps`, and
+`database_refinement_steps`. Exit status is 0 for
 equality, 1 for disequality, and 2 for invalid input or I/O failure. `--terms-only`
 selects term equality for the exit status; both results are always reported.
+Step counts measure processed worklist blocks, not synchronous refinement depth.
 
 ## Semantics
 
@@ -23,8 +24,11 @@ that the same groups contain observable roots on both sides.
 This is the idea behind [DFA minimization](https://en.wikipedia.org/wiki/DFA_minimization).
 For its generalization to other transition structures, see Jacobs and Wißmann,
 [Fast Coalgebraic Bisimilarity Minimization](https://arxiv.org/abs/2204.12368).
-The implementation here uses whole-graph rounds; it does **not** implement
-Hopcroft's smaller-half splitter worklist or the fast algorithm in that paper.
+The comparator uses the paper's smaller-half worklist idea: when a block splits,
+its largest piece keeps the old ID. Only predecessors of newly numbered pieces
+become dirty. Each block stores its clean members contiguously, so processing
+recomputes dirty signatures plus one clean representative, without scanning all
+clean members. Clean members have identical signatures and stay together.
 
 This is conservative e-graph partition refinement: cycles merge only when the
 complete sets of e-nodes in their e-classes are identical modulo the refined
@@ -56,10 +60,13 @@ different observations.
 Costs, roots, extraction preferences, and runtime implementation details are
 outside this database format.
 
-The implementation recomputes exact signatures each round. It has at most a
-linear number of splitting rounds and can take quadratic time (plus signature
-sorting). There is no probabilistic equality or depth limit. Performance
-improvements preserve exact signature equality.
+Each class changes block IDs at most O(log n) times, giving O(m log n) reverse
+edge visits and O(n + m log n) signature evaluations for n classes and m child
+occurrences. A signature still scans, sorts, and deduplicates all of its class's
+nodes, so this is not an unconditional O(m log n) runtime guarantee. The reverse
+index and refinable partition use O(n + m) space, in addition to signature
+scratch storage. Comparisons remain exact, with no depth limit. Internal block
+IDs depend on worklist order and are not canonical serialization IDs.
 
 ## Version 1 JSON
 

--- a/egraph-comparison/src/hopcroft.rs
+++ b/egraph-comparison/src/hopcroft.rs
@@ -1,0 +1,235 @@
+//! Dirty-state partition refinement (Jacobs–Wißmann, Algorithm 6).
+//! A largest piece retains its ID; only predecessors of smaller pieces are
+//! invalidated. Clean members of a block have equal current signatures.
+use crate::ids::{BlockId, ClassId};
+use crate::{refine::Partition, signatures::Signatures};
+use egglog_numeric_id::NumericId;
+use std::collections::VecDeque;
+
+/// Members occupy [start, end), with dirty members in [clean, end).
+struct Block {
+    start: usize,
+    clean: usize,
+    end: usize,
+}
+
+struct Worklist {
+    members: Vec<ClassId>,
+    position: Vec<usize>,
+    blocks: Vec<Block>,
+    // FIFO lets pending child splits accumulate before a parent is revisited.
+    pending: VecDeque<BlockId>,
+    // Compressed reverse edges: predecessors of c are parents[offset[c]..offset[c+1]].
+    offset: Vec<usize>,
+    parents: Vec<ClassId>,
+    steps: usize,
+    #[cfg(test)]
+    evaluations: usize,
+    #[cfg(test)]
+    moves: Vec<usize>,
+}
+
+impl Worklist {
+    fn new(partition: &Partition<'_>) -> Self {
+        let n = partition.blocks.len();
+        let count = partition
+            .blocks
+            .iter()
+            .map(|b| b.index() + 1)
+            .max()
+            .unwrap_or(0);
+        let mut sizes = vec![0; count];
+        for b in &partition.blocks {
+            sizes[b.index()] += 1;
+        }
+        let mut start = 0;
+        let blocks: Vec<_> = sizes
+            .iter()
+            .map(|&size| {
+                let block = Block {
+                    start,
+                    clean: start,
+                    end: start + size,
+                };
+                start += size;
+                block
+            })
+            .collect();
+        let mut cursor: Vec<_> = blocks.iter().map(|b| b.start).collect();
+        let mut members = vec![ClassId::from_usize(0); n];
+        let mut position = vec![0; n];
+        for (i, b) in partition.blocks.iter().enumerate() {
+            position[i] = cursor[b.index()];
+            members[position[i]] = ClassId::from_usize(i);
+            cursor[b.index()] += 1;
+        }
+
+        let mut offset = vec![0; n + 1];
+        for nodes in partition.left.nodes.iter().chain(&partition.right.nodes) {
+            for child in nodes.iter().flat_map(|node| &node.children) {
+                offset[child.index()] += 1;
+            }
+        }
+        let mut total = 0;
+        for entry in &mut offset {
+            let degree = *entry;
+            *entry = total;
+            total += degree;
+        }
+        let mut parents = vec![ClassId::from_usize(0); total];
+        cursor.clear();
+        cursor.extend_from_slice(&offset[..n]);
+        for (i, nodes) in partition
+            .left
+            .nodes
+            .iter()
+            .chain(&partition.right.nodes)
+            .enumerate()
+        {
+            for child in nodes.iter().flat_map(|node| &node.children) {
+                parents[cursor[child.index()]] = ClassId::from_usize(i);
+                cursor[child.index()] += 1;
+            }
+        }
+        Self {
+            members,
+            position,
+            blocks,
+            pending: (0..count).map(BlockId::from_usize).collect(),
+            offset,
+            parents,
+            steps: 0,
+            #[cfg(test)]
+            evaluations: 0,
+            #[cfg(test)]
+            moves: vec![0; n],
+        }
+    }
+
+    fn swap(&mut self, a: usize, b: usize) {
+        self.members.swap(a, b);
+        self.position[self.members[a].index()] = a;
+        self.position[self.members[b].index()] = b;
+    }
+
+    fn dirty(&mut self, id: ClassId, partition: &Partition<'_>) {
+        let b = partition.blocks[id.index()];
+        let block = &mut self.blocks[b.index()];
+        let pos = self.position[id.index()];
+        if pos >= block.clean {
+            return; // Already dirty and queued, including repeated child edges.
+        }
+        if block.clean == block.end {
+            self.pending.push_back(b);
+        }
+        block.clean -= 1;
+        let boundary = block.clean;
+        self.swap(pos, boundary);
+    }
+
+    fn finish(&mut self, partition: &mut Partition<'_>) {
+        let mut signatures = Signatures::default();
+        let mut nodes = Vec::new();
+        let mut assignments = Vec::new();
+        let mut sizes = Vec::new();
+        let mut starts = Vec::new();
+        let mut cursor = Vec::new();
+        while let Some(b) = self.pending.pop_front() {
+            self.steps += 1;
+            let Block { start, clean, end } = self.blocks[b.index()];
+            signatures.clear();
+            assignments.clear();
+            sizes.clear();
+            if start < clean {
+                // Intern the one clean representative first: bucket 0 holds
+                // every clean member and any dirty members that still match.
+                partition.signature(self.members[start], &mut nodes, &mut signatures);
+                sizes.push(clean - start);
+            }
+            for &id in &self.members[clean..end] {
+                let group = partition.signature(id, &mut nodes, &mut signatures).index();
+                if group == sizes.len() {
+                    sizes.push(0);
+                }
+                sizes[group] += 1;
+                assignments.push((id, group));
+            }
+            #[cfg(test)]
+            {
+                self.evaluations += end - clean + usize::from(start < clean);
+            }
+            self.blocks[b.index()].clean = end;
+            if sizes.len() <= 1 {
+                continue;
+            }
+            // Counting-sort only dirty members into contiguous buckets. The
+            // potentially huge clean prefix already belongs to bucket 0.
+            starts.clear();
+            let mut next = start;
+            for &size in &sizes {
+                starts.push(next);
+                next += size;
+            }
+            cursor.clear();
+            cursor.extend_from_slice(&starts);
+            cursor[0] = clean;
+            for &(id, group) in &assignments {
+                self.swap(self.position[id.index()], cursor[group]);
+                cursor[group] += 1;
+            }
+            let largest = sizes
+                .iter()
+                .enumerate()
+                .max_by_key(|&(_, size)| size)
+                .unwrap()
+                .0;
+            for (group, (&start, &size)) in starts.iter().zip(&sizes).enumerate() {
+                let block = Block {
+                    start,
+                    clean: start + size,
+                    end: start + size,
+                };
+                if group == largest {
+                    self.blocks[b.index()] = block;
+                } else {
+                    let new_id = BlockId::from_usize(self.blocks.len());
+                    for &id in &self.members[start..start + size] {
+                        partition.blocks[id.index()] = new_id;
+                        #[cfg(test)]
+                        {
+                            self.moves[id.index()] += 1;
+                        }
+                    }
+                    self.blocks.push(block);
+                }
+            }
+            // Finish all ID updates before invalidating predecessors: a parent
+            // can lie in this same block (cycles), or in another new piece.
+            // All smaller pieces lie before or after the retained largest
+            // range. Save their IDs before dirty() can reorder those ranges.
+            assignments.clear();
+            let kept = &self.blocks[b.index()];
+            for &id in self.members[start..kept.start]
+                .iter()
+                .chain(&self.members[kept.end..end])
+            {
+                assignments.push((id, 0));
+            }
+            for &(id, _) in &assignments {
+                for edge in self.offset[id.index()]..self.offset[id.index() + 1] {
+                    self.dirty(self.parents[edge], partition);
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn refine(partition: &mut Partition<'_>) -> usize {
+    let mut worklist = Worklist::new(partition);
+    worklist.finish(partition);
+    worklist.steps
+}
+
+#[cfg(test)]
+#[path = "../tests/support/hopcroft.rs"]
+mod tests;

--- a/egraph-comparison/src/lib.rs
+++ b/egraph-comparison/src/lib.rs
@@ -1,4 +1,5 @@
 //! Compare complete serialized databases by conservative partition refinement.
+mod hopcroft;
 mod ids;
 mod model;
 mod refine;

--- a/egraph-comparison/src/refine.rs
+++ b/egraph-comparison/src/refine.rs
@@ -10,10 +10,10 @@ pub struct Comparison {
     pub terms_equal: bool,
     /// Additionally, declarations and the full database coalgebra agree.
     pub database_equal: bool,
-    /// Rounds in constructor-only refinement.
-    pub refinement_rounds: usize,
-    /// Rounds in full-database refinement (reused when observations coincide).
-    pub database_refinement_rounds: usize,
+    /// Worklist blocks processed during constructor-only refinement, not depth.
+    pub refinement_steps: usize,
+    /// Worklist blocks processed for database equality (possibly reused).
+    pub database_refinement_steps: usize,
 }
 
 // Intern complete labels jointly across the inputs. Neither names nor schemas
@@ -106,6 +106,7 @@ pub(crate) struct Partition<'a> {
     pub left: Graph<'a>,
     pub right: Graph<'a>,
     pub blocks: Vec<BlockId>,
+    #[cfg(test)]
     pub rounds: usize,
 }
 
@@ -136,40 +137,54 @@ impl<'a> Partition<'a> {
             left,
             right,
             blocks,
+            #[cfg(test)]
             rounds: 0,
         }
     }
 
+    pub(crate) fn signature(
+        &self,
+        id: ClassId,
+        nodes: &mut Vec<SmallVec<[usize; 3]>>,
+        signatures: &mut crate::signatures::Signatures,
+    ) -> BlockId {
+        let class = if id.index() < self.left.nodes.len() {
+            &self.left.nodes[id.index()]
+        } else {
+            &self.right.nodes[id.index() - self.left.nodes.len()]
+        };
+        nodes.clear();
+        nodes.extend(class.iter().map(|node| {
+            let mut signature = SmallVec::new();
+            signature.push(node.symbol.index());
+            signature.extend(
+                node.children
+                    .iter()
+                    .map(|&child| self.blocks[child.index()].index()),
+            );
+            signature
+        }));
+        nodes.sort_unstable();
+        nodes.dedup();
+        signatures.intern(self.blocks[id.index()], nodes)
+    }
+
+    // The synchronous reference also supplies depth-bounded certificate replay
+    // in the subsequent certificate layer. Worklist steps are not term depths.
+    #[cfg(test)]
     pub fn step(&mut self) -> bool {
         let mut signatures = crate::signatures::Signatures::default();
-        let mut next_blocks = Vec::with_capacity(self.blocks.len());
-        // Scratch node signatures contain a symbol followed by child blocks.
-        // Unary/binary operators stay inline; unique class keys are copied into
-        // one flat arena, with cached hashes and exact comparisons on lookup.
-        let mut key: (BlockId, Vec<SmallVec<[usize; 3]>>) = (BlockId::from_usize(0), Vec::new());
-        for (i, nodes) in self.left.nodes.iter().chain(&self.right.nodes).enumerate() {
-            key.0 = self.blocks[i]; // Retain old block: split, never merge.
-            key.1.clear();
-            key.1.extend(nodes.iter().map(|node| {
-                let mut signature = SmallVec::new();
-                signature.push(node.symbol.index());
-                signature.extend(
-                    node.children
-                        .iter()
-                        .map(|&child| self.blocks[child.index()].index()),
-                );
-                signature
-            }));
-            key.1.sort_unstable();
-            key.1.dedup();
-            next_blocks.push(signatures.intern(key.0, &key.1));
-        }
+        let mut nodes = Vec::new();
+        let next_blocks = (0..self.blocks.len())
+            .map(|i| self.signature(ClassId::from_usize(i), &mut nodes, &mut signatures))
+            .collect::<Vec<_>>();
         self.rounds += 1;
         let changed = next_blocks != self.blocks;
         self.blocks = next_blocks;
         changed
     }
 
+    #[cfg(test)]
     pub fn finish(&mut self) {
         while self.step() {}
     }
@@ -186,20 +201,18 @@ impl<'a> Partition<'a> {
     }
 }
 
-/// Exact whole-graph refinement; this does not use Hopcroft's smaller-half
-/// splitter worklist. Hash collisions use full equality; there is no depth cutoff.
-///
-/// Each round scans all nodes/edges and sorts each class's signatures. There
-/// are at most O(classes) splitting rounds, so worst-case time remains quadratic
-/// (plus signature sorting). Names, schemas, and IDs are resolved only at setup.
+/// Exact partition refinement using a smaller-half worklist. Each class moves
+/// to a newly numbered block at most O(log(classes)) times; only predecessors
+/// of moved classes become dirty. Signatures still inspect and sort all nodes
+/// of each dirty class, so their cost is additional to the worklist bound.
+/// Hash collisions use full equality; there is no probabilistic/depth cutoff.
 /// Ordinary functions never participate in constructor-term syntax.
 pub fn compare(left: &Database, right: &Database) -> Result<Comparison, Error> {
     left.validate()?;
     right.validate()?;
     let mut partition = Partition::new(left, right);
-    partition.finish();
+    let refinement_steps = crate::hopcroft::refine(&mut partition);
     let terms_equal = partition.terms_equal();
-    let refinement_rounds = partition.rounds;
     let same_observations = [left, right].iter().all(|db| {
         db.functions
             .values()
@@ -210,14 +223,14 @@ pub fn compare(left: &Database, right: &Database) -> Result<Comparison, Error> {
         return Ok(Comparison {
             terms_equal,
             database_equal: terms_equal && left.functions == right.functions,
-            refinement_rounds,
-            database_refinement_rounds: refinement_rounds,
+            refinement_steps,
+            database_refinement_steps: refinement_steps,
         });
     }
     // Release the first graph before constructing the full-database graph.
     drop(partition);
     let mut partition = Partition::database(left, right);
-    partition.finish();
+    let database_refinement_steps = crate::hopcroft::refine(&mut partition);
     // Every row is a member of an output class. Matching output blocks at the
     // fixed point already implies matching rows modulo the child/output blocks;
     // rebuilding a second set of string-keyed row signatures is redundant.
@@ -226,7 +239,7 @@ pub fn compare(left: &Database, right: &Database) -> Result<Comparison, Error> {
     Ok(Comparison {
         terms_equal,
         database_equal,
-        refinement_rounds,
-        database_refinement_rounds: partition.rounds,
+        refinement_steps,
+        database_refinement_steps,
     })
 }

--- a/egraph-comparison/src/signatures.rs
+++ b/egraph-comparison/src/signatures.rs
@@ -13,7 +13,7 @@ struct Entry {
     block: BlockId,
 }
 
-/// Per-round interning with one flat key arena. Table entries retain their hash
+/// Per-batch interning with one flat key arena. Table entries retain their hash
 /// so growth never re-hashes long signatures. Collisions compare complete keys.
 #[derive(Default)]
 pub(crate) struct Signatures {
@@ -23,6 +23,18 @@ pub(crate) struct Signatures {
 }
 
 impl Signatures {
+    /// Reuse allocations after processing a block; no signature survives a split.
+    pub fn clear(&mut self) {
+        // HashTable::clear touches its capacity. Release an oversized table so
+        // a large split cannot make every later tiny batch cost O(large split).
+        if self.table.capacity() > 4 * self.table.len().max(1) {
+            self.table = HashTable::new();
+        } else {
+            self.table.clear();
+        }
+        self.words.clear();
+    }
+
     pub fn intern(&mut self, previous: BlockId, nodes: &[SmallVec<[usize; 3]>]) -> BlockId {
         self.scratch.clear();
         self.scratch.push(previous.index());

--- a/egraph-comparison/tests/comparison.rs
+++ b/egraph-comparison/tests/comparison.rs
@@ -313,5 +313,5 @@ fn propagates_a_difference_through_a_long_chain() {
     let mut right = left.clone();
     right.rows.last_mut().unwrap().output = "78".into();
     assert!(!compare(&left, &right).unwrap().terms_equal);
-    assert!(compare(&left, &left).unwrap().refinement_rounds >= 79);
+    assert!(compare(&left, &left).unwrap().refinement_steps >= 79);
 }

--- a/egraph-comparison/tests/support/hopcroft.rs
+++ b/egraph-comparison/tests/support/hopcroft.rs
@@ -1,0 +1,177 @@
+use super::*;
+use crate::{Class, Database, Function, FunctionKind, Row};
+use std::collections::BTreeMap;
+
+fn classes(n: usize) -> Database {
+    let mut db = Database::default();
+    for i in 0..n {
+        db.classes.insert(
+            i.to_string(),
+            Class {
+                sort: "E".into(),
+                literal: None,
+            },
+        );
+    }
+    db
+}
+
+fn declare(db: &mut Database, name: &str, arity: usize, kind: FunctionKind) {
+    db.functions.insert(
+        name.into(),
+        Function {
+            kind,
+            inputs: vec!["E".into(); arity],
+            output: "E".into(),
+        },
+    );
+}
+
+fn row(db: &mut Database, name: &str, inputs: &[usize], output: usize) {
+    db.rows.push(Row {
+        function: name.into(),
+        inputs: inputs.iter().map(usize::to_string).collect(),
+        output: output.to_string(),
+        subsumed: false,
+    });
+}
+
+fn check(left: &Database, right: &Database, functions: bool) {
+    left.validate().unwrap();
+    right.validate().unwrap();
+    let make = || {
+        if functions {
+            Partition::database(left, right)
+        } else {
+            Partition::new(left, right)
+        }
+    };
+    let mut reference = make();
+    reference.finish();
+    let mut fast = make();
+    let mut work = Worklist::new(&fast);
+    work.finish(&mut fast);
+    // Compare entire equivalence relations, not arbitrary block numbers or just
+    // root coverage. Maps in both directions detect both over- and under-splits.
+    let (mut forward, mut backward) = (BTreeMap::new(), BTreeMap::new());
+    for (&a, &b) in reference.blocks.iter().zip(&fast.blocks) {
+        assert_eq!(*forward.entry(a).or_insert(b), b);
+        assert_eq!(*backward.entry(b).or_insert(a), a);
+    }
+    assert_eq!(reference.terms_equal(), fast.terms_equal());
+    let bound = fast.blocks.len().max(1).ilog2() as usize;
+    assert!(work.moves.iter().all(|&moves| moves <= bound));
+    // Every member occurs exactly once, in the right block, with a valid inverse
+    // position. At termination all members are clean and every block is nonempty.
+    for (i, block) in work.blocks.iter().enumerate() {
+        assert!(block.start < block.end);
+        assert_eq!(block.clean, block.end);
+        for pos in block.start..block.end {
+            let id = work.members[pos];
+            assert_eq!(work.position[id.index()], pos);
+            assert_eq!(fast.blocks[id.index()].index(), i);
+        }
+    }
+}
+
+#[test]
+fn matches_synchronous_refinement_on_generated_set_valued_graphs() {
+    fn generated(mut seed: u64) -> Database {
+        let mut next = || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed as usize
+        };
+        let n = 1 + next() % 32;
+        let mut db = classes(n);
+        for (name, arity, kind) in [
+            ("f", 1, FunctionKind::Constructor),
+            ("g", 2, FunctionKind::Constructor),
+            ("h", 4, FunctionKind::Function),
+        ] {
+            declare(&mut db, name, arity, kind);
+            let mut table = BTreeMap::new();
+            for _ in 0..n * 3 {
+                let inputs = (0..arity).map(|_| next() % n).collect::<Vec<_>>();
+                table.insert(inputs, next() % n);
+            }
+            for (inputs, output) in table {
+                row(&mut db, name, &inputs, output);
+                db.rows.last_mut().unwrap().subsumed = next().is_multiple_of(3);
+                if next().is_multiple_of(5) {
+                    db.rows.push(db.rows.last().unwrap().clone());
+                }
+            }
+        }
+        db
+    }
+    for seed in 1..401 {
+        let left = generated(seed);
+        let right = generated(seed * 193);
+        for functions in [false, true] {
+            check(&left, &right, functions);
+            let mut right = left.clone();
+            right.rows.reverse();
+            check(&left, &right, functions);
+        }
+    }
+}
+
+#[test]
+fn preserves_sorts_literals_empty_classes_and_cycles() {
+    let mut left = classes(8);
+    declare(&mut left, "f", 1, FunctionKind::Constructor);
+    declare(&mut left, "pair", 2, FunctionKind::Constructor);
+    row(&mut left, "f", &[0], 0);
+    row(&mut left, "f", &[1], 2);
+    row(&mut left, "f", &[2], 1);
+    row(&mut left, "pair", &[0, 1], 3);
+    row(&mut left, "pair", &[1, 0], 3);
+    row(&mut left, "pair", &[4, 4], 5);
+    left.classes.get_mut("6").unwrap().sort = "Other".into();
+    left.classes.get_mut("7").unwrap().literal = Some("literal".into());
+    let mut right = left.clone();
+    right.rows.pop();
+    check(&left, &right, false);
+    check(&Database::default(), &Database::default(), false);
+    check(&left, &Database::default(), false);
+}
+
+#[test]
+fn peels_a_long_chain_without_rescanning_the_clean_remainder() {
+    let n = 16_384;
+    let mut db = classes(n);
+    declare(&mut db, "end", 0, FunctionKind::Constructor);
+    declare(&mut db, "f", 1, FunctionKind::Constructor);
+    row(&mut db, "end", &[], 0);
+    for i in 1..n {
+        row(&mut db, "f", &[i - 1], i);
+    }
+    let mut partition = Partition::new(&db, &db);
+    let mut work = Worklist::new(&partition);
+    work.finish(&mut partition);
+    assert!(partition.terms_equal());
+    assert_eq!(work.blocks.len(), n);
+    assert!(work.evaluations < 8 * n, "{} evaluations", work.evaluations);
+    assert!(work.moves.iter().all(|&moves| moves <= 1));
+}
+
+#[test]
+fn duplicate_edges_and_high_fanout_do_not_duplicate_pending_blocks() {
+    let mut db = classes(128);
+    declare(&mut db, "base", 0, FunctionKind::Constructor);
+    declare(&mut db, "f", 2, FunctionKind::Constructor);
+    row(&mut db, "base", &[], 0);
+    for i in 1..128 {
+        row(&mut db, "f", &[0, i], i);
+        for _ in 0..4 {
+            db.rows.push(db.rows.last().unwrap().clone());
+        }
+    }
+    check(&db, &db, false);
+    let mut partition = Partition::new(&db, &db);
+    let mut work = Worklist::new(&partition);
+    work.finish(&mut partition);
+    assert!(work.steps <= 3);
+}


### PR DESCRIPTION
*From Codex:*

Whole-graph refinement recomputes unchanged class signatures at every depth. Use a smaller-half worklist for both constructor equality and full-database equality, following Algorithm 6 of [Jacobs–Wißmann](https://arxiv.org/abs/2204.12368).

Keep the largest piece's block ID on each split, and use a compressed reverse child index to dirty only predecessors of renumbered pieces. A contiguous refinable partition separates clean and dirty members: evaluate dirty signatures plus one clean representative, and group only the dirty suffix. Finish every ID update before invalidating predecessors, including cyclic dependencies.

Use FIFO scheduling to accumulate changes before revisiting a block. Reuse flat signature storage while releasing oversized hash tables, because clearing a retained large table for every tiny block defeats the worklist bound. Each class changes IDs at most O(log n) times; complete signature construction and sorting still cost extra.

Comparison JSON now reports `refinement_steps` and `database_refinement_steps` (processed worklist blocks) in place of the old synchronous round counters. Keep synchronous refinement as a test oracle; the subsequent certificate layer also retains it for depth-based witnesses. Canonical numbering in later PRs remains separate.

Stack order: #1011 core → #1022 compact storage → this PR → #1012 certificates → #1013 export → remaining function/snapshot/canonical layers, in actual `gh stack` #1023.

Validation: all comparison tests and Clippy pass at this layer. New tests compare complete partitions against synchronous refinement across 1,600 generated input/mode cases, check sort/literal/hole/cycle behavior and duplicate edges, and verify linear signature work on a 16,384-class chain. The rebased stack passes 53 targeted tests including certificates, canonicalization, export, and snapshots; feature checks with and without comparison pass.

Local release benchmarks compare this PR (`250ba84c`) with its reordered parent (`debd68d4`) using the existing math-microbenchmark corpus and an equivalent copy with renamed IDs and reversed rows. Both binaries use Rust 1.91.0, the same dependency lock and harness, and the same Apple M4 Max machine (16 CPU cores, 128 GiB RAM); comparison is single-threaded. Timings include validation, graph construction, refinement, and cleanup; JSON parsing is excluded. Runs 1–11 use medians of five samples with repeated calls for small inputs; run 12 uses three separate single-comparison processes for each binary, alternating order. Constructor-only observations reuse one partition. These measurements do not time certificate extraction or canonicalization.

| `(run N)` | Classes per input | Parent comparison | This PR | Time reduction |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 58 | 0.031 ms | 0.030 ms | 3.4% |
| 2 | 79 | 0.047 ms | 0.046 ms | 1.7% |
| 3 | 124 | 0.087 ms | 0.080 ms | 8.2% |
| 4 | 205 | 0.170 ms | 0.145 ms | 14.9% |
| 5 | 369 | 0.330 ms | 0.291 ms | 11.9% |
| 6 | 674 | 0.714 ms | 0.593 ms | 16.9% |
| 7 | 1,355 | 1.586 ms | 1.244 ms | 21.5% |
| 8 | 3,584 | 4.755 ms | 3.602 ms | 24.2% |
| 9 | 12,453 | 18.117 ms | 13.093 ms | 27.7% |
| 10 | 58,472 | 109.966 ms | 75.957 ms | 30.9% |
| 11 | 443,840 | 1.17 s | 875.132 ms | 25.1% |
| 12 | 6,865,591 | 29.63 s | 20.43 s | 31.0% |

For run 12, parent samples were 29.18–30.52 s and this PR's samples were 20.35–20.47 s: **31.0% lower comparison time (1.45× speedup)**. Median whole-process time including input reads/parsing was 40.61 → 31.47 s. Sampled peak process RSS was 22.72–27.72 GiB for the parent and 22.63–23.02 GiB here; those memory values are observed ranges rather than a stable percentage improvement.

The first local prototype used LIFO and retained oversized hash tables (run 11 median 1.71 s); releasing oversized tables gave 1.33 s, then FIFO gave 0.92 s in exploratory three-sample runs. The table above uses the final five-sample sweep.

Scripts, raw results, and binaries are kept in a private ignored directory. No one-off benchmark artifacts are committed.

Non-test diff: **364 added/deleted lines**. Tests are in their own files: **179 added/deleted lines**, **543 total**.
