### PR TITLE
Speed up e-graph comparison with compact signature storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "smallvec",
  "thiserror",
 ]
 

--- a/egraph-comparison/Cargo.toml
+++ b/egraph-comparison/Cargo.toml
@@ -14,3 +14,4 @@ thiserror.workspace = true
 egglog-numeric-id.workspace = true
 hashbrown.workspace = true
 rustc-hash.workspace = true
+smallvec.workspace = true

--- a/egraph-comparison/README.md
+++ b/egraph-comparison/README.md
@@ -43,7 +43,8 @@ than equality of finite ground-term languages. This is not graph isomorphism.
 
 `database_equal` additionally compares function declarations and all rows,
 including constructor rows and subsumption flags. Its full-database refinement
-includes ordinary function calls in class observations. This preserves
+includes ordinary function calls in class observations; constructor-only inputs
+without subsumption can reuse the term partition. This preserves
 structure carried only by function tables, even when values have no constructor
 terms. Values in the rows are compared using this full-database partition.
 Non-constructor functions never become term operators or enter finite term
@@ -79,7 +80,7 @@ improvements preserve exact signature equality.
 
 Class IDs are arbitrary strings scoped to one file. The numeric `version` field
 is a `FormatVersion` identifying the wire format, not an e-class identifier.
-Setup resolves class names to distinct typed class and partition IDs.
+Setup resolves class names to distinct typed class, symbol, and partition IDs.
 `literal` is an opaque, stable encoding qualified by its sort. `subsumed` defaults to false. Declarations
 are explicit even for empty tables. Unknown fields, unsupported versions,
 dangling IDs, wrong sorts/arity, duplicate literal identities, and conflicting

--- a/egraph-comparison/src/ids.rs
+++ b/egraph-comparison/src/ids.rs
@@ -33,3 +33,4 @@ serial_id!(
     "Equivalence block in one refinement partition. IDs are local to that partition and round, not stable e-class identities."
 );
 define_id!(pub RowId, usize, "Index in one input database's rows, used by the representative worklist.");
+define_id!(pub(crate) SymbolId, usize, "Interned complete node label, shared by both inputs during joint refinement.");

--- a/egraph-comparison/src/lib.rs
+++ b/egraph-comparison/src/lib.rs
@@ -2,6 +2,7 @@
 mod ids;
 mod model;
 mod refine;
+mod signatures;
 pub use ids::{FormatVersion, RowId};
 pub use model::{Class, Database, Error, Function, FunctionKind, Row};
 pub use refine::{Comparison, compare};

--- a/egraph-comparison/src/main.rs
+++ b/egraph-comparison/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use egraph_comparison::{Database, compare};
-use std::{fs::File, io::BufReader, path::PathBuf, process::ExitCode};
+use std::{path::PathBuf, process::ExitCode};
 
 #[derive(Parser)]
 #[command(about = "Compare two serialized e-graphs modulo constructor bisimulation")]
@@ -17,7 +17,9 @@ struct Args {
 
 fn run(args: &Args) -> Result<bool, Box<dyn std::error::Error>> {
     let read = |path: &PathBuf| -> Result<Database, Box<dyn std::error::Error>> {
-        Ok(serde_json::from_reader(BufReader::new(File::open(path)?))?)
+        // Parse each byte slice and release it before reading the next input.
+        let bytes = std::fs::read(path)?;
+        Ok(serde_json::from_slice(&bytes)?)
     };
     let result = compare(&read(&args.left)?, &read(&args.right)?)?;
     serde_json::to_writer_pretty(std::io::stdout().lock(), &result)?;

--- a/egraph-comparison/src/refine.rs
+++ b/egraph-comparison/src/refine.rs
@@ -1,8 +1,8 @@
-use crate::ids::{BlockId, ClassId};
-use crate::{Database, Error, Function, FunctionKind};
+use crate::ids::{BlockId, ClassId, SymbolId};
+use crate::{Database, Error, Function, FunctionKind, HashMap};
 use egglog_numeric_id::NumericId;
 use serde::Serialize;
-use std::collections::{BTreeMap, BTreeSet};
+use smallvec::SmallVec;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Comparison {
@@ -12,86 +12,122 @@ pub struct Comparison {
     pub database_equal: bool,
     /// Rounds in constructor-only refinement.
     pub refinement_rounds: usize,
-    /// Rounds in refinement including ordinary functions and subsumption.
+    /// Rounds in full-database refinement (reused when observations coincide).
     pub database_refinement_rounds: usize,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum Node<I = ClassId> {
-    Literal(String),
-    Call(String, Function, Vec<I>, bool),
+// Intern complete labels jointly across the inputs. Neither names nor schemas
+// are copied per node or per refinement round; hash collisions still use Eq.
+#[derive(PartialEq, Eq, Hash)]
+pub(crate) enum Label<'a> {
+    Literal(&'a str),
+    Call(&'a str, &'a Function, bool),
 }
 
-pub(crate) struct Graph {
-    pub sorts: Vec<String>,
+fn intern<'a>(labels: &mut HashMap<Label<'a>, SymbolId>, label: Label<'a>) -> SymbolId {
+    let next = SymbolId::from_usize(labels.len());
+    *labels.entry(label).or_insert(next)
+}
+
+#[derive(Clone)]
+pub(crate) struct Node {
+    pub symbol: SymbolId,
+    pub children: SmallVec<[ClassId; 2]>,
+}
+
+pub(crate) struct Graph<'a> {
+    pub sorts: Vec<&'a str>,
     pub nodes: Vec<Vec<Node>>,
-    pub roots: BTreeSet<ClassId>,
-    pub index: BTreeMap<String, ClassId>,
+    /// Sorted, unique output IDs. Mark once per row instead of tree insertion.
+    pub roots: Vec<ClassId>,
 }
 
-impl Graph {
-    fn new(db: &Database, offset: usize, include_functions: bool) -> Self {
-        let ids: Vec<_> = db.classes.keys().cloned().collect();
-        let index: BTreeMap<_, _> = ids
-            .iter()
+impl<'a> Graph<'a> {
+    pub(crate) fn new(
+        db: &'a Database,
+        offset: usize,
+        include_functions: bool,
+        labels: &mut HashMap<Label<'a>, SymbolId>,
+    ) -> Self {
+        let index: HashMap<_, _> = db
+            .classes
+            .keys()
             .enumerate()
-            .map(|(i, id)| (id.clone(), ClassId::from_usize(i + offset)))
+            .map(|(i, id)| (id.as_str(), ClassId::from_usize(i + offset)))
             .collect();
-        let sorts = db.classes.values().map(|c| c.sort.clone()).collect();
-        let mut nodes = vec![Vec::new(); ids.len()];
+        let sorts = db.classes.values().map(|c| c.sort.as_str()).collect();
+        let mut nodes = vec![Vec::new(); db.classes.len()];
         for (id, class) in &db.classes {
             if let Some(literal) = &class.literal {
-                nodes[index[id].index() - offset].push(Node::Literal(literal.clone()));
+                nodes[index[id.as_str()].index() - offset].push(Node {
+                    symbol: intern(labels, Label::Literal(literal)),
+                    children: SmallVec::new(),
+                });
             }
         }
-        let mut roots = BTreeSet::new();
+        let operators: HashMap<_, _> = db
+            .functions
+            .iter()
+            .filter(|(_, f)| include_functions || f.kind == FunctionKind::Constructor)
+            .map(|(name, function)| {
+                (
+                    name.as_str(),
+                    [
+                        intern(labels, Label::Call(name, function, false)),
+                        intern(labels, Label::Call(name, function, include_functions)),
+                    ],
+                )
+            })
+            .collect();
+        let mut roots = vec![false; db.classes.len()];
         for row in &db.rows {
-            let function = &db.functions[&row.function];
-            if include_functions || function.kind == FunctionKind::Constructor {
-                roots.insert(index[&row.output]);
-                nodes[index[&row.output].index() - offset].push(Node::Call(
-                    row.function.clone(),
-                    function.clone(),
-                    row.inputs.iter().map(|id| index[id]).collect(),
-                    include_functions && row.subsumed,
-                ));
+            if let Some(symbols) = operators.get(row.function.as_str()) {
+                let output = index[row.output.as_str()].index() - offset;
+                roots[output] = true;
+                nodes[output].push(Node {
+                    symbol: symbols[usize::from(row.subsumed)],
+                    children: row.inputs.iter().map(|id| index[id.as_str()]).collect(),
+                });
             }
         }
         Self {
             sorts,
             nodes,
-            roots,
-            index,
+            roots: roots
+                .into_iter()
+                .enumerate()
+                .filter_map(|(i, root)| root.then_some(ClassId::from_usize(i + offset)))
+                .collect(),
         }
     }
 }
 
-pub(crate) struct Partition {
-    pub left: Graph,
-    pub right: Graph,
+pub(crate) struct Partition<'a> {
+    pub left: Graph<'a>,
+    pub right: Graph<'a>,
     pub blocks: Vec<BlockId>,
     pub rounds: usize,
 }
 
-impl Partition {
-    pub fn new(left: &Database, right: &Database) -> Self {
+impl<'a> Partition<'a> {
+    pub fn new(left: &'a Database, right: &'a Database) -> Self {
         Self::with_functions(left, right, false)
     }
 
-    pub fn database(left: &Database, right: &Database) -> Self {
+    pub fn database(left: &'a Database, right: &'a Database) -> Self {
         Self::with_functions(left, right, true)
     }
 
-    fn with_functions(left: &Database, right: &Database, include_functions: bool) -> Self {
-        let left = Graph::new(left, 0, include_functions);
-        let right = Graph::new(right, left.nodes.len(), include_functions);
-        // Sorts must never become equivalent, even for empty e-classes.
-        let mut sorts = BTreeMap::new();
+    fn with_functions(left: &'a Database, right: &'a Database, include_functions: bool) -> Self {
+        let mut labels = HashMap::default();
+        let left = Graph::new(left, 0, include_functions, &mut labels);
+        let right = Graph::new(right, left.nodes.len(), include_functions, &mut labels);
+        let mut sorts = HashMap::default();
         let blocks = left
             .sorts
             .iter()
             .chain(&right.sorts)
-            .map(|sort| {
+            .map(|&sort| {
                 let next = BlockId::from_usize(sorts.len());
                 *sorts.entry(sort).or_insert(next)
             })
@@ -105,31 +141,28 @@ impl Partition {
     }
 
     pub fn step(&mut self) -> bool {
-        let mut signatures = BTreeMap::new();
+        let mut signatures = crate::signatures::Signatures::default();
         let mut next_blocks = Vec::with_capacity(self.blocks.len());
+        // Scratch node signatures contain a symbol followed by child blocks.
+        // Unary/binary operators stay inline; unique class keys are copied into
+        // one flat arena, with cached hashes and exact comparisons on lookup.
+        let mut key: (BlockId, Vec<SmallVec<[usize; 3]>>) = (BlockId::from_usize(0), Vec::new());
         for (i, nodes) in self.left.nodes.iter().chain(&self.right.nodes).enumerate() {
-            let signature: BTreeSet<_> = nodes
-                .iter()
-                .map(|node| match node {
-                    Node::Literal(value) => Node::Literal(value.clone()),
-                    Node::Call(op, schema, children, subsumed) => Node::Call(
-                        op.clone(),
-                        schema.clone(),
-                        children
-                            .iter()
-                            .map(|&child| self.blocks[child.index()])
-                            .collect(),
-                        *subsumed,
-                    ),
-                })
-                .collect();
-            // Retain the old block: every round is a refinement, never a merge.
-            let next = BlockId::from_usize(signatures.len());
-            next_blocks.push(
-                *signatures
-                    .entry((self.blocks[i], signature))
-                    .or_insert(next),
-            );
+            key.0 = self.blocks[i]; // Retain old block: split, never merge.
+            key.1.clear();
+            key.1.extend(nodes.iter().map(|node| {
+                let mut signature = SmallVec::new();
+                signature.push(node.symbol.index());
+                signature.extend(
+                    node.children
+                        .iter()
+                        .map(|&child| self.blocks[child.index()].index()),
+                );
+                signature
+            }));
+            key.1.sort_unstable();
+            key.1.dedup();
+            next_blocks.push(signatures.intern(key.0, &key.1));
         }
         self.rounds += 1;
         let changed = next_blocks != self.blocks;
@@ -141,26 +174,25 @@ impl Partition {
         while self.step() {}
     }
 
-    pub fn root_blocks(&self, graph: &Graph) -> BTreeSet<BlockId> {
-        graph
-            .roots
-            .iter()
-            .map(|&id| self.blocks[id.index()])
-            .collect()
-    }
-
     pub fn terms_equal(&self) -> bool {
-        self.root_blocks(&self.left) == self.root_blocks(&self.right)
+        let mut coverage = vec![0u8; self.blocks.len()];
+        for &root in &self.left.roots {
+            coverage[self.blocks[root.index()].index()] |= 1;
+        }
+        for &root in &self.right.roots {
+            coverage[self.blocks[root.index()].index()] |= 2;
+        }
+        coverage.iter().all(|&sides| sides == 0 || sides == 3)
     }
 }
 
-/// Exact whole-graph refinement; no iteration/depth cutoff. This does not use
-/// Hopcroft's smaller-half splitter worklist.
+/// Exact whole-graph refinement; this does not use Hopcroft's smaller-half
+/// splitter worklist. Hash collisions use full equality; there is no depth cutoff.
 ///
-/// This intentionally starts with the straightforward whole-graph algorithm.
-/// A round scans all nodes and edges and sorts signatures; there are at most
-/// O(classes) splitting rounds. The result ignores row order and duplicate rows
-/// or bisimilar cyclic classes. Function rows do not participate in term syntax.
+/// Each round scans all nodes/edges and sorts each class's signatures. There
+/// are at most O(classes) splitting rounds, so worst-case time remains quadratic
+/// (plus signature sorting). Names, schemas, and IDs are resolved only at setup.
+/// Ordinary functions never participate in constructor-term syntax.
 pub fn compare(left: &Database, right: &Database) -> Result<Comparison, Error> {
     left.validate()?;
     right.validate()?;
@@ -168,30 +200,29 @@ pub fn compare(left: &Database, right: &Database) -> Result<Comparison, Error> {
     partition.finish();
     let terms_equal = partition.terms_equal();
     let refinement_rounds = partition.rounds;
-    // Constructor-only blocks can erase structure carried by ordinary functions.
-    // Refine again with all rows to preserve those observations, while keeping
-    // the term result and finite certificates strictly constructor-only.
+    let same_observations = [left, right].iter().all(|db| {
+        db.functions
+            .values()
+            .all(|f| f.kind == FunctionKind::Constructor)
+            && db.rows.iter().all(|row| !row.subsumed)
+    });
+    if same_observations {
+        return Ok(Comparison {
+            terms_equal,
+            database_equal: terms_equal && left.functions == right.functions,
+            refinement_rounds,
+            database_refinement_rounds: refinement_rounds,
+        });
+    }
+    // Release the first graph before constructing the full-database graph.
+    drop(partition);
     let mut partition = Partition::database(left, right);
     partition.finish();
-    let rows = |db: &Database, graph: &Graph| -> BTreeSet<_> {
-        db.rows
-            .iter()
-            .map(|row| {
-                (
-                    row.function.clone(),
-                    row.inputs
-                        .iter()
-                        .map(|id| partition.blocks[graph.index[id].index()])
-                        .collect::<Vec<_>>(),
-                    partition.blocks[graph.index[&row.output].index()],
-                    row.subsumed,
-                )
-            })
-            .collect()
-    };
-    let database_equal = terms_equal
-        && left.functions == right.functions
-        && rows(left, &partition.left) == rows(right, &partition.right);
+    // Every row is a member of an output class. Matching output blocks at the
+    // fixed point already implies matching rows modulo the child/output blocks;
+    // rebuilding a second set of string-keyed row signatures is redundant.
+    let database_equal =
+        terms_equal && left.functions == right.functions && partition.terms_equal();
     Ok(Comparison {
         terms_equal,
         database_equal,

--- a/egraph-comparison/src/signatures.rs
+++ b/egraph-comparison/src/signatures.rs
@@ -1,0 +1,65 @@
+use crate::ids::BlockId;
+use egglog_numeric_id::NumericId;
+use hashbrown::HashTable;
+use smallvec::SmallVec;
+use std::{
+    hash::{Hash, Hasher},
+    ops::Range,
+};
+
+struct Entry {
+    hash: u64,
+    words: Range<usize>,
+    block: BlockId,
+}
+
+/// Per-round interning with one flat key arena. Table entries retain their hash
+/// so growth never re-hashes long signatures. Collisions compare complete keys.
+#[derive(Default)]
+pub(crate) struct Signatures {
+    table: HashTable<Entry>,
+    words: Vec<usize>,
+    scratch: Vec<usize>,
+}
+
+impl Signatures {
+    pub fn intern(&mut self, previous: BlockId, nodes: &[SmallVec<[usize; 3]>]) -> BlockId {
+        self.scratch.clear();
+        self.scratch.push(previous.index());
+        // These usize words are an encoding, not interchangeable IDs: each node
+        // has a length prefix, followed by its SymbolId and ordered BlockIds.
+        // Lengths distinguish different arities and adjacent-node boundaries.
+        for node in nodes {
+            self.scratch.push(node.len());
+            self.scratch.extend_from_slice(node);
+        }
+        let mut hasher = rustc_hash::FxHasher::default();
+        self.scratch.hash(&mut hasher);
+        self.intern_hashed(hasher.finish())
+    }
+
+    fn intern_hashed(&mut self, hash: u64) -> BlockId {
+        if let Some(entry) = self.table.find(hash, |entry| {
+            self.words[entry.words.clone()] == self.scratch
+        }) {
+            return entry.block;
+        }
+        let block = BlockId::from_usize(self.table.len());
+        let start = self.words.len();
+        self.words.extend_from_slice(&self.scratch);
+        self.table.insert_unique(
+            hash,
+            Entry {
+                hash,
+                words: start..self.words.len(),
+                block,
+            },
+            |entry| entry.hash,
+        );
+        block
+    }
+}
+
+#[cfg(test)]
+#[path = "../tests/support/signatures.rs"]
+mod tests;

--- a/egraph-comparison/tests/comparison.rs
+++ b/egraph-comparison/tests/comparison.rs
@@ -250,6 +250,37 @@ fn agrees_with_relation_oracle_on_small_cyclic_graphs() {
             "seed {seed}"
         );
         assert!(compare(&left, &left).unwrap().database_equal);
+        // An unused ordinary declaration forces the full-database path without
+        // changing either graph's observations. Check the reuse optimization
+        // against that path on every generated cyclic pair.
+        let (mut full_left, mut full_right) = (left.clone(), right.clone());
+        for db in [&mut full_left, &mut full_right] {
+            db.functions.insert(
+                "unused".into(),
+                Function {
+                    kind: FunctionKind::Function,
+                    inputs: vec![],
+                    output: "E".into(),
+                },
+            );
+        }
+        assert_eq!(
+            compare(&left, &right).unwrap(),
+            compare(&full_left, &full_right).unwrap()
+        );
+        let (mut left, mut right) = (left, right);
+        for db in [&mut left, &mut right] {
+            for function in db.functions.values_mut() {
+                function.kind = FunctionKind::Function;
+            }
+        }
+        let result = compare(&left, &right).unwrap();
+        assert!(result.terms_equal);
+        assert_eq!(
+            result.database_equal,
+            oracle(&left, &right),
+            "function seed {seed}"
+        );
     }
 }
 

--- a/egraph-comparison/tests/performance.rs
+++ b/egraph-comparison/tests/performance.rs
@@ -1,0 +1,90 @@
+use egraph_comparison::{Class, Database, Function, FunctionKind, Row, compare};
+
+fn wide() -> Database {
+    let mut db = Database::default();
+    for i in 0..8 {
+        db.classes.insert(
+            i.to_string(),
+            Class {
+                sort: "i64".into(),
+                literal: Some(i.to_string()),
+            },
+        );
+    }
+    db.classes.insert(
+        "out".into(),
+        Class {
+            sort: "E".into(),
+            literal: None,
+        },
+    );
+    db.functions.insert(
+        "wide".into(),
+        Function {
+            kind: FunctionKind::Constructor,
+            inputs: vec!["i64".into(); 8],
+            output: "E".into(),
+        },
+    );
+    db.rows.push(Row {
+        function: "wide".into(),
+        inputs: (0..8).map(|i| i.to_string()).collect(),
+        output: "out".into(),
+        subsumed: false,
+    });
+    db
+}
+
+#[test]
+fn spilled_signatures_preserve_argument_order() {
+    let left = wide();
+    let mut right = left.clone();
+    right.rows[0].inputs.swap(6, 7);
+    assert!(!compare(&left, &right).unwrap().terms_equal);
+}
+
+#[test]
+fn interned_labels_include_arity_and_kind() {
+    let left = wide();
+    let mut right = left.clone();
+    right.rows[0].inputs.pop();
+    right.functions.get_mut("wide").unwrap().inputs.pop();
+    assert!(!compare(&left, &right).unwrap().terms_equal);
+    let mut right = left.clone();
+    right.functions.get_mut("wide").unwrap().kind = FunctionKind::Function;
+    assert!(!compare(&left, &right).unwrap().terms_equal);
+    assert!(!compare(&left, &right).unwrap().database_equal);
+}
+
+#[test]
+fn full_database_root_coverage_detects_subsumption_and_missing_function_rows() {
+    let mut left = wide();
+    left.functions.insert(
+        "analysis".into(),
+        Function {
+            kind: FunctionKind::Function,
+            inputs: vec!["E".into()],
+            output: "i64".into(),
+        },
+    );
+    left.rows.push(Row {
+        function: "analysis".into(),
+        inputs: vec!["out".into()],
+        output: "0".into(),
+        subsumed: false,
+    });
+    let mut right = left.clone();
+    right.rows.pop();
+    let result = compare(&left, &right).unwrap();
+    assert!(result.terms_equal);
+    assert!(!result.database_equal);
+    let mut right = left.clone();
+    right.rows[0].subsumed = true;
+    let result = compare(&left, &right).unwrap();
+    assert!(result.terms_equal);
+    assert!(!result.database_equal);
+    right = left.clone();
+    right.rows.reverse();
+    right.rows.push(right.rows[0].clone());
+    assert!(compare(&left, &right).unwrap().database_equal);
+}

--- a/egraph-comparison/tests/support/signatures.rs
+++ b/egraph-comparison/tests/support/signatures.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+#[test]
+fn colliding_hashes_and_table_growth_preserve_full_key_equality() {
+    let mut signatures = Signatures::default();
+    for n in 0..1000 {
+        signatures.scratch = vec![n, 1, 7];
+        assert_eq!(signatures.intern_hashed(0), BlockId::from_usize(n));
+    }
+    let allocated = signatures.words.len();
+    for n in (0..1000).rev() {
+        signatures.scratch = vec![n, 1, 7];
+        assert_eq!(signatures.intern_hashed(0), BlockId::from_usize(n));
+    }
+    assert_eq!(signatures.words.len(), allocated);
+}
+
+#[test]
+fn node_boundaries_and_previous_blocks_are_part_of_the_key() {
+    let mut signatures = Signatures::default();
+    let a = [SmallVec::from_slice(&[1, 2]), SmallVec::from_slice(&[3])];
+    let b = [SmallVec::from_slice(&[1]), SmallVec::from_slice(&[2, 3])];
+    let old = BlockId::from_usize(0);
+    let first = signatures.intern(old, &a);
+    assert_ne!(first, signatures.intern(old, &b));
+    assert_ne!(first, signatures.intern(BlockId::from_usize(1), &a));
+    assert_eq!(first, signatures.intern(old, &a));
+}


### PR DESCRIPTION
*From Codex:*

Reduce comparison overhead with interned labels, borrowed graph indexes, inline node scratch storage, dense root coverage, and reuse of constructor refinement when observations coincide. Intern class signatures in a flat `hashbrown::HashTable`: cached hashes and ranges refer into one key arena, with exact equality on collisions. The CLI parses byte slices.

Keep class, symbol, and partition ID namespaces distinct using numeric-id. The algorithm still performs whole-graph refinement rounds. One-off benchmark scripts, reports, and raw CSVs are intentionally not checked in.

Validation: all comparison tests and Clippy pass, including forced hash collisions through table growth and signature-boundary checks. Local three-sample run-10/run-11 checks found the flat-key change reduced comparison time by about 18%/28%; local experiment artifacts remain under `target/`.

This PR replaces #1017 and preserves its compact-storage changes. During the restack, GitHub automatically marked #1017 merged into its former stack base after that base was rewritten to include this layer. Main was unchanged; the original review comments remain at #1017.

This layer now follows #1011 directly, before certificates and export. The smaller-half worklist follows in #1021.

Part of the actual `gh stack` #1023. Non-test diff: 321 added/deleted lines; tests are in separate files.
